### PR TITLE
Show iMessage sessions in All Chats

### DIFF
--- a/agent/hooks/session-owner.ts
+++ b/agent/hooks/session-owner.ts
@@ -1,4 +1,5 @@
 import { defineHook } from "eve/hooks";
+import { saveChat } from "@/db/services/chats";
 import { ensureScope } from "@/db/services/scope";
 import { claimSession } from "@/db/services/sessions";
 import { scopeFromPrincipal } from "@/lib/access-scope";
@@ -12,6 +13,14 @@ export default defineHook({
       const scope = scopeFromPrincipal(initiator);
       await ensureScope(scope);
       await claimSession(scope, ctx.session.id);
+    },
+    async "message.received"(_event, ctx) {
+      const initiator = ctx.session.auth.initiator;
+      if (!initiator) return;
+
+      await saveChat(scopeFromPrincipal(initiator), {
+        sessionId: ctx.session.id,
+      });
     },
   },
 });

--- a/db/services/chats.ts
+++ b/db/services/chats.ts
@@ -1,8 +1,8 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { AccessScope } from "@/lib/access-scope";
 import { chatListSchema, type ChatSummary, type SaveChat } from "@/lib/chat";
-import { chats, db } from "@/db";
+import { agentSessions, chats, db } from "@/db";
 import { ensureScope } from "./scope";
 
 const chatRowSchema = z.object({
@@ -24,15 +24,23 @@ function toChatSummary(row: z.infer<typeof chatRowSchema>): ChatSummary {
 }
 
 export async function listChats(scope: AccessScope) {
-  const rows = chatRowSchema
-    .array()
-    .parse(
-      await db
-        .select()
-        .from(chats)
-        .where(eq(chats.workspaceId, scope.workspaceId))
-        .orderBy(desc(chats.updatedAt))
-    );
+  const updatedAt = sql<string>`coalesce(${chats.updatedAt}, ${agentSessions.createdAt})`;
+  const rows = chatRowSchema.array().parse(
+    await db
+      .select({
+        costUsd: chats.costUsd,
+        createdAt: sql<string>`coalesce(${chats.createdAt}, ${agentSessions.createdAt})`,
+        inputTokens: sql<number>`coalesce(${chats.inputTokens}, 0)`,
+        outputTokens: sql<number>`coalesce(${chats.outputTokens}, 0)`,
+        sessionId: agentSessions.sessionId,
+        title: sql<string>`coalesce(${chats.title}, 'New chat')`,
+        updatedAt,
+      })
+      .from(agentSessions)
+      .leftJoin(chats, eq(chats.sessionId, agentSessions.sessionId))
+      .where(eq(agentSessions.workspaceId, scope.workspaceId))
+      .orderBy(desc(updatedAt))
+  );
   return chatListSchema.parse(rows.map(toChatSummary));
 }
 

--- a/tests/services.test.ts
+++ b/tests/services.test.ts
@@ -50,6 +50,34 @@ describe("database services", () => {
     );
     expect(await sessions.listOwnedSessionIds(bob)).toEqual(new Set());
 
+    await sessions.claimSession(alice, "session-imessage");
+    const unindexedChats = (await chats.listChats(alice)).sort((left, right) =>
+      left.sessionId.localeCompare(right.sessionId)
+    );
+    expect(
+      unindexedChats.map(({ sessionId, title, usage }) => ({
+        sessionId,
+        title,
+        usage,
+      }))
+    ).toEqual([
+      {
+        sessionId: "session-alice",
+        title: "New chat",
+        usage: { costUsd: null, inputTokens: 0, outputTokens: 0 },
+      },
+      {
+        sessionId: "session-imessage",
+        title: "New chat",
+        usage: { costUsd: null, inputTokens: 0, outputTokens: 0 },
+      },
+    ]);
+    expect(
+      unindexedChats.every(
+        (chat) => chat.createdAt.length > 0 && chat.updatedAt.length > 0
+      )
+    ).toBe(true);
+
     await sessions.claimSession(bob, "session-alice");
     expect(await sessions.isSessionOwned(alice, "session-alice")).toBe(true);
     expect(await sessions.isSessionOwned(bob, "session-alice")).toBe(false);
@@ -72,7 +100,14 @@ describe("database services", () => {
       outputTokens: 4,
     });
     expect(await chats.readChat(bob, "session-alice")).toBeUndefined();
-    expect(await chats.listChats(alice)).toEqual([aliceChat]);
+    const indexedChats = await chats.listChats(alice);
+    expect(indexedChats).toHaveLength(2);
+    expect(
+      indexedChats.find((chat) => chat.sessionId === "session-alice")
+    ).toEqual(aliceChat);
+    expect(indexedChats.map((chat) => chat.sessionId)).toContain(
+      "session-imessage"
+    );
     expect(await chats.listChats(bob)).toEqual([]);
 
     await expect(

--- a/tests/session-owner.test.ts
+++ b/tests/session-owner.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { saveChat } from "@/db/services/chats";
+import type { ensureScope } from "@/db/services/scope";
+import type { claimSession } from "@/db/services/sessions";
+
+const mocks = vi.hoisted(() => ({
+  claimSession: vi.fn<typeof claimSession>(),
+  ensureScope: vi.fn<typeof ensureScope>(),
+  saveChat: vi.fn<typeof saveChat>(),
+}));
+
+vi.mock("@/db/services/chats", () => ({ saveChat: mocks.saveChat }));
+vi.mock("@/db/services/scope", () => ({ ensureScope: mocks.ensureScope }));
+vi.mock("@/db/services/sessions", () => ({
+  claimSession: mocks.claimSession,
+}));
+
+import sessionOwner from "../agent/hooks/session-owner";
+
+type MessageReceivedHandler = NonNullable<
+  NonNullable<typeof sessionOwner.events>["message.received"]
+>;
+
+const scope = { userId: "user-1", workspaceId: "workspace-1" };
+const context = {
+  session: {
+    auth: {
+      initiator: {
+        attributes: { workspaceId: scope.workspaceId },
+        principalId: scope.userId,
+      },
+    },
+    id: "session-1",
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("session ownership hook", () => {
+  it("indexes messages received outside the web chat client", async () => {
+    const handler = sessionOwner.events?.["message.received"];
+    expect(handler).toBeDefined();
+
+    // The handler only reads session identity; the event payload and remaining
+    // runtime services are intentionally omitted from this focused unit test.
+    // oxlint-disable typescript/no-unsafe-type-assertion -- The handler only
+    // reads the fields supplied by this focused unit test.
+    const event = {} as Parameters<MessageReceivedHandler>[0];
+    const hookContext =
+      context as unknown as Parameters<MessageReceivedHandler>[1];
+    // oxlint-enable typescript/no-unsafe-type-assertion
+    await handler?.(event, hookContext);
+
+    expect(mocks.saveChat).toHaveBeenCalledWith(scope, {
+      sessionId: "session-1",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- list every workspace-owned Eve session in All Chats, even when it originated from iMessage
- retain existing chat metadata as an optional overlay for titles and usage
- refresh chat recency whenever a top-level session receives a message
- add coverage for unindexed channel sessions and the message hook

## Verification
- `pnpm check`
- `pnpm build`