### PR TITLE
Fix link button semantics

### DIFF
--- a/app/_components/browser-batch-runner.tsx
+++ b/app/_components/browser-batch-runner.tsx
@@ -57,7 +57,11 @@ export function BrowserBatchRunner() {
             one persistent dashboard.
           </p>
         </div>
-        <Button render={<Link href="/chat" />} variant="outline">
+        <Button
+          nativeButton={false}
+          render={<Link href="/chat" />}
+          variant="outline"
+        >
           Open chat
           <MessageSquareIcon data-icon="inline-end" />
         </Button>

--- a/app/_components/manager/workspace.tsx
+++ b/app/_components/manager/workspace.tsx
@@ -101,6 +101,7 @@ function ChannelsSection({ browserReady }: { readonly browserReady: boolean }) {
         {browserReady ? (
           <Button
             className="h-11 justify-start"
+            nativeButton={false}
             render={<Link href="/chat" />}
             variant="outline"
           >
@@ -115,6 +116,7 @@ function ChannelsSection({ browserReady }: { readonly browserReady: boolean }) {
         )}
         <Button
           className="h-11 justify-start"
+          nativeButton={false}
           render={<a href={`sms:${LINQ_PHONE_NUMBER}`} />}
           variant="outline"
         >


### PR DESCRIPTION
## Summary

Base UI expects `Button` to render a native `<button>` unless `nativeButton` is disabled. The workspace and browser-jobs views instead compose those buttons with Next.js links or an `sms:` anchor, which triggers a console error and gives Base UI the wrong semantic contract.

Mark all three link-backed button compositions as `nativeButton={false}`. Navigation targets, styling, and native button usages remain unchanged.

## Validation

- `pnpm check`
  - 14 test files and 49 tests passed
  - lint, type checking, formatting, Knip, and package boundaries passed
- `pnpm build`
- Focused Oxlint and Oxfmt checks on both changed components
- Source scan confirmed no remaining `Button` compositions under `app/` render `Link` or `<a>` without `nativeButton={false}`

## Reviewer focus

Confirm the three affected controls retain their existing link destinations while opting into anchor semantics explicitly.
