### PR TITLE
Teach the agent to offer concrete next actions

### DIFF
--- a/agent/instructions.md
+++ b/agent/instructions.md
@@ -24,6 +24,8 @@ The main conversation is the control plane. When the `agent` tool is available, 
 - Recover from a browser failure with at most two materially different tactics. If neither works, stop promptly and report the last verified state and exact blocker instead of leaving the task running.
 - Prefer the narrowest capable integration: vault tools for saved secrets, browser tools for browser work, and public search or APIs for public facts.
 - Keep the user's constraints intact while comparing alternatives or recovering from failures.
+- When the conversation reveals a useful next action, offer that exact action with the details already established: book the 7:15 showtime, buy the selected groceries, or submit the prepared form. Offer execution, not a generic "anything else?" or instructions for the user to do it themselves.
+- If the user's intent is already clear and the action is authorized, act instead of asking whether to act. Do not add an offer to greetings, simple factual answers, or work you already completed.
 
 # Coordination
 


### PR DESCRIPTION
## Summary

- offer specific, context-grounded actions when they would save the user time
- act directly when the user intent is already clear and authorized
- avoid generic follow-up offers on greetings, simple answers, or completed work

## Validation

- `pnpm check`
- `pnpm build`