### PR TITLE
Fix Linq message line-break concatenation

### DIFF
--- a/agent/channels/linq-message-delivery.ts
+++ b/agent/channels/linq-message-delivery.ts
@@ -1,0 +1,32 @@
+/* oxlint-disable typescript/no-unsafe-call, typescript/no-unsafe-member-access -- Eve's Linq adapter exposes the thread through a transitive Chat SDK type; the handler remains contextually type-checked against LinqChannelConfig. */
+import type { LinqChannelConfig } from "eve/channels/linq";
+
+type LinqMessageCompletedHandler = NonNullable<
+  NonNullable<LinqChannelConfig["events"]>["message.completed"]
+>;
+
+export const deliverCompletedLinqMessage: LinqMessageCompletedHandler = async (
+  event,
+  context
+) => {
+  if (event.finishReason === "tool-calls") {
+    context.state.pendingToolCallMessage = event.message
+      ? (firstNonEmptyLine(event.message) ?? null)
+      : null;
+    return;
+  }
+
+  context.state.pendingToolCallMessage = null;
+  if (!event.message || !context.thread) return;
+
+  // Linq/iMessage supports raw text. Passing Markdown through Chat SDK's
+  // converter collapses soft line breaks and can concatenate adjacent lines.
+  await context.thread.post(event.message);
+};
+
+function firstNonEmptyLine(message: string) {
+  return message
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .find(Boolean);
+}

--- a/agent/channels/linq.ts
+++ b/agent/channels/linq.ts
@@ -6,6 +6,7 @@ import { auth } from "@/auth";
 import { normalizeAuthPhoneNumber } from "@/auth/phone-number";
 import { accessScopeForUser } from "@/lib/access-scope";
 import { env } from "@/lib/env";
+import { deliverCompletedLinqMessage } from "./linq-message-delivery";
 
 const verifiedPhoneUserSchema = z.object({
   id: z.string().min(1),
@@ -14,6 +15,9 @@ const verifiedPhoneUserSchema = z.object({
 
 export default linqChannel({
   credentials: connectLinqCredentials(env.LINQ_CONNECTOR_UID),
+  events: {
+    "message.completed": deliverCompletedLinqMessage,
+  },
   async onMessage(_context, message) {
     if (message.author.isBot) return null;
 

--- a/tests/linq-message-delivery.test.ts
+++ b/tests/linq-message-delivery.test.ts
@@ -1,0 +1,82 @@
+/* oxlint-disable typescript/no-unsafe-type-assertion -- Eve's Linq adapter exposes the handler context through a transitive Chat SDK `any`; the fixture supplies only the fields exercised here. */
+import { describe, expect, it, vi } from "vitest";
+import { deliverCompletedLinqMessage } from "../agent/channels/linq-message-delivery";
+
+type HandlerParameters = Parameters<typeof deliverCompletedLinqMessage>;
+
+describe("Linq message delivery", () => {
+  it("posts final multiline responses as unchanged raw text", async () => {
+    const message = [
+      "Still blocked. No order was submitted.",
+      "The order remains unchanged:",
+      "Spider-Man: Brand New Day",
+      "$15.00 total",
+    ].join("\n");
+    const { context, post } = handlerContext();
+
+    await deliverCompletedLinqMessage(
+      completedEvent({ message }),
+      context,
+      sessionContext()
+    );
+
+    expect(post).toHaveBeenCalledExactlyOnceWith(message);
+  });
+
+  it("suppresses intermediate tool-call messages", async () => {
+    const { context, post, state } = handlerContext();
+
+    await deliverCompletedLinqMessage(
+      completedEvent({
+        finishReason: "tool-calls",
+        message: "Checking the checkout\nwith the browser",
+      }),
+      context,
+      sessionContext()
+    );
+
+    expect(post).not.toHaveBeenCalled();
+    expect(state.pendingToolCallMessage).toBe("Checking the checkout");
+  });
+
+  it("does not post an empty final response", async () => {
+    const { context, post } = handlerContext();
+
+    await deliverCompletedLinqMessage(
+      completedEvent({ message: null }),
+      context,
+      sessionContext()
+    );
+
+    expect(post).not.toHaveBeenCalled();
+  });
+});
+
+function completedEvent(
+  overrides: Partial<HandlerParameters[0]> = {}
+): HandlerParameters[0] {
+  return {
+    finishReason: "stop",
+    message: "Done",
+    sequence: 0,
+    stepIndex: 0,
+    turnId: "turn-1",
+    ...overrides,
+  };
+}
+
+function handlerContext() {
+  const post = vi.fn<(message: string) => Promise<void>>();
+  post.mockResolvedValue();
+  const state: Record<string, unknown> = {};
+  const context = {
+    state,
+    thread: { post },
+  } as unknown as HandlerParameters[1];
+
+  return { context, post, state };
+}
+
+function sessionContext() {
+  return {} as HandlerParameters[2];
+}


### PR DESCRIPTION
## Summary
- deliver final Linq/iMessage responses as raw text so newlines survive platform formatting
- keep intermediate tool-call messages suppressed while preserving Eve typing-status bookkeeping
- add regression coverage for multiline, tool-call, and empty completions

## Verification
- `pnpm check`
- `pnpm build`