### PR TITLE
Let the model choose iMessage reactions

### DIFF
--- a/agent/channels/linq.ts
+++ b/agent/channels/linq.ts
@@ -11,6 +11,7 @@ import { auth } from "@/auth";
 import { normalizeAuthPhoneNumber } from "@/auth/phone-number";
 import { accessScopeForUser } from "@/lib/access-scope";
 import { env } from "@/lib/env";
+import { linqReactionRequestSchema } from "@/agent/lib/linq-reactions";
 
 const verifiedPhoneUserSchema = z.object({
   id: z.string().min(1),
@@ -30,6 +31,31 @@ const credentials: LinqChannelCredentials = env.LINQ_CONNECTOR
 type LinqMessageCompletedHandler = NonNullable<
   NonNullable<LinqChannelConfig["events"]>["message.completed"]
 >;
+type LinqActionResultHandler = NonNullable<
+  NonNullable<LinqChannelConfig["events"]>["action.result"]
+>;
+
+export const deliverLinqReaction: LinqActionResultHandler = async (
+  event,
+  context
+) => {
+  if (
+    event.status !== "completed" ||
+    event.result.kind !== "tool-result" ||
+    event.result.toolName !== "react_to_message" ||
+    !context.thread
+  ) {
+    return;
+  }
+
+  const request = linqReactionRequestSchema.safeParse(event.result.output);
+  const messageId = context.thread.toJSON().currentMessage?.id;
+  if (!request.success || !messageId) return;
+
+  await context.bot
+    .getAdapter("linq")
+    .addReaction(context.thread.id, messageId, request.data.reaction);
+};
 
 export const deliverCompletedLinqMessage: LinqMessageCompletedHandler = async (
   event,
@@ -39,7 +65,6 @@ export const deliverCompletedLinqMessage: LinqMessageCompletedHandler = async (
     context.state.pendingToolCallMessage = event.message
       ? (firstNonEmptyLine(event.message) ?? null)
       : null;
-    await acknowledgeLinqToolWork(context);
     return;
   }
 
@@ -54,6 +79,7 @@ export const deliverCompletedLinqMessage: LinqMessageCompletedHandler = async (
 export default linqChannel({
   credentials,
   events: {
+    "action.result": deliverLinqReaction,
     "message.completed": deliverCompletedLinqMessage,
   },
   async onMessage(_context, message) {
@@ -100,22 +126,4 @@ async function findVerifiedAuthUserIdByPhoneNumber(phoneNumber: string) {
   });
   const parsed = verifiedPhoneUserSchema.safeParse(user);
   return parsed.success ? parsed.data.id : undefined;
-}
-
-async function acknowledgeLinqToolWork(
-  context: Parameters<LinqMessageCompletedHandler>[1]
-) {
-  if (!context.thread) return;
-  const messageId = context.thread.toJSON().currentMessage?.id;
-  if (!messageId || context.state.acknowledgedLinqMessageId === messageId)
-    return;
-
-  try {
-    await context.bot
-      .getAdapter("linq")
-      .addReaction(context.thread.id, messageId, "thumbs_up");
-    context.state.acknowledgedLinqMessageId = messageId;
-  } catch {
-    // SMS/RCS and some carrier paths do not support iMessage tapbacks.
-  }
 }

--- a/agent/instructions/imessage.ts
+++ b/agent/instructions/imessage.ts
@@ -1,0 +1,12 @@
+import { defineDynamic, defineInstructions } from "eve/instructions";
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, context) =>
+      context.channel.kind === "channel:linq"
+        ? defineInstructions({
+            content: `You are replying in iMessage. The react_to_message tool adds a native tapback to the user's latest message. Decide whether a reaction is natural; never react automatically to every message. Use a reaction by itself when it fully communicates acknowledgment, agreement, amusement, support, emphasis, or a question. When words add value, send a concise text reply and react only if the tapback genuinely complements it. Never claim that you cannot react when this tool is available, and never narrate a reaction instead of using the tool.`,
+          })
+        : null,
+  },
+});

--- a/agent/lib/linq-reactions.ts
+++ b/agent/lib/linq-reactions.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const linqReactionRequestSchema = z.object({
+  reaction: z
+    .enum(["love", "like", "dislike", "laugh", "emphasize", "question"])
+    .describe("The native iMessage tapback to add."),
+});

--- a/agent/tools/react_to_message.ts
+++ b/agent/tools/react_to_message.ts
@@ -1,0 +1,24 @@
+import { defineDynamic, defineTool, toolOutput } from "eve/tools";
+import { linqReactionRequestSchema } from "@/agent/lib/linq-reactions";
+
+export const reactToMessageTool = defineTool({
+  description:
+    "Add a native iMessage tapback to the user's latest message. Use this only when a reaction is a natural conversational choice, never as an automatic acknowledgment. A reaction may replace a text reply when it fully communicates the response.",
+  inputSchema: linqReactionRequestSchema,
+  outputSchema: linqReactionRequestSchema,
+  execute(input) {
+    return input;
+  },
+  toModelOutput({ reaction }) {
+    return toolOutput.text(
+      `The ${reaction} tapback was added. Do not narrate the reaction or add redundant text.`
+    );
+  },
+});
+
+export default defineDynamic({
+  events: {
+    "turn.started": (_event, context) =>
+      context.channel.kind === "channel:linq" ? reactToMessageTool : null,
+  },
+});

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -5,6 +5,7 @@ export default {
     "agent/channels/**/*.ts",
     "agent/extensions/**/*.ts",
     "agent/hooks/**/*.ts",
+    "agent/instructions/**/*.ts",
     "agent/tools/**/*.ts",
     "browser-extension/entrypoints/**/*.ts",
     "db/drizzle.config.ts",

--- a/tests/linq-message-delivery.test.ts
+++ b/tests/linq-message-delivery.test.ts
@@ -1,6 +1,9 @@
 /* oxlint-disable typescript/no-unsafe-type-assertion -- Eve's Linq adapter exposes the handler context through a transitive Chat SDK `any`; the fixture supplies only the fields exercised here. */
 import { describe, expect, it, vi } from "vitest";
-import { deliverCompletedLinqMessage } from "../agent/channels/linq";
+import {
+  deliverCompletedLinqMessage,
+  deliverLinqReaction,
+} from "../agent/channels/linq";
 
 type HandlerParameters = Parameters<typeof deliverCompletedLinqMessage>;
 
@@ -23,7 +26,7 @@ describe("Linq message delivery", () => {
     expect(post).toHaveBeenCalledExactlyOnceWith({ markdown: message });
   });
 
-  it("suppresses intermediate tool-call messages", async () => {
+  it("suppresses intermediate tool-call messages without reacting automatically", async () => {
     const { addReaction, context, post, state } = handlerContext();
 
     await deliverCompletedLinqMessage(
@@ -36,11 +39,7 @@ describe("Linq message delivery", () => {
     );
 
     expect(post).not.toHaveBeenCalled();
-    expect(addReaction).toHaveBeenCalledExactlyOnceWith(
-      "linq:dm:chat-1",
-      "message-1",
-      "thumbs_up"
-    );
+    expect(addReaction).not.toHaveBeenCalled();
     expect(state.pendingToolCallMessage).toBe("Checking the checkout");
   });
 
@@ -54,6 +53,33 @@ describe("Linq message delivery", () => {
     );
 
     expect(post).not.toHaveBeenCalled();
+  });
+
+  it("applies a reaction only when the model calls react_to_message", async () => {
+    const { addReaction, context } = handlerContext();
+
+    await deliverLinqReaction(
+      {
+        result: {
+          callId: "call-1",
+          kind: "tool-result",
+          output: { reaction: "laugh" },
+          toolName: "react_to_message",
+        },
+        sequence: 0,
+        status: "completed",
+        stepIndex: 0,
+        turnId: "turn-1",
+      },
+      context,
+      sessionContext()
+    );
+
+    expect(addReaction).toHaveBeenCalledExactlyOnceWith(
+      "linq:dm:chat-1",
+      "message-1",
+      "laugh"
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the automatic tool-work tapback added in #42
- expose `react_to_message` only on Linq/iMessage turns
- let the model select a native love, like, dislike, laugh, emphasize, or question tapback
- add iMessage-only system guidance so reactions are intentional and can replace redundant text
- apply the selected reaction through Eve’s existing Linq adapter

No direct Linq SDK, custom formatter, or reply shim is introduced.

## Verification
- `pnpm check`
- `pnpm build:eve`
- `pnpm build` (using the existing local env file)