### PR TITLE
Fix chat prompt input composition

### DIFF
--- a/app/_components/agent-chat.tsx
+++ b/app/_components/agent-chat.tsx
@@ -2,7 +2,7 @@
 
 import type { UserContent } from "ai";
 import { useEveAgent } from "eve/react";
-import { AlertCircleIcon, BrainIcon, PlusIcon, SquareIcon } from "lucide-react";
+import { AlertCircleIcon, BrainIcon, PlusIcon } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import {
   Conversation,
@@ -12,10 +12,12 @@ import {
 import { Message, MessageContent } from "@/components/ai-elements/message";
 import {
   PromptInput,
-  PromptInputButton,
+  PromptInputBody,
+  PromptInputFooter,
   type PromptInputMessage,
   PromptInputSubmit,
   PromptInputTextarea,
+  PromptInputTools,
 } from "@/components/ai-elements/prompt-input";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { Button } from "@/components/ui/button";
@@ -211,24 +213,21 @@ export function AgentChat({
 
   const composer = (
     <PromptInput onSubmit={handleSubmit}>
-      <PromptInputTextarea
-        disabled={isRestoring}
-        placeholder="Send a message…"
-      />
-      {isBusy && !isRestoring ? (
-        <PromptInputButton
-          aria-label="Stop"
-          className="absolute right-12 bottom-2.5 rounded-full"
-          onClick={requestCancellation}
-          variant="default"
-        >
-          <SquareIcon className="size-3 fill-current" />
-        </PromptInputButton>
-      ) : null}
-      <PromptInputSubmit
-        disabled={isRestoring}
-        status={isBusy || isRestoring ? undefined : agent.status}
-      />
+      <PromptInputBody>
+        <PromptInputTextarea
+          disabled={isRestoring}
+          placeholder="Send a message…"
+          className="min-h-0"
+        />
+      </PromptInputBody>
+      <PromptInputFooter>
+        <PromptInputTools />
+        <PromptInputSubmit
+          disabled={isRestoring}
+          onStop={requestCancellation}
+          status={isRestoring ? undefined : agent.status}
+        />
+      </PromptInputFooter>
     </PromptInput>
   );
 


### PR DESCRIPTION
## Summary

- compose the chat prompt with the canonical AI Elements body and footer slots
- use the built-in status-driven submit-to-stop replacement
- remove the duplicate custom stop control while preserving restoring and steering behavior

## Validation

- `pnpm check` — passed (25 test files, 99 tests, lint, types, formatting, Knip, and boundaries)
- `pnpm build` — extension build, Next compilation, and TypeScript passed; app page-data collection is blocked because `DATABASE_URL`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, and `SECRET_ENCRYPTION_KEY` are unavailable in this worktree
- independent read-only review — clean, no findings