### PR TITLE
Remove redundant generated type files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .eve
 .vercel
 .next
+next-env.d.ts
 .turbo
 .output
 .nitro

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test": "turbo run test:app",
     "test:app": "vitest run",
     "types:check": "turbo run types:check:app",
-    "types:check:app": "tsc --noEmit -p tsconfig.json",
+    "types:check:app": "next typegen && tsc --noEmit -p tsconfig.json",
     "build:eve": "eve build",
     "dev:eve": "eve dev",
     "start:eve": "eve start"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
     "test": "turbo run test:app",
     "test:app": "vitest run",
     "types:check": "turbo run types:check:app",
-    "types:check:app": "next typegen && tsc --noEmit -p tsconfig.json",
+    "types:generate": "next typegen",
+    "types:check:app": "tsc --noEmit -p tsconfig.json",
     "build:eve": "eve build",
     "dev:eve": "eve dev",
     "start:eve": "eve start"

--- a/turbo.json
+++ b/turbo.json
@@ -47,8 +47,12 @@
     "test:app": {
       "outputs": []
     },
+    "types:generate": {
+      "outputs": [".next/types/**", "next-env.d.ts"]
+    },
     "types:check:app": {
-      "outputs": [".next/types/**", "next-env.d.ts", "*.tsbuildinfo"]
+      "dependsOn": ["types:generate"],
+      "outputs": ["*.tsbuildinfo"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -13,11 +13,11 @@
   "tasks": {
     "build:app": {
       "dependsOn": ["^build:app"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**", "next-env.d.ts"]
     },
     "build:vercel": {
       "dependsOn": ["db:migrate"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**", "next-env.d.ts"]
     },
     "db:migrate": {
       "cache": false,
@@ -48,7 +48,7 @@
       "outputs": []
     },
     "types:check:app": {
-      "outputs": ["*.tsbuildinfo"]
+      "outputs": [".next/types/**", "next-env.d.ts", "*.tsbuildinfo"]
     }
   }
 }

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -1,1 +1,0 @@
-declare module "*.css";


### PR DESCRIPTION
## Summary

- remove the redundant `types/css.d.ts` declaration now covered by Next's global types
- stop tracking `next-env.d.ts` and add it to `.gitignore` per Next 16 guidance
- expose `types:generate` as the package-owned `next typegen` command
- make `types:check:app` depend on `types:generate` through Turbo, with each task owning only its generated outputs
- include `next-env.d.ts` in both cached Next build output sets

## Validation

- `pnpm turbo run types:check:app --dry=json` confirms the same-package generation dependency and separated outputs
- cold `pnpm types:check` from an output-free state (2/2 tasks)
- cached `pnpm types:check` restored `.next/types`, `next-env.d.ts`, and `tsconfig.tsbuildinfo` byte-for-byte (2/2 cache hits)
- `pnpm check` (6/6 tasks, 16 files, 49 tests)
- `pnpm build` with non-secret schema-valid environment placeholders
- build cache restoration of `.next` and `next-env.d.ts`, compared byte-for-byte
- `git diff --check`

`build:vercel` cache execution was intentionally not run because its task graph invokes the uncached `db:migrate` side effect; its dry run confirms the same generated Next output ownership as `build:app`.