### PR TITLE
Fix clean local dev shutdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,4 +89,5 @@ Before planning or changing product UI:
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 
 This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
 <!-- END:nextjs-agent-rules -->

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -15,17 +15,36 @@ let activeChild;
 let composeAttempted = false;
 let shutdownSignal;
 
+function interrupt(child, signal) {
+  try {
+    if (process.platform === "win32") {
+      child.kill(signal);
+      return;
+    }
+
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") {
+      console.error(`Failed to forward ${signal} to ${child.pid}:`, error);
+      process.exitCode = 1;
+    }
+  }
+}
+
 for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
   process.on(signal, () => {
     if (shutdownSignal === undefined) {
       shutdownSignal = signal;
-      activeChild?.kill(signal);
+      if (activeChild !== undefined) {
+        interrupt(activeChild, signal);
+      }
     }
   });
 }
 
 async function run(command, args, { allowInterruption = false } = {}) {
   const child = spawn(command, args, {
+    detached: process.platform !== "win32",
     env: developmentEnvironment,
     stdio: "inherit",
   });
@@ -61,7 +80,7 @@ try {
   }
 
   if (shouldContinue) {
-    await run("pnpm", ["exec", "turbo", "run", "dev:app"], {
+    await run("pnpm", ["dev:app"], {
       allowInterruption: true,
     });
   }
@@ -69,9 +88,4 @@ try {
   if (composeAttempted) {
     await run("docker", ["compose", "down"]);
   }
-}
-
-if (shutdownSignal !== undefined) {
-  const signalExitCodes = { SIGHUP: 129, SIGINT: 130, SIGTERM: 143 };
-  process.exitCode = signalExitCodes[shutdownSignal];
 }

--- a/tests/local-development.test.ts
+++ b/tests/local-development.test.ts
@@ -35,9 +35,7 @@ describe("local development", () => {
 
     const start = developmentScript.indexOf("composeAttempted = true");
     const migrate = developmentScript.indexOf('["db:migrate"]');
-    const application = developmentScript.indexOf(
-      '["exec", "turbo", "run", "dev:app"]'
-    );
+    const application = developmentScript.indexOf('["dev:app"]');
     const stop = developmentScript.indexOf('["compose", "down"]');
 
     expect(start).toBeGreaterThan(-1);
@@ -53,14 +51,14 @@ describe("local development", () => {
   it("tears Compose down when interrupted during startup", async () => {
     const result = await interruptDuringStartup();
 
-    expect(result.code).toBe(130);
+    expect(result.code).toBe(0);
     expect(result.commands).toBe("compose up --detach --wait\ncompose down\n");
   });
 
   it("does not advance when interrupted startup exits cleanly", async () => {
     const result = await interruptDuringStartup({ DEV_STARTUP_EXIT: "0" });
 
-    expect(result.code).toBe(130);
+    expect(result.code).toBe(0);
     expect(result.commands).toBe("compose up --detach --wait\ncompose down\n");
   });
 
@@ -131,7 +129,7 @@ printf 'pnpm %s\\n' "$*" >> "$DEV_SUPERVISOR_LOG"
 }
 
 async function waitForLogEntry(path: string, expected: string) {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
+  for (let attempt = 0; attempt < 250; attempt += 1) {
     const contents = await readFile(path, "utf8").catch(() => "");
     if (contents.includes(expected)) {
       return;


### PR DESCRIPTION
## Summary

- supervise the Next.js development process directly instead of routing the interactive task through Turbo
- isolate child process groups and forward a single shutdown signal safely
- treat successful Ctrl+C cleanup as success while preserving teardown and signal-forwarding failures
- strengthen local-development shutdown coverage and polling tolerance

## Verification

- `pnpm test -- tests/local-development.test.ts` — 4/4 passed
- `pnpm check` — passed (96 tests, lint, types, formatting, Knip, and boundaries)
- real `pnpm dev` terminal smoke test — one Ctrl+C removed Compose resources and exited 0 without Turbo force-kill or pnpm lifecycle-error output
- independent read-only review — clean
- `pnpm build` — extension build and Next.js compilation/typecheck passed; page-data collection was blocked by missing required local environment variables: `DATABASE_URL`, `KERNEL_API_KEY`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, and `SECRET_ENCRYPTION_KEY`