### PR TITLE
Separate benchmark environment configuration

### DIFF
--- a/evals/browser/benchmark-reporter.ts
+++ b/evals/browser/benchmark-reporter.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { EveEvalResult, EveEvalRunSummary } from "eve/evals";
 import type { EvalReporter } from "eve/evals/reporters";
-import { env } from "@/lib/env";
+import { browserBenchmarkEnv } from "@/evals/browser/env";
 import {
   measureBrowserTask,
   readTaskCompletion,
@@ -114,7 +114,7 @@ async function buildBenchmark(
   )?.result.runtimeIdentity;
   const gitSha =
     runtimeIdentity?.build?.gitSha ?? (await readCurrentGitSha()) ?? null;
-  const environmentLabel = env.BROWSER_BENCH_LABEL?.trim();
+  const environmentLabel = browserBenchmarkEnv.BROWSER_BENCH_LABEL?.trim();
 
   return {
     completedAt: summary.completedAt,

--- a/evals/browser/browser.eval.ts
+++ b/evals/browser/browser.eval.ts
@@ -2,9 +2,9 @@ import { defineEval } from "eve/evals";
 import { includes } from "eve/evals/expect";
 import type { MessageStreamEvent } from "eve/client";
 import { browserBenchmarkTasks } from "@/lib/browser/benchmark-tasks";
-import { env } from "@/lib/env";
+import { browserBenchmarkEnv } from "@/evals/browser/env";
 
-const repetitions = env.BROWSER_BENCH_REPETITIONS;
+const repetitions = browserBenchmarkEnv.BROWSER_BENCH_REPETITIONS;
 
 export default browserBenchmarkTasks.flatMap((task) =>
   Array.from({ length: repetitions }, (_, repetitionIndex) =>

--- a/evals/browser/env.ts
+++ b/evals/browser/env.ts
@@ -1,0 +1,15 @@
+import { createEnv } from "@t3-oss/env-nextjs";
+import { z } from "zod";
+
+export const browserBenchmarkEnv = createEnv({
+  server: {
+    BROWSER_BENCH_LABEL: z.string().min(1).optional(),
+    BROWSER_BENCH_REPETITIONS: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(20)
+      .default(1),
+  },
+  experimental__runtimeEnv: {},
+});

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -18,13 +18,6 @@ const runtimeEnv = createEnv({
       (value) => URL.canParse(value),
       "BETTER_AUTH_URL must be an absolute URL"
     ),
-    BROWSER_BENCH_LABEL: z.string().min(1).optional(),
-    BROWSER_BENCH_REPETITIONS: z.coerce
-      .number()
-      .int()
-      .min(1)
-      .max(20)
-      .default(1),
     DATABASE_URL: databaseUrlSchema,
     EVE_NEXT_PRODUCTION_ORIGIN: optionalValue.refine(
       (value) => value === undefined || URL.canParse(value),

--- a/tests/browser-benchmark-env.test.ts
+++ b/tests/browser-benchmark-env.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("browser benchmark environment", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubEnv("BROWSER_BENCH_LABEL", undefined);
+    vi.stubEnv("BROWSER_BENCH_REPETITIONS", undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("provides benchmark defaults independently of the runtime environment", async () => {
+    const { browserBenchmarkEnv } = await import("../evals/browser/env");
+
+    expect(browserBenchmarkEnv.BROWSER_BENCH_LABEL).toBeUndefined();
+    expect(browserBenchmarkEnv.BROWSER_BENCH_REPETITIONS).toBe(1);
+  });
+
+  it("validates the repetition count", async () => {
+    vi.stubEnv("BROWSER_BENCH_REPETITIONS", "21");
+
+    await expect(import("../evals/browser/env")).rejects.toThrow(
+      "Invalid environment variables"
+    );
+  });
+});

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -27,7 +27,6 @@ describe("environment", () => {
     const { env } = await import("../lib/env");
 
     expect(env).toMatchObject(requiredEnvironment);
-    expect(env.BROWSER_BENCH_REPETITIONS).toBe(1);
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- move browser benchmark variables into an eval-owned validated environment module
- keep `lib/env.ts` limited to production runtime configuration
- add focused coverage for benchmark defaults and repetition validation

## Validation

- `pnpm exec vitest run tests/env.test.ts tests/browser-benchmark-env.test.ts`
- `pnpm check`
- `pnpm build` with non-secret test runtime values
- independent read-only review: clean