### PR TITLE
Allow local development sign-in without OTP

### DIFF
--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { PhoneAuthForm } from "@/app/sign-in/phone-auth-form";
 import { Logo } from "@/components/ui/logo";
+import { isLocalPhoneAuthBypassEnabled } from "@/lib/env";
 import { getAuthSession } from "@/lib/server/auth-session";
 
 export default async function SignInPage({
@@ -22,7 +23,10 @@ export default async function SignInPage({
       <section className="w-full max-w-sm">
         <Logo className="size-9" />
         <h1 className="type-page-title mt-6">Sign in</h1>
-        <PhoneAuthForm callbackUrl={callbackUrl} />
+        <PhoneAuthForm
+          callbackUrl={callbackUrl}
+          skipOtp={isLocalPhoneAuthBypassEnabled()}
+        />
       </section>
     </main>
   );

--- a/app/sign-in/phone-auth-form.tsx
+++ b/app/sign-in/phone-auth-form.tsx
@@ -11,8 +11,10 @@ type AuthStep = "phone-number" | "verification-code";
 
 export function PhoneAuthForm({
   callbackUrl,
+  skipOtp,
 }: {
   readonly callbackUrl: string;
+  readonly skipOtp: boolean;
 }) {
   const [error, setError] = useState<string>();
   const [loading, setLoading] = useState(false);
@@ -31,13 +33,21 @@ export function PhoneAuthForm({
     setPhoneNumber(normalizedPhoneNumber);
     setLoading(true);
     try {
+      if (skipOtp) {
+        await verifyPhoneNumber(normalizedPhoneNumber, "000000");
+        return;
+      }
       const result = await authClient.phoneNumber.sendOtp({
         phoneNumber: normalizedPhoneNumber,
       });
       if (result.error) throw new Error(result.error.message);
       setStep("verification-code");
     } catch {
-      setError("Unable to send a code. Please try again.");
+      setError(
+        skipOtp
+          ? "Unable to sign in locally. Please try again."
+          : "Unable to send a code. Please try again."
+      );
     } finally {
       setLoading(false);
     }
@@ -54,14 +64,7 @@ export function PhoneAuthForm({
 
     setLoading(true);
     try {
-      const verified = await authClient.phoneNumber.verify({
-        code,
-        disableSession: false,
-        phoneNumber,
-        updatePhoneNumber: false,
-      });
-      if (verified.error) throw new Error(verified.error.message);
-      navigateAfterAuth();
+      await verifyPhoneNumber(phoneNumber, code);
     } catch {
       setError(
         "That code could not be verified. Request a new code and try again."
@@ -69,6 +72,17 @@ export function PhoneAuthForm({
     } finally {
       setLoading(false);
     }
+  }
+
+  async function verifyPhoneNumber(phoneNumberValue: string, code: string) {
+    const verified = await authClient.phoneNumber.verify({
+      code,
+      disableSession: false,
+      phoneNumber: phoneNumberValue,
+      updatePhoneNumber: false,
+    });
+    if (verified.error) throw new Error(verified.error.message);
+    navigateAfterAuth();
   }
 
   function navigateAfterAuth() {
@@ -133,7 +147,13 @@ export function PhoneAuthForm({
         <p className="type-supporting-body text-destructive">{error}</p>
       ) : null}
       <Button className="w-full" disabled={loading} type="submit">
-        {loading ? "Sending…" : "Send code"}
+        {loading
+          ? skipOtp
+            ? "Signing in…"
+            : "Sending…"
+          : skipOtp
+            ? "Continue locally"
+            : "Send code"}
       </Button>
     </form>
   );

--- a/auth.ts
+++ b/auth.ts
@@ -5,7 +5,7 @@ import { phoneNumber } from "better-auth/plugins/phone-number";
 import { Pool } from "pg";
 import { z } from "zod";
 import { isE164PhoneNumber } from "@/lib/phone-number";
-import { env } from "@/lib/env";
+import { env, isLocalPhoneAuthBypassEnabled } from "@/lib/env";
 import { sendLinqText } from "@/lib/server/linq";
 
 const AUTH_MIGRATION_LOCK_ID = 1_972_040_815;
@@ -18,6 +18,7 @@ const AUTH_TABLE_NAMES = [
 const authSchemaReadinessSchema = z.object({ ready: z.boolean() });
 
 const databaseUrl = withExplicitVerifiedSsl(env.DATABASE_URL);
+const localPhoneAuthBypass = isLocalPhoneAuthBypassEnabled(env);
 
 const authPool = new Pool({ connectionString: databaseUrl, max: 5 });
 
@@ -55,7 +56,9 @@ export const auth = betterAuth({
       expiresIn: 300,
       phoneNumberValidator: isE164PhoneNumber,
       requireVerification: true,
-      sendOTP: ({ code, phoneNumber: to }) => sendPhoneCode({ code, to }),
+      sendOTP: localPhoneAuthBypass
+        ? () => undefined
+        : ({ code, phoneNumber: to }) => sendPhoneCode({ code, to }),
       signUpOnVerification: {
         getTempEmail: (phoneNumberValue) =>
           `phone-${createHash("sha256")
@@ -63,6 +66,9 @@ export const auth = betterAuth({
             .digest("hex")}@local-vault.invalid`,
         getTempName: () => "Phone user",
       },
+      verifyOTP: localPhoneAuthBypass
+        ? ({ phoneNumber: value }) => isE164PhoneNumber(value)
+        : undefined,
     }),
   ],
   secret: env.BETTER_AUTH_SECRET,

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -33,6 +33,9 @@ const runtimeEnv = createEnv({
     HOSTED_SECRET_ENCRYPTION_KEY: optionalValue,
     SECRET_ENCRYPTION_KEY: optionalValue,
     KERNEL_API_KEY: requiredValue,
+    NODE_ENV: z
+      .enum(["development", "production", "test"])
+      .default("production"),
     VERCEL_ENV: z.enum(["production", "preview", "development"]).optional(),
   },
   experimental__runtimeEnv: {},
@@ -55,3 +58,22 @@ export const env = {
   ...runtimeEnv,
   SECRET_ENCRYPTION_KEY: secretEncryptionKey,
 };
+
+export function isLocalPhoneAuthBypassEnabled(
+  environment: Pick<
+    typeof env,
+    "BETTER_AUTH_URL" | "NODE_ENV" | "VERCEL_ENV"
+  > = env
+) {
+  if (
+    environment.NODE_ENV !== "development" ||
+    environment.VERCEL_ENV !== undefined
+  ) {
+    return false;
+  }
+
+  const hostname = new URL(environment.BETTER_AUTH_URL).hostname;
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]"
+  );
+}

--- a/tests/session-auth.test.ts
+++ b/tests/session-auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { accessScopeForUser } from "../lib/access-scope";
 import { isFullyAuthenticatedUser } from "../lib/auth-user";
+import { isLocalPhoneAuthBypassEnabled } from "../lib/env";
 import { sessionIdFromPath } from "../lib/eve-session-path";
 import { normalizeAuthPhoneNumber } from "../lib/phone-number";
 
@@ -49,5 +50,36 @@ describe("multi-user request identity", () => {
     expect(normalizeAuthPhoneNumber("1 202 555 0123")).toBe("+12025550123");
     expect(normalizeAuthPhoneNumber("+44 7911 123456")).toBe("+447911123456");
     expect(normalizeAuthPhoneNumber("not-a-number")).toBeUndefined();
+  });
+
+  it("bypasses phone OTP only during local development", () => {
+    expect(
+      isLocalPhoneAuthBypassEnabled({
+        BETTER_AUTH_URL: "http://localhost:3000",
+        NODE_ENV: "development",
+        VERCEL_ENV: undefined,
+      })
+    ).toBe(true);
+    expect(
+      isLocalPhoneAuthBypassEnabled({
+        BETTER_AUTH_URL: "http://localhost:3000",
+        NODE_ENV: "production",
+        VERCEL_ENV: undefined,
+      })
+    ).toBe(false);
+    expect(
+      isLocalPhoneAuthBypassEnabled({
+        BETTER_AUTH_URL: "http://localhost:3000",
+        NODE_ENV: "development",
+        VERCEL_ENV: "development",
+      })
+    ).toBe(false);
+    expect(
+      isLocalPhoneAuthBypassEnabled({
+        BETTER_AUTH_URL: "https://preview.example.com",
+        NODE_ENV: "development",
+        VERCEL_ENV: undefined,
+      })
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- skip Linq OTP only for local `next dev` sign-in
- preserve normal Better Auth sessions and phone-based workspace identity
- require development mode, no Vercel environment, and a loopback Better Auth URL
- leave production and preview OTP delivery/verification unchanged

## Verification
- `pnpm check`
- production `pnpm build` with schema-valid placeholder environment and `VERCEL_ENV=production`
- guard tests cover local development, production, Vercel development, and a non-loopback development URL