### PR TITLE
Use generated Google Workspace clients

### DIFF
--- a/agent/lib/google-workspace/calendar.ts
+++ b/agent/lib/google-workspace/calendar.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
+import { calendar, type calendar_v3 } from "@googleapis/calendar";
+import { people } from "@googleapis/people";
 import type { ToolContext } from "eve/tools";
 import { z } from "zod";
-import { googleWorkspaceFetch } from "./client";
+import { googleApiErrorStatus, withGoogleAuth } from "./client";
 
 export const calendarEventSchema = z.object({
   attendees: z.array(z.email()).max(50).default([]),
@@ -14,27 +16,6 @@ export const calendarEventSchema = z.object({
   timezone: z.string().min(1).default("UTC"),
 });
 
-const calendarAvailabilitySchema = z.object({
-  calendars: z
-    .record(
-      z.string(),
-      z.object({
-        busy: z
-          .array(z.object({ end: z.string(), start: z.string() }))
-          .optional(),
-        errors: z
-          .array(
-            z.object({
-              domain: z.string().optional(),
-              reason: z.string().optional(),
-            })
-          )
-          .optional(),
-      })
-    )
-    .optional(),
-});
-
 export async function listCalendarEvents(
   ctx: ToolContext,
   input: {
@@ -44,21 +25,22 @@ export async function listCalendarEvents(
     timeMin: string;
   }
 ) {
-  const params = new URLSearchParams({
-    fields:
-      "items(id,status,summary,description,location,start,end,attendees(email,responseStatus),htmlLink)",
-    maxResults: String(input.maxResults),
-    orderBy: "startTime",
-    singleEvents: "true",
-    timeMax: input.timeMax,
-    timeMin: input.timeMin,
+  return withCalendar(ctx, async (client) => {
+    const { data } = await client.events.list(
+      {
+        calendarId: input.calendarId,
+        fields:
+          "items(id,status,summary,description,location,start,end,attendees(email,responseStatus),htmlLink)",
+        maxResults: input.maxResults,
+        orderBy: "startTime",
+        singleEvents: true,
+        timeMax: input.timeMax,
+        timeMin: input.timeMin,
+      },
+      { signal: ctx.abortSignal }
+    );
+    return { events: data.items ?? [] };
   });
-  const response = await googleWorkspaceFetch(
-    ctx,
-    `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(input.calendarId)}/events?${params}`,
-    z.object({ items: z.array(z.unknown()).optional() })
-  );
-  return { events: response.items ?? [] };
 }
 
 export async function checkCalendarAvailability(
@@ -70,26 +52,26 @@ export async function checkCalendarAvailability(
     timezone: string;
   }
 ) {
-  const response = await googleWorkspaceFetch(
-    ctx,
-    "https://www.googleapis.com/calendar/v3/freeBusy",
-    z.unknown(),
-    {
-      body: JSON.stringify({
-        items: input.calendars.map((id) => ({ id })),
-        timeMax: input.timeMax,
-        timeMin: input.timeMin,
-        timeZone: input.timezone,
-      }),
-      method: "POST",
-    }
-  );
-  return parseCalendarAvailability(response);
+  return withCalendar(ctx, async (client) => {
+    const { data } = await client.freebusy.query(
+      {
+        requestBody: {
+          items: input.calendars.map((id) => ({ id })),
+          timeMax: input.timeMax,
+          timeMin: input.timeMin,
+          timeZone: input.timezone,
+        },
+      },
+      { signal: ctx.abortSignal }
+    );
+    return parseCalendarAvailability(data);
+  });
 }
 
-export function parseCalendarAvailability(value: unknown) {
-  const result = calendarAvailabilitySchema.parse(value);
-  const failures = Object.entries(result.calendars ?? {}).flatMap(
+export function parseCalendarAvailability(
+  value: calendar_v3.Schema$FreeBusyResponse
+) {
+  const failures = Object.entries(value.calendars ?? {}).flatMap(
     ([calendarId, calendar]) =>
       (calendar.errors ?? []).map(
         (error) => `${calendarId}: ${error.reason ?? error.domain ?? "unknown"}`
@@ -100,7 +82,7 @@ export function parseCalendarAvailability(value: unknown) {
       `Google Calendar could not read availability for ${failures.join(", ")}.`
     );
   }
-  return result;
+  return value;
 }
 
 export async function createCalendarEvent(
@@ -111,37 +93,36 @@ export async function createCalendarEvent(
     .update(`${ctx.session.id}:${ctx.callId}`)
     .digest("hex")
     .slice(0, 32);
-  const path = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(payload.calendarId)}/events`;
-  try {
-    return await googleWorkspaceFetch(
-      ctx,
-      `${path}?sendUpdates=${payload.attendees.length ? "all" : "none"}`,
-      z.record(z.string(), z.unknown()),
-      {
-        body: JSON.stringify({
-          attendees: payload.attendees.map((email) => ({ email })),
-          description: payload.description,
-          end: { dateTime: payload.end, timeZone: payload.timezone },
-          id: eventId,
-          location: payload.location,
-          start: { dateTime: payload.start, timeZone: payload.timezone },
-          status: "confirmed",
-          summary: payload.summary,
-          visibility: "private",
-        }),
-        method: "POST",
-      }
-    );
-  } catch (error) {
-    if (!(error instanceof Error) || !error.message.includes("HTTP 409")) {
-      throw error;
+  return withCalendar(ctx, async (client) => {
+    try {
+      const { data } = await client.events.insert(
+        {
+          calendarId: payload.calendarId,
+          requestBody: {
+            attendees: payload.attendees.map((email) => ({ email })),
+            description: payload.description,
+            end: { dateTime: payload.end, timeZone: payload.timezone },
+            id: eventId,
+            location: payload.location,
+            start: { dateTime: payload.start, timeZone: payload.timezone },
+            status: "confirmed",
+            summary: payload.summary,
+            visibility: "private",
+          },
+          sendUpdates: payload.attendees.length ? "all" : "none",
+        },
+        { signal: ctx.abortSignal }
+      );
+      return data;
+    } catch (error) {
+      if (googleApiErrorStatus(error) !== 409) throw error;
+      const { data } = await client.events.get(
+        { calendarId: payload.calendarId, eventId },
+        { signal: ctx.abortSignal }
+      );
+      return data;
     }
-    return googleWorkspaceFetch(
-      ctx,
-      `${path}/${eventId}`,
-      z.record(z.string(), z.unknown())
-    );
-  }
+  });
 }
 
 export async function searchGoogleContacts(
@@ -150,20 +131,23 @@ export async function searchGoogleContacts(
   pageSize: number
 ) {
   const readMask = "names,emailAddresses,phoneNumbers,organizations";
-  await googleWorkspaceFetch(
-    ctx,
-    `https://people.googleapis.com/v1/people:searchContacts?query=&readMask=${readMask}`,
-    z.unknown()
-  );
-  const params = new URLSearchParams({
-    pageSize: String(pageSize),
-    query,
-    readMask,
+  return withGoogleAuth(ctx, async (auth) => {
+    const client = people({ auth, version: "v1" });
+    const options = { signal: ctx.abortSignal };
+    await client.people.searchContacts({ query: "", readMask }, options);
+    const { data } = await client.people.searchContacts(
+      { pageSize, query, readMask },
+      options
+    );
+    return { contacts: data.results ?? [] };
   });
-  const response = await googleWorkspaceFetch(
-    ctx,
-    `https://people.googleapis.com/v1/people:searchContacts?${params}`,
-    z.object({ results: z.array(z.unknown()).optional() })
+}
+
+function withCalendar<T>(
+  ctx: ToolContext,
+  execute: (client: ReturnType<typeof calendar>) => Promise<T>
+) {
+  return withGoogleAuth(ctx, (auth) =>
+    execute(calendar({ auth, version: "v3" }))
   );
-  return { contacts: response.results ?? [] };
 }

--- a/agent/lib/google-workspace/client.ts
+++ b/agent/lib/google-workspace/client.ts
@@ -1,6 +1,6 @@
+import { auth } from "@googleapis/gmail";
 import { connect, type EveAuthorizationOptions } from "@vercel/connect/eve";
 import type { ToolContext } from "eve/tools";
-import type { output, ZodType } from "zod";
 import { env } from "@/lib/env";
 import {
   googleWorkspaceSubject,
@@ -23,66 +23,29 @@ export const googleWorkspaceAuthOptions = {
 
 const googleWorkspaceAuth = connect(googleWorkspaceAuthOptions);
 
-export async function googleWorkspaceFetch<TSchema extends ZodType>(
+export async function withGoogleAuth<T>(
   ctx: ToolContext,
-  url: string,
-  schema: TSchema,
-  init: RequestInit = {}
-): Promise<output<TSchema>> {
+  execute: (authClient: InstanceType<typeof auth.OAuth2>) => Promise<T>
+) {
   const { token } = await ctx.getToken(googleWorkspaceAuth);
-  const headers = new Headers(init.headers);
-  headers.set("accept", "application/json");
-  headers.set("authorization", `Bearer ${token}`);
-  if (init.body && !headers.has("content-type")) {
-    headers.set("content-type", "application/json");
-  }
-  const response = await fetch(url, {
-    ...init,
-    headers,
-    signal: ctx.abortSignal,
-  });
+  const authClient = new auth.OAuth2();
+  authClient.setCredentials({ access_token: token });
 
-  if (response.status === 401) ctx.requireAuth(googleWorkspaceAuth);
-  if (!response.ok) {
-    const detail = await response.text().catch(() => "");
-    throw new Error(
-      `Google Workspace returned HTTP ${String(response.status)}: ${detail.slice(0, 500)}`
-    );
+  try {
+    return await execute(authClient);
+  } catch (error) {
+    if (googleApiErrorStatus(error) === 401) {
+      ctx.requireAuth(googleWorkspaceAuth);
+    }
+    throw error;
   }
-  const body: unknown =
-    response.status === 204 ? undefined : await response.json();
-  return schema.parse(body);
 }
 
-export function decodeBase64Url(value: string) {
-  return Buffer.from(
-    value.replace(/-/gu, "+").replace(/_/gu, "/"),
-    "base64"
-  ).toString("utf8");
-}
-
-export function encodeBase64Url(value: string) {
-  return Buffer.from(value, "utf8").toString("base64url");
-}
-
-const secretPatterns: readonly (readonly [RegExp, string])[] = [
-  [/\b\d{6}\b/gu, "[six-digit code redacted]"],
-  [/\bsk-(?:proj-)?[A-Za-z0-9_-]{12,}\b/gu, "[api key redacted]"],
-  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/gu, "[github token redacted]"],
-  [/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/gu, "[aws key redacted]"],
-  [/\bAIza[A-Za-z0-9_-]{30,}\b/gu, "[google api key redacted]"],
-  [/\b(?:bearer\s+)[A-Za-z0-9._~+/-]+=*\b/giu, "Bearer [token redacted]"],
-  [
-    /\b(password|passcode|api[_ -]?key|access[_ -]?token|refresh[_ -]?token|client[_ -]?secret)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/giu,
-    "$1=[credential redacted]",
-  ],
-  [/\b(?:\d[ -]*?){13,19}\b/gu, "[payment number redacted]"],
-];
-
-export function redactGoogleText(value: string, maxLength = 12_000) {
-  let redacted = value.slice(0, maxLength);
-  for (const [pattern, replacement] of secretPatterns) {
-    redacted = redacted.replace(pattern, replacement);
+export function googleApiErrorStatus(error: unknown) {
+  if (!error || typeof error !== "object" || !("response" in error)) return;
+  const { response } = error;
+  if (!response || typeof response !== "object" || !("status" in response)) {
+    return;
   }
-  return redacted;
+  return typeof response.status === "number" ? response.status : undefined;
 }

--- a/agent/lib/google-workspace/gmail.ts
+++ b/agent/lib/google-workspace/gmail.ts
@@ -1,53 +1,11 @@
 import { createHash } from "node:crypto";
+import { gmail, type gmail_v1 } from "@googleapis/gmail";
 import type { ToolContext } from "eve/tools";
 import { z } from "zod";
-import {
-  decodeBase64Url,
-  encodeBase64Url,
-  googleWorkspaceFetch,
-  redactGoogleText,
-} from "./client";
+import { withGoogleAuth } from "./client";
 
-const gmailPartSchema = z.object({
-  body: z
-    .object({
-      attachmentId: z.string().optional(),
-      data: z.string().optional(),
-      size: z.number().optional(),
-    })
-    .optional(),
-  filename: z.string().optional(),
-  headers: z
-    .array(
-      z.object({
-        name: z.string().optional(),
-        value: z.string().optional(),
-      })
-    )
-    .optional(),
-  mimeType: z.string().optional(),
-  parts: z.array(z.unknown()).optional(),
-});
-
-const gmailMessageSchema = z.object({
-  id: z.string().optional(),
-  labelIds: z.array(z.string()).optional(),
-  payload: gmailPartSchema.optional(),
-  snippet: z.string().optional(),
-  threadId: z.string().optional(),
-});
-
-const gmailListSchema = z.object({
-  messages: z.array(z.object({ id: z.string() })).optional(),
-});
-
-const gmailThreadSchema = z.object({
-  id: z.string().optional(),
-  messages: z.array(gmailMessageSchema).optional(),
-});
-
-type GmailMessage = z.infer<typeof gmailMessageSchema>;
-type GmailPart = z.infer<typeof gmailPartSchema>;
+type GmailMessage = gmail_v1.Schema$Message;
+type GmailPart = gmail_v1.Schema$MessagePart;
 
 export const GMAIL_UPDATE_ACTIONS = [
   "archive",
@@ -75,37 +33,53 @@ export async function searchGmail(
   query: string,
   maxResults: number
 ) {
-  const listed = await googleWorkspaceFetch(
-    ctx,
-    `https://gmail.googleapis.com/gmail/v1/users/me/messages?q=${encodeURIComponent(query)}&maxResults=${String(maxResults)}`,
-    gmailListSchema
-  );
-  const messages = await Promise.all(
-    (listed.messages ?? []).map(({ id }) =>
-      googleWorkspaceFetch(
-        ctx,
-        `https://gmail.googleapis.com/gmail/v1/users/me/messages/${encodeURIComponent(id)}?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Subject&metadataHeaders=Date&metadataHeaders=Message-ID`,
-        gmailMessageSchema
+  return withGmail(ctx, async (client) => {
+    const listed = await client.users.messages.list(
+      { maxResults, q: query, userId: "me" },
+      { signal: ctx.abortSignal }
+    );
+    const messages = await Promise.all(
+      (listed.data.messages ?? []).flatMap(({ id }) =>
+        id
+          ? [
+              client.users.messages.get(
+                {
+                  format: "metadata",
+                  id,
+                  metadataHeaders: [
+                    "From",
+                    "To",
+                    "Subject",
+                    "Date",
+                    "Message-ID",
+                  ],
+                  userId: "me",
+                },
+                { signal: ctx.abortSignal }
+              ),
+            ]
+          : []
       )
-    )
-  );
-  return messages.map(minimizeMessage);
+    );
+    return messages.map(({ data }) => minimizeMessage(data));
+  });
 }
 
 export async function readGmailThread(ctx: ToolContext, threadId: string) {
-  const thread = await googleWorkspaceFetch(
-    ctx,
-    `https://gmail.googleapis.com/gmail/v1/users/me/threads/${encodeURIComponent(threadId)}?format=full`,
-    gmailThreadSchema
-  );
-  return {
-    id: thread.id ?? threadId,
-    messages: (thread.messages ?? []).slice(-20).map((message) => ({
-      ...minimizeMessage(message),
-      attachments: collectAttachments(message.payload),
-      body: redactGoogleText(plainText(message.payload)),
-    })),
-  };
+  return withGmail(ctx, async (client) => {
+    const { data: thread } = await client.users.threads.get(
+      { format: "full", id: threadId, userId: "me" },
+      { signal: ctx.abortSignal }
+    );
+    return {
+      id: thread.id ?? threadId,
+      messages: (thread.messages ?? []).slice(-20).map((message) => ({
+        ...minimizeMessage(message),
+        attachments: collectAttachments(message.payload),
+        body: redactGoogleText(plainText(message.payload)),
+      })),
+    };
+  });
 }
 
 export async function updateGmail(
@@ -114,14 +88,14 @@ export async function updateGmail(
   action: GmailUpdateAction
 ) {
   const ids = [...new Set(messageIds)];
-  await googleWorkspaceFetch(
-    ctx,
-    "https://gmail.googleapis.com/gmail/v1/users/me/messages/batchModify",
-    z.void(),
-    {
-      body: JSON.stringify({ ids, ...gmailUpdateLabels(action) }),
-      method: "POST",
-    }
+  await withGmail(ctx, async (client) =>
+    client.users.messages.batchModify(
+      {
+        requestBody: { ids, ...gmailUpdateLabels(action) },
+        userId: "me",
+      },
+      { signal: ctx.abortSignal }
+    )
   );
   return { action, updatedCount: ids.length };
 }
@@ -154,19 +128,23 @@ export async function sendGmail(
     'Content-Type: text/plain; charset="UTF-8"',
     "Content-Transfer-Encoding: 8bit",
   ];
-  const raw = encodeBase64Url(`${headers.join("\r\n")}\r\n\r\n${payload.body}`);
-  return googleWorkspaceFetch(
-    ctx,
-    "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
-    z.object({ id: z.string(), threadId: z.string() }),
-    {
-      body: JSON.stringify({
-        raw,
-        ...(payload.threadId ? { threadId: payload.threadId } : {}),
-      }),
-      method: "POST",
-    }
-  );
+  const raw = Buffer.from(
+    `${headers.join("\r\n")}\r\n\r\n${payload.body}`,
+    "utf8"
+  ).toString("base64url");
+  return withGmail(ctx, async (client) => {
+    const { data } = await client.users.messages.send(
+      {
+        requestBody: {
+          raw,
+          ...(payload.threadId ? { threadId: payload.threadId } : {}),
+        },
+        userId: "me",
+      },
+      { signal: ctx.abortSignal }
+    );
+    return data;
+  });
 }
 
 export function gmailUpdateLabels(action: GmailUpdateAction) {
@@ -200,8 +178,7 @@ function plainText(part: GmailPart | undefined): string {
     return decodeBase64Url(part.body.data);
   }
   for (const child of part.parts ?? []) {
-    const parsed = gmailPartSchema.safeParse(child);
-    const text = parsed.success ? plainText(parsed.data) : "";
+    const text = plainText(child);
     if (text) return text;
   }
   if (part.mimeType === "text/html" && part.body?.data) {
@@ -243,12 +220,44 @@ function collectAttachments(part: GmailPart | undefined): {
         ]
       : [];
   const nested = (part.parts ?? []).flatMap((child) => {
-    const parsed = gmailPartSchema.safeParse(child);
-    return parsed.success ? collectAttachments(parsed.data) : [];
+    return collectAttachments(child);
   });
   return [...own, ...nested];
 }
 
 function safeHeader(value: string) {
   return value.replace(/[\r\n]+/gu, " ").trim();
+}
+
+function withGmail<T>(
+  ctx: ToolContext,
+  execute: (client: ReturnType<typeof gmail>) => Promise<T>
+) {
+  return withGoogleAuth(ctx, (auth) => execute(gmail({ auth, version: "v1" })));
+}
+
+function decodeBase64Url(value: string) {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+const secretPatterns: readonly (readonly [RegExp, string])[] = [
+  [/\b\d{6}\b/gu, "[six-digit code redacted]"],
+  [/\bsk-(?:proj-)?[A-Za-z0-9_-]{12,}\b/gu, "[api key redacted]"],
+  [/\bgh[pousr]_[A-Za-z0-9]{20,}\b/gu, "[github token redacted]"],
+  [/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/gu, "[aws key redacted]"],
+  [/\bAIza[A-Za-z0-9_-]{30,}\b/gu, "[google api key redacted]"],
+  [/\b(?:bearer\s+)[A-Za-z0-9._~+/-]+=*\b/giu, "Bearer [token redacted]"],
+  [
+    /\b(password|passcode|api[_ -]?key|access[_ -]?token|refresh[_ -]?token|client[_ -]?secret)\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)/giu,
+    "$1=[credential redacted]",
+  ],
+  [/\b(?:\d[ -]*?){13,19}\b/gu, "[payment number redacted]"],
+];
+
+function redactGoogleText(value: string, maxLength = 12_000) {
+  let redacted = value.slice(0, maxLength);
+  for (const [pattern, replacement] of secretPatterns) {
+    redacted = redacted.replace(pattern, replacement);
+  }
+  return redacted;
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "license": "MIT",
   "dependencies": {
     "@base-ui/react": "^1.7.0",
+    "@googleapis/calendar": "^16.0.0",
+    "@googleapis/gmail": "^18.0.0",
+    "@googleapis/people": "^8.0.0",
     "@onkernel/eve-extension": "^0.1.4",
     "@onkernel/sdk": "^0.96.0",
     "@opentelemetry/api": "^1.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@base-ui/react':
         specifier: ^1.7.0
         version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@googleapis/calendar':
+        specifier: ^16.0.0
+        version: 16.0.0
+      '@googleapis/gmail':
+        specifier: ^18.0.0
+        version: 18.0.0
+      '@googleapis/people':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@onkernel/eve-extension':
         specifier: ^0.1.4
         version: 0.1.4(c8ba74d3560b66367327a185277b6d95)
@@ -1048,6 +1057,18 @@ packages:
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
+  '@googleapis/calendar@16.0.0':
+    resolution: {integrity: sha512-Z/8Jdf4hMvmMlBMhP0whZNPSixEpYv4mC5RJfrlvrnqpf/rV68MJ+8M9MmyqUt7/SQp2zRfVmEqkk+csB2Cgmg==}
+    engines: {node: '>=12.0.0'}
+
+  '@googleapis/gmail@18.0.0':
+    resolution: {integrity: sha512-qC8CaF3mgi8ZMm7IYK1Pk6AF3z2v1IE++8rtn+Mmpx+zIhbS9MMazY7+WicwgLKKskn5zQLXCoNv0Jn7OdFfPg==}
+    engines: {node: '>=12.0.0'}
+
+  '@googleapis/people@8.0.0':
+    resolution: {integrity: sha512-YGdkT345sCCGhPYbwaM9D9lBsuWqzLs2EIba1DU0lpKPjNTrpT5amWCA0V781pgBtmhuygGZA1pz6MdUyzwQuw==}
+    engines: {node: '>=12.0.0'}
+
   '@henrygd/queue@1.2.0':
     resolution: {integrity: sha512-jW/BLSTpcvExDhqJGxtIPgGr2O0IFF8XUNDwEbfCfhrXT8a4xztQ9Lv6U/vbYzYC0xVWn+3zv6YnLUh3bEFUKA==}
 
@@ -1252,6 +1273,10 @@ packages:
   '@isaacs/brace-expansion@5.0.1':
     resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -2239,6 +2264,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -3409,6 +3438,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -3476,6 +3509,9 @@ packages:
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.11.19:
     resolution: {integrity: sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==}
@@ -3552,6 +3588,9 @@ packages:
       zod:
         optional: true
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -3565,6 +3604,9 @@ packages:
 
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -3581,6 +3623,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -3986,6 +4031,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   dayjs@1.11.23:
     resolution: {integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==}
 
@@ -4251,6 +4300,12 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   edge-runtime@2.5.9:
     resolution: {integrity: sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==}
     engines: {node: '>=16'}
@@ -4267,6 +4322,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -4559,6 +4617,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -4597,10 +4659,18 @@ packages:
   flatted@3.4.4:
     resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
     engines: {node: '>=18.3.0'}
     hasBin: true
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -4646,6 +4716,14 @@ packages:
 
   fzf@0.5.2:
     resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
+
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.4:
+    resolution: {integrity: sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==}
+    engines: {node: '>=18'}
 
   generic-pool@3.4.2:
     resolution: {integrity: sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag==}
@@ -4713,9 +4791,26 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  googleapis-common@8.0.3:
+    resolution: {integrity: sha512-7g1yzQKx0mmNTjiK0H9dJ8eqKqDBveES9vLHeg5neb3BMQy/d1oQefIMhIpOVT8a+f+LOcixMEdRbFIW/cQUJw==}
+    engines: {node: '>=18'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -4723,6 +4818,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   h3@2.0.1-rc.22:
     resolution: {integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==}
@@ -5001,6 +5100,9 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -5035,6 +5137,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -5076,6 +5181,12 @@ packages:
 
   jsonlines@0.1.1:
     resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
@@ -5298,6 +5409,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
@@ -5597,6 +5711,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -5726,6 +5844,11 @@ packages:
       zephyr-agent:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -5755,6 +5878,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build-optional-packages@5.1.1:
     resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
@@ -5939,6 +6066,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
@@ -5989,6 +6119,10 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -6340,6 +6474,10 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
@@ -6375,6 +6513,9 @@ packages:
 
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -6569,6 +6710,10 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -7000,6 +7145,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -7158,6 +7306,10 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   web-vitals@0.2.4:
     resolution: {integrity: sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==}
 
@@ -7192,6 +7344,10 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -8009,6 +8165,24 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
+  '@googleapis/calendar@16.0.0':
+    dependencies:
+      googleapis-common: 8.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@googleapis/gmail@18.0.0':
+    dependencies:
+      googleapis-common: 8.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@googleapis/people@8.0.0':
+    dependencies:
+      googleapis-common: 8.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@henrygd/queue@1.2.0': {}
 
   '@hono/node-server@2.1.1(hono@4.13.5)':
@@ -8151,6 +8325,15 @@ snapshots:
   '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -8728,6 +8911,9 @@ snapshots:
     optional: true
 
   '@oxlint/binding-win32-x64-msvc@1.80.0':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@quansync/fs@1.0.0':
@@ -9975,6 +10161,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   any-promise@1.3.0: {}
 
   arg@4.1.0: {}
@@ -10014,6 +10202,8 @@ snapshots:
   balanced-match@4.0.4: {}
 
   bare-events@2.9.2: {}
+
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.11.19: {}
 
@@ -10057,6 +10247,8 @@ snapshots:
     optionalDependencies:
       zod: 4.4.3
 
+  bignumber.js@9.3.1: {}
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -10082,6 +10274,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
@@ -10099,6 +10295,8 @@ snapshots:
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
   buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -10508,6 +10706,8 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-uri-to-buffer@4.0.1: {}
+
   dayjs@1.11.23: {}
 
   db0@0.3.4(@electric-sql/pglite@0.5.8)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.23.1)(kysely@0.29.5)(pg@8.23.0)):
@@ -10646,6 +10846,12 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   edge-runtime@2.5.9:
     dependencies:
       '@edge-runtime/format': 2.2.1
@@ -10665,6 +10871,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -11095,6 +11303,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.7
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -11138,9 +11351,18 @@ snapshots:
 
   flatted@3.4.4: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   formatly@0.3.0:
     dependencies:
       fd-package-json: 2.0.0
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -11181,6 +11403,23 @@ snapshots:
   fuzzysort@3.1.0: {}
 
   fzf@0.5.2: {}
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.4:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generic-pool@3.4.2: {}
 
@@ -11243,15 +11482,56 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.6
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  google-auth-library@10.5.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.3
+      gcp-metadata: 8.1.4
+      google-logging-utils: 1.1.3
+      gtoken: 8.0.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  googleapis-common@8.0.3:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.3
+      google-auth-library: 10.5.0
+      google-logging-utils: 1.1.3
+      qs: 6.15.3
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   h3@2.0.1-rc.22(crossws@0.4.12(srvx@0.11.22)):
     dependencies:
@@ -11554,6 +11834,12 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@2.7.0: {}
 
   jose@5.10.0: {}
@@ -11577,6 +11863,10 @@ snapshots:
       argparse: 2.0.1
 
   jsesc@3.1.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -11610,6 +11900,17 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonlines@0.1.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   katex@0.16.47:
     dependencies:
@@ -11785,6 +12086,8 @@ snapshots:
       is-unicode-supported: 1.3.0
 
   longest-streak@3.1.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.5.2: {}
 
@@ -12320,6 +12623,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.18
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -12454,6 +12761,8 @@ snapshots:
       - uploadthing
       - wrangler
 
+  node-domexception@1.0.0: {}
+
   node-fetch-native@1.6.7: {}
 
   node-fetch@2.6.7:
@@ -12467,6 +12776,12 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build-optional-packages@5.1.1:
     dependencies:
@@ -12775,6 +13090,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@1.8.0: {}
 
   parent-module@1.0.1:
@@ -12819,6 +13136,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -13185,6 +13507,10 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
+
   robust-predicates@3.0.3: {}
 
   rolldown@1.0.0-rc.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3):
@@ -13258,6 +13584,8 @@ snapshots:
       queue-microtask: 1.2.3
 
   rw@1.3.3: {}
+
+  safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
@@ -13538,6 +13866,12 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -13903,6 +14237,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-template@2.0.8: {}
+
   use-callback-ref@1.3.3(@types/react@19.2.18)(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -14056,6 +14392,8 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  web-streams-polyfill@3.3.3: {}
+
   web-vitals@0.2.4: {}
 
   webidl-conversions@3.0.1: {}
@@ -14087,6 +14425,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/tests/google-workspace-generated-clients.test.ts
+++ b/tests/google-workspace-generated-clients.test.ts
@@ -1,0 +1,209 @@
+import { createHash } from "node:crypto";
+import type { ToolContext } from "eve/tools";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createCalendarEvent,
+  searchGoogleContacts,
+} from "@/agent/lib/google-workspace/calendar";
+import { withGoogleAuth } from "@/agent/lib/google-workspace/client";
+import { sendGmail } from "@/agent/lib/google-workspace/gmail";
+
+interface RequestOptions {
+  signal: AbortSignal;
+}
+
+const google = vi.hoisted(() => ({
+  calendar: vi.fn<(options: unknown) => unknown>(),
+  gmail: vi.fn<(options: unknown) => unknown>(),
+  people: vi.fn<(options: unknown) => unknown>(),
+  setCredentials: vi.fn<(credentials: { access_token: string }) => void>(),
+}));
+
+vi.mock("@googleapis/calendar", () => ({ calendar: google.calendar }));
+vi.mock("@googleapis/gmail", () => ({
+  auth: {
+    OAuth2: class {
+      setCredentials = google.setCredentials;
+    },
+  },
+  gmail: google.gmail,
+}));
+vi.mock("@googleapis/people", () => ({ people: google.people }));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("generated Google Workspace clients", () => {
+  it("hands the Connect token to Google and requests reauthorization on 401", async () => {
+    const ctx = toolContext();
+    const error = new GoogleApiError(401);
+
+    await expect(withGoogleAuth(ctx, () => Promise.reject(error))).rejects.toBe(
+      error
+    );
+
+    expect(ctx.getToken).toHaveBeenCalledOnce();
+    expect(google.setCredentials).toHaveBeenCalledWith({
+      access_token: "google-access-token",
+    });
+    expect(ctx.requireAuth).toHaveBeenCalledOnce();
+  });
+
+  it("sends typed Gmail requests with a stable retry-safe message ID", async () => {
+    const ctx = toolContext();
+    const send = vi
+      .fn<
+        (
+          request: unknown,
+          options: RequestOptions
+        ) => Promise<{ data: { id: string; threadId: string } }>
+      >()
+      .mockResolvedValue({
+        data: { id: "sent-1", threadId: "thread-1" },
+      });
+    googleClients({ gmail: { users: { messages: { send } } } });
+
+    await sendGmail(ctx, {
+      bcc: [],
+      body: "Hello",
+      cc: [],
+      subject: "Status",
+      to: ["person@example.com"],
+    });
+
+    const stableId = createHash("sha256")
+      .update("session-1:call-1")
+      .digest("hex")
+      .slice(0, 48);
+    const raw = Buffer.from(
+      [
+        "To: person@example.com",
+        "Subject: Status",
+        `Message-ID: <openinstinct-${stableId}@local>`,
+        "MIME-Version: 1.0",
+        'Content-Type: text/plain; charset="UTF-8"',
+        "Content-Transfer-Encoding: 8bit",
+      ].join("\r\n") + "\r\n\r\nHello",
+      "utf8"
+    ).toString("base64url");
+    expect(send).toHaveBeenCalledWith(
+      { requestBody: { raw }, userId: "me" },
+      { signal: ctx.abortSignal }
+    );
+  });
+
+  it("recovers a duplicate Calendar insert using the stable event ID", async () => {
+    const ctx = toolContext();
+    const insert = vi
+      .fn<(request: unknown, options: RequestOptions) => Promise<never>>()
+      .mockRejectedValue(new GoogleApiError(409));
+    const get = vi
+      .fn<
+        (
+          request: { calendarId: string; eventId: string },
+          options: RequestOptions
+        ) => Promise<{ data: { id: string; summary: string } }>
+      >()
+      .mockResolvedValue({
+        data: { id: "existing-event", summary: "Planning" },
+      });
+    googleClients({ calendar: { events: { get, insert } } });
+
+    await expect(
+      createCalendarEvent(ctx, {
+        attendees: ["person@example.com"],
+        calendarId: "primary",
+        end: "2026-08-28T11:00:00-04:00",
+        start: "2026-08-28T10:00:00-04:00",
+        summary: "Planning",
+        timezone: "America/New_York",
+      })
+    ).resolves.toEqual({ id: "existing-event", summary: "Planning" });
+
+    const eventId = createHash("sha256")
+      .update("session-1:call-1")
+      .digest("hex")
+      .slice(0, 32);
+    expect(insert.mock.calls[0]?.[1]).toEqual({ signal: ctx.abortSignal });
+    expect(get).toHaveBeenCalledWith(
+      { calendarId: "primary", eventId },
+      { signal: ctx.abortSignal }
+    );
+  });
+
+  it("warms the People search cache before the typed contact query", async () => {
+    const ctx = toolContext();
+    const searchContacts = vi
+      .fn<
+        (
+          request: unknown,
+          options: RequestOptions
+        ) => Promise<{
+          data: { results?: { person: { resourceName: string } }[] };
+        }>
+      >()
+      .mockResolvedValueOnce({ data: {} })
+      .mockResolvedValueOnce({
+        data: { results: [{ person: { resourceName: "people/1" } }] },
+      });
+    googleClients({ people: { people: { searchContacts } } });
+
+    await expect(searchGoogleContacts(ctx, "Person", 10)).resolves.toEqual({
+      contacts: [{ person: { resourceName: "people/1" } }],
+    });
+
+    expect(searchContacts).toHaveBeenNthCalledWith(
+      1,
+      {
+        query: "",
+        readMask: "names,emailAddresses,phoneNumbers,organizations",
+      },
+      { signal: ctx.abortSignal }
+    );
+    expect(searchContacts).toHaveBeenNthCalledWith(
+      2,
+      {
+        pageSize: 10,
+        query: "Person",
+        readMask: "names,emailAddresses,phoneNumbers,organizations",
+      },
+      { signal: ctx.abortSignal }
+    );
+  });
+});
+
+function toolContext() {
+  const getToken = vi
+    .fn<ToolContext["getToken"]>()
+    .mockResolvedValue({ token: "google-access-token" });
+  const requireAuth = vi.fn<ToolContext["requireAuth"]>();
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- The fixture supplies exactly the ToolContext fields exercised by these helpers.
+  return {
+    abortSignal: new AbortController().signal,
+    callId: "call-1",
+    getToken,
+    requireAuth,
+    session: { id: "session-1" },
+  } as unknown as ToolContext & {
+    getToken: typeof getToken;
+    requireAuth: typeof requireAuth;
+  };
+}
+
+function googleClients(clients: {
+  calendar?: unknown;
+  gmail?: unknown;
+  people?: unknown;
+}) {
+  google.calendar.mockReturnValue(clients.calendar ?? {});
+  google.gmail.mockReturnValue(clients.gmail ?? {});
+  google.people.mockReturnValue(clients.people ?? {});
+}
+
+class GoogleApiError extends Error {
+  readonly response: { status: number };
+
+  constructor(status: number) {
+    super(`Google API returned ${String(status)}`);
+    this.response = { status };
+  }
+}


### PR DESCRIPTION
## Summary

- replace handwritten Gmail, Calendar, and People routes and response schemas with the official service-specific Google clients
- keep Vercel Connect as the narrow per-user auth and reauthorization boundary
- preserve MIME handling, redaction, cancellation, approval behavior, and retry-safe Gmail and Calendar identifiers
- add focused coverage for token handoff, 401 reauthorization, Gmail send identity, Calendar conflict recovery, and People search warmup

## Validation

- `pnpm check` — passed (6 tasks, 26 test files, 102 tests)
- focused Google Workspace tests — passed (12 tests)
- `git diff --check` — passed
- `pnpm build` — extension build and Next compilation/type checking passed; page-data collection is blocked locally because `DATABASE_URL`, `KERNEL_API_KEY`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, and `SECRET_ENCRYPTION_KEY` are not available in this worktree environment