### PR TITLE
Show live subagent traces in web chat

### DIFF
--- a/app/_components/agent-chat.tsx
+++ b/app/_components/agent-chat.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import type { UserContent } from "ai";
-import { isTurnFailureEvent } from "eve/client";
 import { useEveAgent } from "eve/react";
 import { AlertCircleIcon, BrainIcon, PlusIcon, SquareIcon } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -22,9 +21,11 @@ import { Shimmer } from "@/components/ai-elements/shimmer";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { formatChatUsage, summarizeChatUsage } from "@/app/_lib/chat-usage";
+import { getLatestTurnFailure } from "@/app/_lib/turn-failure";
 import type { ChatUsage } from "@/lib/chat";
 import { cn } from "@/lib/utils";
 import { AgentMessage } from "./agent-message";
+import { SubagentTrace } from "./subagent-trace";
 
 const AGENT_NAME = "Local Vault Assistant";
 
@@ -144,6 +145,19 @@ export function AgentChat({
 
     return deliveriesByMessage;
   }, [agent.events]);
+  const subagentTraces = useMemo(() => {
+    const traces = new Map<string, ReactNode>();
+
+    for (const event of agent.events) {
+      if (event.type !== "subagent.called") continue;
+      traces.set(
+        event.data.callId,
+        <SubagentTrace key={event.data.childSessionId} target={event.data} />
+      );
+    }
+
+    return traces;
+  }, [agent.events]);
 
   useEffect(() => {
     if (activeSessionId === undefined || latestTerminalTurnAt === undefined) {
@@ -246,6 +260,9 @@ export function AgentChat({
               isPendingAssistantShell &&
               message.id === lastMessage.id ? null : (
                 <AgentMessage
+                  afterToolCalls={
+                    traceView === "trace" ? subagentTraces : undefined
+                  }
                   canRespond={!isBusy && !isRestoring}
                   deliveredAssistantMessages={deliveredAssistantMessages.get(
                     message.id
@@ -414,32 +431,4 @@ async function saveChat(sessionId: string, title?: string, usage?: ChatUsage) {
     headers: { "Content-Type": "application/json" },
     method: "POST",
   });
-}
-
-function getLatestTurnFailure(
-  events: ReturnType<typeof useEveAgent>["events"]
-): string | undefined {
-  for (let index = events.length - 1; index >= 0; index -= 1) {
-    const event = events[index];
-
-    if (!event) {
-      continue;
-    }
-
-    if (isTurnFailureEvent(event) && event.type === "turn.failed") {
-      return event.data.code === "MODEL_CALL_FAILED"
-        ? "The model is temporarily unavailable. Please try again."
-        : event.data.message;
-    }
-
-    if (event.type === "turn.completed" || event.type === "turn.cancelled") {
-      return undefined;
-    }
-
-    if (event.type === "message.received") {
-      return undefined;
-    }
-  }
-
-  return undefined;
 }

--- a/app/_components/agent-message.tsx
+++ b/app/_components/agent-message.tsx
@@ -15,7 +15,7 @@ import {
   KeyRoundIcon,
   XCircleIcon,
 } from "lucide-react";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import {
   Message,
   MessageContent,
@@ -56,6 +56,7 @@ export type AgentInputResponse = {
 type EveFilePart = Extract<EveMessagePart, { type: "file" }>;
 
 export function AgentMessage({
+  afterToolCalls,
   canRespond,
   deliveredAssistantMessages,
   isStreaming,
@@ -64,6 +65,7 @@ export function AgentMessage({
   timestamp,
   userVisibleOnly = false,
 }: {
+  readonly afterToolCalls?: ReadonlyMap<string, ReactNode>;
   readonly canRespond: boolean;
   readonly deliveredAssistantMessages?: ReadonlyMap<number, readonly string[]>;
   readonly isStreaming: boolean;
@@ -99,6 +101,7 @@ export function AgentMessage({
         {visibleParts.map((part, index) =>
           hasAssistantText && part.type === "reasoning" ? null : (
             <AgentMessagePart
+              afterToolCalls={afterToolCalls}
               canRespond={canRespond}
               key={partKey(part, index)}
               onInputResponses={onInputResponses}
@@ -184,12 +187,14 @@ function formatFullTimestamp(timestamp: string) {
 }
 
 function AgentMessagePart({
+  afterToolCalls,
   canRespond,
   onInputResponses,
   part,
   showCaret,
   userVisibleOnly,
 }: {
+  readonly afterToolCalls?: ReadonlyMap<string, ReactNode>;
   readonly canRespond: boolean;
   readonly onInputResponses: (
     responses: readonly AgentInputResponse[]
@@ -241,7 +246,7 @@ function AgentMessagePart({
         );
       }
 
-      return (
+      const tool = (
         <Tool
           defaultOpen={
             part.state === "approval-requested" ||
@@ -259,6 +264,15 @@ function AgentMessagePart({
             <ToolOutput errorText={part.errorText} output={part.output} />
           </ToolContent>
         </Tool>
+      );
+      const afterToolCall = afterToolCalls?.get(part.toolCallId);
+      return afterToolCall ? (
+        <>
+          {tool}
+          {afterToolCall}
+        </>
+      ) : (
+        tool
       );
     }
   }

--- a/app/_components/subagent-trace.tsx
+++ b/app/_components/subagent-trace.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import type { SubagentCalledStreamEvent } from "eve/client";
+import { useEveAgent } from "eve/react";
+import { BotIcon } from "lucide-react";
+import { useMemo } from "react";
+import { Shimmer } from "@/components/ai-elements/shimmer";
+import { Badge } from "@/components/ui/badge";
+import { getLatestTurnFailure } from "@/app/_lib/turn-failure";
+import { AgentMessage } from "./agent-message";
+
+export function SubagentTrace({
+  target,
+}: {
+  readonly target: SubagentCalledStreamEvent["data"];
+}) {
+  const trace = useEveAgent({
+    initialSession: { sessionId: target.childSessionId, streamIndex: 0 },
+    resume: true,
+  });
+  const timestamps = useMemo(() => {
+    const values = new Map<string, string>();
+    for (const event of trace.events) {
+      if (event.type === "message.received") {
+        values.set(`${event.data.turnId}:user`, event.meta.at);
+      }
+      if (
+        event.type === "message.completed" &&
+        event.data.finishReason !== "tool-calls"
+      ) {
+        values.set(`${event.data.turnId}:assistant`, event.meta.at);
+      }
+    }
+    return values;
+  }, [trace.events]);
+  const isRunning =
+    trace.status === "resuming" ||
+    trace.status === "submitted" ||
+    trace.status === "streaming";
+  const turnFailure = useMemo(
+    () => getLatestTurnFailure(trace.events),
+    [trace.events]
+  );
+  const error = trace.error?.message ?? turnFailure;
+  const status = error ? "Failed" : isRunning ? "Running" : "Settled";
+  const badgeVariant = error
+    ? "destructive"
+    : isRunning
+      ? "information"
+      : "secondary";
+
+  return (
+    <section className="mt-3 overflow-hidden rounded-lg border bg-muted/20">
+      <header className="flex items-center gap-2 px-3 py-2">
+        <BotIcon className="size-4 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate type-label">
+          {target.name} trace
+        </span>
+        <Badge variant={badgeVariant}>{status}</Badge>
+      </header>
+      <div className="space-y-4 border-t px-3 py-3">
+        {trace.data.messages.map((message, index) => (
+          <AgentMessage
+            canRespond={false}
+            isStreaming={
+              trace.status === "streaming" &&
+              index === trace.data.messages.length - 1
+            }
+            key={message.id}
+            message={message}
+            onInputResponses={() => undefined}
+            timestamp={timestamps.get(message.id)}
+          />
+        ))}
+        {isRunning && trace.data.messages.length === 0 ? (
+          <Shimmer className="type-supporting-body" duration={1}>
+            Loading task trace
+          </Shimmer>
+        ) : null}
+        {error ? (
+          <p className="type-supporting-body text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/app/_lib/turn-failure.ts
+++ b/app/_lib/turn-failure.ts
@@ -1,0 +1,24 @@
+import { isTurnFailureEvent, type MessageStreamEvent } from "eve/client";
+
+export function getLatestTurnFailure(
+  events: readonly MessageStreamEvent[]
+): string | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (!event) continue;
+
+    if (isTurnFailureEvent(event) && event.type === "turn.failed") {
+      return event.data.code === "MODEL_CALL_FAILED"
+        ? "The model is temporarily unavailable. Please try again."
+        : event.data.message;
+    }
+    if (
+      event.type === "turn.completed" ||
+      event.type === "turn.cancelled" ||
+      event.type === "message.received"
+    ) {
+      return undefined;
+    }
+  }
+  return undefined;
+}

--- a/tests/agent-message.test.tsx
+++ b/tests/agent-message.test.tsx
@@ -1,7 +1,9 @@
+import type { MessageStreamEvent } from "eve/client";
 import type { EveMessage } from "eve/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { AgentMessage } from "../app/_components/agent-message";
+import { getLatestTurnFailure } from "../app/_lib/turn-failure";
 
 describe("agent messages", () => {
   it("renders ordinary assistant text without a delivery tool result", () => {
@@ -131,5 +133,62 @@ describe("agent messages", () => {
     expect(markup).toContain("Cancel");
     expect(markup).not.toContain("send_payment");
     expect(markup).not.toContain("Hidden recipient");
+  });
+
+  it("renders a matching child trace after its subagent tool", () => {
+    const message = {
+      id: "turn-3:assistant",
+      parts: [
+        {
+          input: { message: "Research this" },
+          output: { status: "working", taskId: "task-1" },
+          state: "output-available",
+          toolCallId: "call-agent",
+          toolName: "agent",
+          type: "dynamic-tool",
+        },
+      ],
+      role: "assistant",
+    } satisfies EveMessage;
+
+    const markup = renderToStaticMarkup(
+      <AgentMessage
+        afterToolCalls={
+          new Map([["call-agent", <div key="trace">Live child trace</div>]])
+        }
+        canRespond
+        isStreaming={false}
+        message={message}
+        onInputResponses={() => undefined}
+      />
+    );
+
+    expect(markup).toContain("agent");
+    expect(markup).toContain("Live child trace");
+    expect(markup.indexOf("Live child trace")).toBeGreaterThan(
+      markup.indexOf("agent")
+    );
+  });
+
+  it("keeps a parked failed child visibly failed", () => {
+    const events = [
+      {
+        data: {
+          code: "CHILD_FAILED",
+          message: "Child failed.",
+          sequence: 1,
+          turnId: "child-turn",
+        },
+        meta: { at: "2026-08-27T20:00:00.000Z", id: "failed" },
+        type: "turn.failed",
+      },
+      {
+        data: { continuationToken: "", wait: "next-user-message" },
+        meta: { at: "2026-08-27T20:00:01.000Z", id: "waiting" },
+        type: "session.waiting",
+      },
+    ] satisfies MessageStreamEvent[];
+
+    expect(getLatestTurnFailure(events)).toBe("Child failed.");
   });
 });


### PR DESCRIPTION
## Summary

Full trace showed the parent `agent` tool receipt, but not the delegated agent's work. Background tasks therefore looked idle until their result returned to the parent conversation.

This PR keeps the fix local to the web client and uses eve's existing React session handling:

- Matches `subagent.called.callId` to the corresponding parent tool call.
- Mounts a nested `useEveAgent` session for the local child and renders its messages, tools, timestamps, result, and status beneath that call.
- Shares the existing latest-turn failure projection so parked failed children remain visibly failed.
- Leaves iMessage rendering unchanged.

OpenInstinct currently delegates only to its local built-in `agent`, so this deliberately does not add a custom stream parser or remote-subagent proxy handling.

## Validation

- `pnpm check` — lint, typecheck, 25 test files / 98 tests, formatting, Knip, and package boundaries passed.
- `pnpm build` — the WXT extension and Next.js production builds passed.
- Focused child placement and parked-failure regressions passed.
- Independent implementation review and bounded re-review passed.
