### PR TITLE
Document local development prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,25 @@ Gotchas:
 
 ## Local development
 
-Docker Desktop (or another Docker Compose installation) is required. Configure
-the non-database variables in `.env.example`, then:
+Prerequisites:
+
+- Node.js 24 and pnpm 11
+- Docker Desktop or another Docker Compose installation, with Docker running
+- A Kernel API key
+
+Docker runs the local PostgreSQL database and Eve task sandboxes. Create a
+loadable local environment file before starting the app:
 
 ```bash
 git clone https://github.com/Merit-Systems/open-instinct.git
 cd open-instinct
 pnpm install
+cp .env.example .env.local
+```
+
+Set `KERNEL_API_KEY` in `.env.local`, then start the development environment:
+
+```bash
 pnpm dev
 ```
 

--- a/tests/local-development.test.ts
+++ b/tests/local-development.test.ts
@@ -16,6 +16,20 @@ afterEach(async () => {
 });
 
 describe("local development", () => {
+  it("documents the required tools and loaded environment file", async () => {
+    const readme = await readFile(
+      new URL("../README.md", import.meta.url),
+      "utf8"
+    );
+
+    expect(readme).toContain("Node.js 24 and pnpm 11");
+    expect(readme).toContain("with Docker running");
+    expect(readme).toContain("A Kernel API key");
+    expect(readme).toContain("cp .env.example .env.local");
+    expect(readme).toContain("Set `KERNEL_API_KEY` in `.env.local`");
+    expect(readme).toContain("Eve task sandboxes");
+  });
+
   it("owns the PostgreSQL lifecycle around the application process", async () => {
     const [compose, developmentScript, packageManifestSource] =
       await Promise.all([


### PR DESCRIPTION
## Summary

- document the remaining fresh-clone prerequisites after recent `main` changes added managed local PostgreSQL, automatic migrations, and local auth/encryption defaults
- make the bootstrap copy `.env.example` to the loadable `.env.local` file and identify `KERNEL_API_KEY` as the value developers must set
- explain that Docker must be running for both local PostgreSQL and Eve task sandboxes
- cover the documented prerequisite and env-file contract in the local-development regression suite

## Validation

- `pnpm exec vitest run tests/local-development.test.ts` — 5 tests passed
- `pnpm check` — 25 test files and 100 tests passed; lint, TypeScript, formatting, Knip, and boundaries passed
- `pnpm build` — browser extension and Next production builds passed

No runtime behavior or changeset is required for this documentation-only fix.

Closes #27
