### PR TITLE
Use Eve-native iMessage formatting and reactions

### DIFF
--- a/agent/channels/linq.ts
+++ b/agent/channels/linq.ts
@@ -1,4 +1,4 @@
-/* oxlint-disable typescript/no-unsafe-call, typescript/no-unsafe-member-access -- Eve's Linq adapter exposes the thread through a transitive Chat SDK type; TypeScript still checks this contextual handler. */
+/* oxlint-disable typescript/no-unsafe-assignment, typescript/no-unsafe-call, typescript/no-unsafe-member-access -- Eve's Linq adapter exposes the thread through a transitive Chat SDK type; TypeScript still checks this contextual handler. */
 import { connectLinqCredentials } from "@vercel/connect/eve";
 import {
   defaultLinqAuth,
@@ -39,15 +39,16 @@ export const deliverCompletedLinqMessage: LinqMessageCompletedHandler = async (
     context.state.pendingToolCallMessage = event.message
       ? (firstNonEmptyLine(event.message) ?? null)
       : null;
+    await acknowledgeLinqToolWork(context);
     return;
   }
 
   context.state.pendingToolCallMessage = null;
   if (!event.message || !context.thread) return;
 
-  // Linq/iMessage supports raw text. Passing Markdown through Chat SDK's
-  // converter collapses soft line breaks and can concatenate adjacent lines.
-  await context.thread.post(event.message);
+  // Eve's Linq adapter translates supported Markdown into native iMessage
+  // decorations, so recipients see styled text instead of literal markers.
+  await context.thread.post({ markdown: event.message });
 };
 
 export default linqChannel({
@@ -99,4 +100,22 @@ async function findVerifiedAuthUserIdByPhoneNumber(phoneNumber: string) {
   });
   const parsed = verifiedPhoneUserSchema.safeParse(user);
   return parsed.success ? parsed.data.id : undefined;
+}
+
+async function acknowledgeLinqToolWork(
+  context: Parameters<LinqMessageCompletedHandler>[1]
+) {
+  if (!context.thread) return;
+  const messageId = context.thread.toJSON().currentMessage?.id;
+  if (!messageId || context.state.acknowledgedLinqMessageId === messageId)
+    return;
+
+  try {
+    await context.bot
+      .getAdapter("linq")
+      .addReaction(context.thread.id, messageId, "thumbs_up");
+    context.state.acknowledgedLinqMessageId = messageId;
+  } catch {
+    // SMS/RCS and some carrier paths do not support iMessage tapbacks.
+  }
 }

--- a/tests/linq-message-delivery.test.ts
+++ b/tests/linq-message-delivery.test.ts
@@ -5,7 +5,7 @@ import { deliverCompletedLinqMessage } from "../agent/channels/linq";
 type HandlerParameters = Parameters<typeof deliverCompletedLinqMessage>;
 
 describe("Linq message delivery", () => {
-  it("posts final multiline responses as unchanged raw text", async () => {
+  it("posts final responses as native iMessage Markdown", async () => {
     const message = [
       "Still blocked. No order was submitted.",
       "The order remains unchanged:",
@@ -20,11 +20,11 @@ describe("Linq message delivery", () => {
       sessionContext()
     );
 
-    expect(post).toHaveBeenCalledExactlyOnceWith(message);
+    expect(post).toHaveBeenCalledExactlyOnceWith({ markdown: message });
   });
 
   it("suppresses intermediate tool-call messages", async () => {
-    const { context, post, state } = handlerContext();
+    const { addReaction, context, post, state } = handlerContext();
 
     await deliverCompletedLinqMessage(
       completedEvent({
@@ -36,6 +36,11 @@ describe("Linq message delivery", () => {
     );
 
     expect(post).not.toHaveBeenCalled();
+    expect(addReaction).toHaveBeenCalledExactlyOnceWith(
+      "linq:dm:chat-1",
+      "message-1",
+      "thumbs_up"
+    );
     expect(state.pendingToolCallMessage).toBe("Checking the checkout");
   });
 
@@ -68,13 +73,33 @@ function completedEvent(
 function handlerContext() {
   const post = vi.fn<(message: string) => Promise<void>>();
   post.mockResolvedValue();
+  const addReaction = vi
+    .fn<(threadId: string, messageId: string, emoji: string) => Promise<void>>()
+    .mockResolvedValue(undefined);
   const state: Record<string, unknown> = {};
   const context = {
+    bot: {
+      getAdapter: () => ({
+        addReaction,
+        decodeThreadId: () => ({ chatId: "chat-1", isGroup: false }),
+      }),
+    },
     state,
-    thread: { post },
+    thread: {
+      id: "linq:dm:chat-1",
+      post,
+      toJSON: () => ({
+        _type: "chat:Thread",
+        adapterName: "linq",
+        channelId: "linq:dm:chat-1",
+        currentMessage: { id: "message-1" },
+        id: "linq:dm:chat-1",
+        isDM: true,
+      }),
+    },
   } as unknown as HandlerParameters[1];
 
-  return { context, post, state };
+  return { addReaction, context, post, state };
 }
 
 function sessionContext() {


### PR DESCRIPTION
## Summary
- post Linq responses through Eve’s native Markdown path so supported emphasis becomes iMessage text decorations
- add a single native 👍 tapback when a request enters tool work
- keep intermediate tool-call text suppressed

Threaded `reply_to` is intentionally excluded: Eve’s Linq adapter does not expose it yet, and this PR avoids a custom SDK send path or adapter fork.

## Verification
- `pnpm check`
- `pnpm build` (using the existing local env file)