### PR TITLE
Add subagent activity panel

### DIFF
--- a/app/_components/agent-chat.tsx
+++ b/app/_components/agent-chat.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import type { UserContent } from "ai";
-import { AlertCircleIcon, BrainIcon, PlusIcon } from "lucide-react";
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { AlertCircleIcon, BrainIcon } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -19,15 +19,14 @@ import {
   PromptInputTools,
 } from "@/components/ai-elements/prompt-input";
 import { Shimmer } from "@/components/ai-elements/shimmer";
-import { Button } from "@/components/ui/button";
-import { ButtonGroup } from "@/components/ui/button-group";
-import { formatChatUsage, summarizeChatUsage } from "@/app/_lib/chat-usage";
+import { summarizeChatUsage } from "@/app/_lib/chat-usage";
 import { getLatestTurnFailure } from "@/app/_lib/turn-failure";
 import { useDurableEveSession } from "@/app/_hooks/use-durable-eve-session";
 import type { ChatUsage } from "@/lib/chat";
 import { cn } from "@/lib/utils";
 import { AgentMessage } from "./agent-message";
-import { SubagentTrace } from "./subagent-trace";
+import { collectSubagentSessions } from "@/app/_lib/subagent-sessions";
+import { SubagentPanel } from "./subagent-panel";
 
 const AGENT_NAME = "Local Vault Assistant";
 
@@ -41,7 +40,7 @@ export function AgentChat({
   readonly sessionless?: boolean;
 }) {
   const [cancellationError, setCancellationError] = useState<string>();
-  const [traceView, setTraceView] = useState<"imessage" | "trace">("trace");
+  const [traceView, setTraceView] = useState<"imessage" | "trace">("imessage");
   const pendingChatTitle = useRef<string | undefined>(undefined);
   const agent = useDurableEveSession({
     initialSession:
@@ -146,19 +145,10 @@ export function AgentChat({
 
     return deliveriesByMessage;
   }, [agent.events]);
-  const subagentTraces = useMemo(() => {
-    const traces = new Map<string, ReactNode>();
-
-    for (const event of agent.events) {
-      if (event.type !== "subagent.called") continue;
-      traces.set(
-        event.data.callId,
-        <SubagentTrace key={event.data.childSessionId} target={event.data} />
-      );
-    }
-
-    return traces;
-  }, [agent.events]);
+  const subagentSessions = useMemo(
+    () => collectSubagentSessions(agent.events),
+    [agent.events]
+  );
 
   useEffect(() => {
     if (activeSessionId === undefined || latestTerminalTurnAt === undefined) {
@@ -231,80 +221,76 @@ export function AgentChat({
   );
 
   return (
-    <main className="relative flex h-full min-h-0 flex-col overflow-hidden bg-background text-foreground">
-      {showConversationLayout ? (
-        <ChatHeader
-          canStartNewChat={activeSessionId !== undefined}
-          onTraceViewChange={setTraceView}
-          traceView={traceView}
-          usage={usage}
-        />
-      ) : null}
+    <div className="relative flex h-full min-h-0 overflow-hidden bg-background text-foreground">
+      <main className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+        {showConversationLayout ? (
+          <Conversation
+            className="min-h-0 flex-1"
+            initial={sessionId === undefined ? undefined : false}
+            resize={activeSessionId === undefined ? "smooth" : "instant"}
+            scrollRestorationKey={
+              isEmpty || activeSessionId === undefined
+                ? undefined
+                : `eve:web-chat-scroll:${activeSessionId}`
+            }
+          >
+            <ConversationContent className="mx-auto w-full max-w-3xl gap-6 px-4 pt-6 pb-36 sm:px-6">
+              {agent.data.messages.map((message, index) =>
+                showPendingThinking &&
+                isPendingAssistantShell &&
+                message.id === lastMessage.id ? null : (
+                  <AgentMessage
+                    canRespond={!isBusy && !isRestoring}
+                    deliveredAssistantMessages={deliveredAssistantMessages.get(
+                      message.id
+                    )}
+                    isStreaming={
+                      agent.status === "streaming" &&
+                      index === agent.data.messages.length - 1
+                    }
+                    key={message.id}
+                    message={message}
+                    onInputResponses={(inputResponses) => {
+                      setCancellationError(undefined);
+                      return agent.respond(inputResponses);
+                    }}
+                    timestamp={messageTimestamps.get(message.id)}
+                    userVisibleOnly={traceView === "imessage"}
+                  />
+                )
+              )}
+              {showPendingThinking ? <PendingThinking /> : null}
+              {errorMessage ? <ErrorMessage message={errorMessage} /> : null}
+            </ConversationContent>
+            <ConversationScrollButton />
+          </Conversation>
+        ) : null}
 
-      {showConversationLayout ? (
-        <Conversation
-          className="min-h-0 flex-1"
-          initial={sessionId === undefined ? undefined : false}
-          resize={activeSessionId === undefined ? "smooth" : "instant"}
-          scrollRestorationKey={
-            isEmpty || activeSessionId === undefined
-              ? undefined
-              : `eve:web-chat-scroll:${activeSessionId}`
-          }
+        <div
+          className={cn(
+            "mx-auto w-full px-4 sm:px-6",
+            showConversationLayout
+              ? "absolute bottom-0 left-1/2 z-20 max-w-3xl -translate-x-1/2 bg-gradient-to-t from-background via-background to-transparent pt-4 pb-6"
+              : "flex max-w-xl flex-1 flex-col items-center justify-center gap-8 pb-[10vh]"
+          )}
         >
-          <ConversationContent className="mx-auto w-full max-w-3xl gap-6 px-4 pt-20 pb-36 sm:px-6">
-            {agent.data.messages.map((message, index) =>
-              showPendingThinking &&
-              isPendingAssistantShell &&
-              message.id === lastMessage.id ? null : (
-                <AgentMessage
-                  afterToolCalls={
-                    traceView === "trace" ? subagentTraces : undefined
-                  }
-                  canRespond={!isBusy && !isRestoring}
-                  deliveredAssistantMessages={deliveredAssistantMessages.get(
-                    message.id
-                  )}
-                  isStreaming={
-                    agent.status === "streaming" &&
-                    index === agent.data.messages.length - 1
-                  }
-                  key={message.id}
-                  message={message}
-                  onInputResponses={(inputResponses) => {
-                    setCancellationError(undefined);
-                    return agent.respond(inputResponses);
-                  }}
-                  timestamp={messageTimestamps.get(message.id)}
-                  userVisibleOnly={traceView === "imessage"}
-                />
-              )
-            )}
-            {showPendingThinking ? <PendingThinking /> : null}
-            {errorMessage ? <ErrorMessage message={errorMessage} /> : null}
-          </ConversationContent>
-          <ConversationScrollButton />
-        </Conversation>
-      ) : null}
-
-      <div
-        className={cn(
-          "mx-auto w-full px-4 sm:px-6",
-          showConversationLayout
-            ? "absolute bottom-0 left-1/2 z-20 max-w-3xl -translate-x-1/2 bg-gradient-to-t from-background via-background to-transparent pt-4 pb-6"
-            : "flex max-w-xl flex-1 flex-col items-center justify-center gap-8 pb-[10vh]"
-        )}
-      >
-        {showConversationLayout ? null : (
-          <div className="flex flex-col items-start gap-3">
-            <h1 className="text-5xl font-medium tracking-tighter">
-              {AGENT_NAME}
-            </h1>
-          </div>
-        )}
-        <div className="w-full">{composer}</div>
-      </div>
-    </main>
+          {showConversationLayout ? null : (
+            <div className="flex flex-col items-start gap-3">
+              <h1 className="text-5xl font-medium tracking-tighter">
+                {AGENT_NAME}
+              </h1>
+            </div>
+          )}
+          <div className="w-full">{composer}</div>
+        </div>
+      </main>
+      <SubagentPanel
+        onTraceViewChange={setTraceView}
+        sessions={subagentSessions}
+        traceView={traceView}
+        usage={usage}
+      />
+    </div>
   );
 }
 
@@ -324,67 +310,6 @@ function ErrorMessage({ message }: { readonly message: string }) {
         </div>
       </MessageContent>
     </Message>
-  );
-}
-
-function ChatHeader({
-  canStartNewChat,
-  onTraceViewChange,
-  traceView,
-  usage,
-}: {
-  readonly canStartNewChat: boolean;
-  readonly onTraceViewChange: (view: "imessage" | "trace") => void;
-  readonly traceView: "imessage" | "trace";
-  readonly usage: ChatUsage;
-}) {
-  return (
-    <header className="pointer-events-none absolute top-0 right-0 left-0 z-20 h-14">
-      <div className="relative mx-auto flex h-full w-full max-w-3xl items-center justify-start bg-background px-4">
-        <div className="min-w-0">
-          <span className="block truncate text-sm text-muted-foreground">
-            {AGENT_NAME}
-          </span>
-          <span className="block type-label text-muted-foreground">
-            Usage {formatChatUsage(usage)}
-          </span>
-        </div>
-        <div className="pointer-events-auto ml-auto flex items-center gap-2">
-          <ButtonGroup aria-label="Trace view">
-            <Button
-              aria-pressed={traceView === "imessage"}
-              onClick={() => onTraceViewChange("imessage")}
-              size="sm"
-              type="button"
-              variant={traceView === "imessage" ? "secondary" : "outline"}
-            >
-              iMessage
-            </Button>
-            <Button
-              aria-pressed={traceView === "trace"}
-              onClick={() => onTraceViewChange("trace")}
-              size="sm"
-              type="button"
-              variant={traceView === "trace" ? "secondary" : "outline"}
-            >
-              Full trace
-            </Button>
-          </ButtonGroup>
-          {canStartNewChat ? (
-            <Button
-              aria-label="Start a new chat"
-              onClick={() => window.location.assign("/chat")}
-              size="sm"
-              type="button"
-              variant="ghost"
-            >
-              <PlusIcon className="size-4" />
-              <span className="hidden sm:inline">New chat</span>
-            </Button>
-          ) : null}
-        </div>
-      </div>
-    </header>
   );
 }
 

--- a/app/_components/agent-message.tsx
+++ b/app/_components/agent-message.tsx
@@ -15,7 +15,7 @@ import {
   KeyRoundIcon,
   XCircleIcon,
 } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 import {
   Message,
   MessageContent,
@@ -56,7 +56,6 @@ export type AgentInputResponse = {
 type EveFilePart = Extract<EveMessagePart, { type: "file" }>;
 
 export function AgentMessage({
-  afterToolCalls,
   canRespond,
   deliveredAssistantMessages,
   isStreaming,
@@ -65,7 +64,6 @@ export function AgentMessage({
   timestamp,
   userVisibleOnly = false,
 }: {
-  readonly afterToolCalls?: ReadonlyMap<string, ReactNode>;
   readonly canRespond: boolean;
   readonly deliveredAssistantMessages?: ReadonlyMap<number, readonly string[]>;
   readonly isStreaming: boolean;
@@ -101,7 +99,6 @@ export function AgentMessage({
         {visibleParts.map((part, index) =>
           hasAssistantText && part.type === "reasoning" ? null : (
             <AgentMessagePart
-              afterToolCalls={afterToolCalls}
               canRespond={canRespond}
               key={partKey(part, index)}
               onInputResponses={onInputResponses}
@@ -187,14 +184,12 @@ function formatFullTimestamp(timestamp: string) {
 }
 
 function AgentMessagePart({
-  afterToolCalls,
   canRespond,
   onInputResponses,
   part,
   showCaret,
   userVisibleOnly,
 }: {
-  readonly afterToolCalls?: ReadonlyMap<string, ReactNode>;
   readonly canRespond: boolean;
   readonly onInputResponses: (
     responses: readonly AgentInputResponse[]
@@ -265,15 +260,7 @@ function AgentMessagePart({
           </ToolContent>
         </Tool>
       );
-      const afterToolCall = afterToolCalls?.get(part.toolCallId);
-      return afterToolCall ? (
-        <>
-          {tool}
-          {afterToolCall}
-        </>
-      ) : (
-        tool
-      );
+      return tool;
     }
   }
 }

--- a/app/_components/subagent-panel.tsx
+++ b/app/_components/subagent-panel.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import { Client, type MessageStreamEvent } from "eve/client";
+import {
+  ChevronRightIcon,
+  CircleDotIcon,
+  ListTreeIcon,
+  SparklesIcon,
+  XIcon,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  getSubagentStatus,
+  getSubagentSubscriptionKey,
+  getSubagentTask,
+  type SubagentSession,
+  type SubagentStatus,
+} from "@/app/_lib/subagent-sessions";
+import { formatChatUsage } from "@/app/_lib/chat-usage";
+import type { ChatUsage } from "@/lib/chat";
+import { cn } from "@/lib/utils";
+import { SubagentTrace } from "./subagent-trace";
+
+const client = new Client({ host: "" });
+
+export function SubagentPanel({
+  onTraceViewChange,
+  sessions,
+  traceView,
+  usage,
+}: {
+  readonly onTraceViewChange: (view: "imessage" | "trace") => void;
+  readonly sessions: readonly SubagentSession[];
+  readonly traceView: "imessage" | "trace";
+  readonly usage: ChatUsage;
+}) {
+  const [eventsBySession, setEventsBySession] = useState<
+    ReadonlyMap<string, readonly MessageStreamEvent[]>
+  >(new Map());
+  const [streamErrors, setStreamErrors] = useState<ReadonlyMap<string, string>>(
+    new Map()
+  );
+  const [selectedId, setSelectedId] = useState<string>();
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const traceCloseButton = useRef<HTMLButtonElement>(null);
+  const restoreFocusId = useRef<string | undefined>(undefined);
+  const subscriptionKey = getSubagentSubscriptionKey(sessions);
+
+  useEffect(() => {
+    if (!subscriptionKey) return;
+    const controllers = subscriptionKey.split("\n").map((subscription) => {
+      const [encodedSessionId] = subscription.split(":");
+      const childSessionId = decodeURIComponent(encodedSessionId ?? "");
+      const controller = new AbortController();
+      const child = client.sessions.attach(childSessionId);
+
+      void (async () => {
+        try {
+          for await (const event of child.stream({
+            signal: controller.signal,
+            startIndex: 0,
+          })) {
+            setStreamErrors((current) => {
+              if (!current.has(childSessionId)) return current;
+              const next = new Map(current);
+              next.delete(childSessionId);
+              return next;
+            });
+            setEventsBySession((current) => {
+              const events = current.get(childSessionId) ?? [];
+              if (
+                events.some((candidate) => candidate.meta.id === event.meta.id)
+              ) {
+                return current;
+              }
+              const next = new Map(current);
+              next.set(childSessionId, [...events, event]);
+              return next;
+            });
+          }
+        } catch (error) {
+          if (!controller.signal.aborted) {
+            setStreamErrors((current) => {
+              const next = new Map(current);
+              next.set(
+                childSessionId,
+                error instanceof Error
+                  ? error.message
+                  : "The task stream disconnected."
+              );
+              return next;
+            });
+          }
+        }
+      })();
+
+      return controller;
+    });
+
+    return () => {
+      for (const controller of controllers) controller.abort();
+    };
+  }, [subscriptionKey]);
+
+  useEffect(() => {
+    if (!window.matchMedia("(min-width: 48rem)").matches) return;
+    if (!selectedId) {
+      const taskId = restoreFocusId.current;
+      if (!taskId) return;
+      const frame = requestAnimationFrame(() => {
+        document
+          .querySelector<HTMLButtonElement>(
+            `[data-task-session="${CSS.escape(taskId)}"]`
+          )
+          ?.focus();
+        restoreFocusId.current = undefined;
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+
+    const frame = requestAnimationFrame(() =>
+      traceCloseButton.current?.focus()
+    );
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setSelectedId(undefined);
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [selectedId]);
+
+  const selected = sessions.find(
+    (session) => session.childSessionId === selectedId
+  );
+  const statuses = useMemo(
+    () =>
+      new Map(
+        sessions.map((session) => [
+          session.childSessionId,
+          getSubagentStatus(
+            eventsBySession.get(session.childSessionId) ?? [],
+            session
+          ),
+        ])
+      ),
+    [eventsBySession, sessions]
+  );
+  const workingCount = [...statuses.values()].filter((status) =>
+    ["starting", "working"].includes(status)
+  ).length;
+  const doneCount = sessions.length - workingCount;
+  const openTask = (sessionId: string) => {
+    restoreFocusId.current = sessionId;
+    setSelectedId(sessionId);
+  };
+  const closeTask = () => setSelectedId(undefined);
+  const activity = (
+    <ActivityCard
+      doneCount={doneCount}
+      eventsBySession={eventsBySession}
+      onSelect={openTask}
+      onTraceViewChange={onTraceViewChange}
+      sessions={sessions}
+      statuses={statuses}
+      traceView={traceView}
+      usage={usage}
+      workingCount={workingCount}
+    />
+  );
+
+  return (
+    <>
+      <aside
+        aria-hidden={selected !== undefined}
+        className={cn(
+          "relative hidden h-full shrink-0 overflow-hidden transition-[width] duration-200 ease-linear md:block",
+          selected ? "w-0" : "w-88"
+        )}
+      >
+        <div
+          className={cn(
+            "absolute inset-y-0 right-0 flex w-88 items-start p-4 transition-[opacity,transform] duration-200",
+            selected
+              ? "pointer-events-none translate-x-6 opacity-0"
+              : "translate-x-0 opacity-100"
+          )}
+        >
+          {activity}
+        </div>
+      </aside>
+
+      <Button
+        aria-label="Open activity panel"
+        className="absolute top-2 right-3 z-30 md:hidden"
+        onClick={() => setMobileOpen(true)}
+        size="icon-sm"
+        type="button"
+        variant="ghost"
+      >
+        <ListTreeIcon />
+      </Button>
+
+      <aside
+        aria-hidden={!selected}
+        className={cn(
+          "relative hidden h-full shrink-0 overflow-hidden border-l bg-background transition-[width] duration-200 ease-linear md:block",
+          selected ? "w-1/2 min-w-80" : "w-0 border-l-0"
+        )}
+      >
+        <div
+          className={cn(
+            "absolute inset-y-0 right-0 flex w-full min-w-80 flex-col transition-[opacity,transform] duration-200",
+            selected
+              ? "translate-x-0 opacity-100"
+              : "pointer-events-none translate-x-6 opacity-0"
+          )}
+        >
+          {selected ? (
+            <TracePreview
+              events={eventsBySession.get(selected.childSessionId) ?? []}
+              closeButtonRef={traceCloseButton}
+              onClose={closeTask}
+              session={selected}
+              status={statuses.get(selected.childSessionId) ?? "starting"}
+              streamError={streamErrors.get(selected.childSessionId)}
+            />
+          ) : null}
+        </div>
+      </aside>
+
+      <Sheet
+        onOpenChange={(open) => {
+          setMobileOpen(open);
+          if (!open) closeTask();
+        }}
+        open={mobileOpen}
+      >
+        <SheetContent
+          className="h-[85svh] w-full gap-0 p-0 sm:max-w-none"
+          side="bottom"
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>
+              {selected ? `${selected.name} trace` : "Agent activity"}
+            </SheetTitle>
+            <SheetDescription>
+              {selected
+                ? "Full trace for the selected subagent"
+                : "Conversation views, sources, and live task statuses"}
+            </SheetDescription>
+          </SheetHeader>
+          {selected ? (
+            <TracePreview
+              events={eventsBySession.get(selected.childSessionId) ?? []}
+              onClose={closeTask}
+              session={selected}
+              status={statuses.get(selected.childSessionId) ?? "starting"}
+              streamError={streamErrors.get(selected.childSessionId)}
+            />
+          ) : (
+            activity
+          )}
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+function ActivityCard({
+  doneCount,
+  eventsBySession,
+  onSelect,
+  onTraceViewChange,
+  sessions,
+  statuses,
+  traceView,
+  usage,
+  workingCount,
+}: {
+  readonly doneCount: number;
+  readonly eventsBySession: ReadonlyMap<string, readonly MessageStreamEvent[]>;
+  readonly onSelect: (sessionId: string) => void;
+  readonly onTraceViewChange: (view: "imessage" | "trace") => void;
+  readonly sessions: readonly SubagentSession[];
+  readonly statuses: ReadonlyMap<string, SubagentStatus>;
+  readonly traceView: "imessage" | "trace";
+  readonly usage: ChatUsage;
+  readonly workingCount: number;
+}) {
+  return (
+    <Card className="max-h-full w-full gap-0 overflow-hidden">
+      <CardContent className="min-h-0 overflow-y-auto pr-6">
+        <p className="type-section-title text-muted-foreground">Activity</p>
+        <label
+          className="mt-4 flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2 hover:bg-muted"
+          htmlFor="show-full-trace"
+        >
+          <span className="type-supporting-body min-w-0 flex-1">
+            Show full trace
+          </span>
+          <Switch
+            checked={traceView === "trace"}
+            id="show-full-trace"
+            onCheckedChange={(checked) =>
+              onTraceViewChange(checked ? "trace" : "imessage")
+            }
+          />
+        </label>
+        <div className="type-supporting-body flex items-center px-2 py-2 text-muted-foreground">
+          <span>Usage</span>
+          <span className="ml-auto">{formatChatUsage(usage)}</span>
+        </div>
+
+        <section className="mt-5 border-t pt-5">
+          <h2 className="type-section-title text-muted-foreground">Tasks</h2>
+          {sessions.length === 0 ? (
+            <p className="type-supporting-body mt-4 text-muted-foreground">
+              No tasks yet
+            </p>
+          ) : (
+            <>
+              <div className="mt-3 flex items-center gap-2 pb-2">
+                <CircleDotIcon className="size-4 text-amber-500" />
+                <span className="type-label">{workingCount} working</span>
+                <span className="ml-auto type-label text-muted-foreground">
+                  {doneCount} done
+                </span>
+              </div>
+              <div className="divide-y">
+                {sessions.map((session) => {
+                  const status =
+                    statuses.get(session.childSessionId) ?? "starting";
+                  const task = getSubagentTask(
+                    eventsBySession.get(session.childSessionId) ?? []
+                  );
+                  return (
+                    <button
+                      className="group flex w-full items-center gap-3 py-3 text-left"
+                      data-task-session={session.childSessionId}
+                      key={session.childSessionId}
+                      onClick={() => onSelect(session.childSessionId)}
+                      type="button"
+                    >
+                      <StatusDot status={status} />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate type-label">
+                          {task ?? session.name}
+                        </span>
+                        <span className="block truncate type-caption text-muted-foreground">
+                          {session.name}
+                        </span>
+                      </span>
+                      <Badge variant={statusVariant(status)}>{status}</Badge>
+                      <ChevronRightIcon className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </section>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TracePreview({
+  closeButtonRef,
+  events,
+  onClose,
+  session,
+  status,
+  streamError,
+}: {
+  readonly closeButtonRef?: RefObject<HTMLButtonElement | null>;
+  readonly events: readonly MessageStreamEvent[];
+  readonly onClose: () => void;
+  readonly session: SubagentSession;
+  readonly status: SubagentStatus;
+  readonly streamError?: string;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <header className="flex h-14 shrink-0 items-center gap-3 border-b px-4">
+        <SparklesIcon className="size-4 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate type-card-title">{session.name}</h2>
+          <p className="truncate type-caption text-muted-foreground">
+            Full task trace
+          </p>
+        </div>
+        <Button
+          aria-label="Close task trace"
+          onClick={onClose}
+          ref={closeButtonRef}
+          size="icon-sm"
+          type="button"
+          variant="ghost"
+        >
+          <XIcon />
+        </Button>
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-6 sm:px-6">
+        <SubagentTrace
+          events={events}
+          status={status}
+          streamError={streamError}
+          target={session}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StatusDot({ status }: { readonly status: SubagentStatus }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "size-2.5 shrink-0 rounded-full",
+        status === "working" || status === "starting"
+          ? "animate-pulse bg-amber-400"
+          : status === "failed"
+            ? "bg-destructive"
+            : status === "cancelled"
+              ? "bg-muted-foreground"
+              : "bg-emerald-500"
+      )}
+    />
+  );
+}
+
+function statusVariant(status: SubagentStatus) {
+  if (status === "failed") return "destructive" as const;
+  if (status === "working" || status === "starting") {
+    return "information" as const;
+  }
+  return "secondary" as const;
+}

--- a/app/_components/subagent-trace.tsx
+++ b/app/_components/subagent-trace.tsx
@@ -1,26 +1,42 @@
 "use client";
 
-import type { SubagentCalledStreamEvent } from "eve/client";
-import { useEveAgent } from "eve/react";
+import {
+  defaultMessageReducer,
+  type MessageStreamEvent,
+  type SubagentCalledStreamEvent,
+} from "eve/client";
 import { BotIcon } from "lucide-react";
 import { useMemo } from "react";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { Badge } from "@/components/ui/badge";
 import { getLatestTurnFailure } from "@/app/_lib/turn-failure";
+import type { SubagentStatus } from "@/app/_lib/subagent-sessions";
 import { AgentMessage } from "./agent-message";
 
+const messageReducer = defaultMessageReducer();
+
 export function SubagentTrace({
+  events,
+  streamError,
+  status,
   target,
 }: {
+  readonly events: readonly MessageStreamEvent[];
+  readonly streamError?: string;
+  readonly status: SubagentStatus;
   readonly target: SubagentCalledStreamEvent["data"];
 }) {
-  const trace = useEveAgent({
-    initialSession: { sessionId: target.childSessionId, streamIndex: 0 },
-    resume: true,
-  });
+  const data = useMemo(
+    () =>
+      events.reduce(
+        (current, event) => messageReducer.reduce(current, event),
+        messageReducer.initial()
+      ),
+    [events]
+  );
   const timestamps = useMemo(() => {
     const values = new Map<string, string>();
-    for (const event of trace.events) {
+    for (const event of events) {
       if (event.type === "message.received") {
         values.set(`${event.data.turnId}:user`, event.meta.at);
       }
@@ -32,17 +48,11 @@ export function SubagentTrace({
       }
     }
     return values;
-  }, [trace.events]);
-  const isRunning =
-    trace.status === "resuming" ||
-    trace.status === "submitted" ||
-    trace.status === "streaming";
-  const turnFailure = useMemo(
-    () => getLatestTurnFailure(trace.events),
-    [trace.events]
-  );
-  const error = trace.error?.message ?? turnFailure;
-  const status = error ? "Failed" : isRunning ? "Running" : "Settled";
+  }, [events]);
+  const isRunning = status === "starting" || status === "working";
+  const turnFailure = useMemo(() => getLatestTurnFailure(events), [events]);
+  const error = streamError ?? turnFailure;
+  const statusLabel = error ? "Failed" : isRunning ? "Running" : status;
   const badgeVariant = error
     ? "destructive"
     : isRunning
@@ -50,29 +60,26 @@ export function SubagentTrace({
       : "secondary";
 
   return (
-    <section className="mt-3 overflow-hidden rounded-lg border bg-muted/20">
-      <header className="flex items-center gap-2 px-3 py-2">
+    <section className="py-4">
+      <header className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 py-2">
         <BotIcon className="size-4 text-muted-foreground" />
         <span className="min-w-0 flex-1 truncate type-label">
           {target.name} trace
         </span>
-        <Badge variant={badgeVariant}>{status}</Badge>
+        <Badge variant={badgeVariant}>{statusLabel}</Badge>
       </header>
-      <div className="space-y-4 border-t px-3 py-3">
-        {trace.data.messages.map((message, index) => (
+      <div className="space-y-5 py-5">
+        {data.messages.map((message, index) => (
           <AgentMessage
             canRespond={false}
-            isStreaming={
-              trace.status === "streaming" &&
-              index === trace.data.messages.length - 1
-            }
+            isStreaming={isRunning && index === data.messages.length - 1}
             key={message.id}
             message={message}
             onInputResponses={() => undefined}
             timestamp={timestamps.get(message.id)}
           />
         ))}
-        {isRunning && trace.data.messages.length === 0 ? (
+        {isRunning && data.messages.length === 0 ? (
           <Shimmer className="type-supporting-body" duration={1}>
             Loading task trace
           </Shimmer>

--- a/app/_lib/subagent-sessions.test.ts
+++ b/app/_lib/subagent-sessions.test.ts
@@ -1,0 +1,168 @@
+import type { MessageStreamEvent } from "eve/client";
+import { describe, expect, it } from "vitest";
+import {
+  collectSubagentSessions,
+  getSubagentStatus,
+  getSubagentSubscriptionKey,
+  getSubagentTask,
+} from "./subagent-sessions";
+
+const meta = { at: "2026-08-27T12:00:00.000Z", id: "evt_01" };
+const called = {
+  type: "subagent.called",
+  data: {
+    callId: "call_1",
+    childSessionId: "child_1",
+    childStreamPath: "/eve/v1/session/child_1/stream",
+    name: "researcher",
+    sequence: 0,
+    sessionId: "parent_1",
+    toolName: "researcher",
+    turnId: "turn_1",
+    workflowId: "workflow_1",
+  },
+  meta,
+} satisfies MessageStreamEvent;
+
+describe("collectSubagentSessions", () => {
+  it("joins completions and keeps the latest call for a continued child", () => {
+    const events = [
+      called,
+      {
+        ...called,
+        data: { ...called.data, callId: "call_2" },
+        meta: { ...meta, id: "evt_02" },
+      },
+      {
+        type: "subagent.completed",
+        data: {
+          callId: "call_2",
+          output: "Done",
+          subagentName: "researcher",
+        },
+        meta: { ...meta, id: "evt_03" },
+      },
+    ] satisfies readonly MessageStreamEvent[];
+
+    const sessions = collectSubagentSessions(events);
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.callId).toBe("call_2");
+    expect(sessions[0]?.completion?.output).toBe("Done");
+  });
+});
+
+describe("getSubagentSubscriptionKey", () => {
+  it("changes when a continued child receives a new call", () => {
+    const [first] = collectSubagentSessions([called]);
+    const [continued] = collectSubagentSessions([
+      called,
+      {
+        ...called,
+        data: { ...called.data, callId: "call_2" },
+        meta: { ...meta, id: "evt_02" },
+      },
+    ]);
+    if (!first || !continued) {
+      throw new Error("Expected collected subagent sessions");
+    }
+
+    expect(getSubagentSubscriptionKey([continued])).not.toBe(
+      getSubagentSubscriptionKey([first])
+    );
+  });
+});
+
+describe("getSubagentStatus", () => {
+  it("uses the child stream instead of a background receipt", () => {
+    const [session] = collectSubagentSessions([
+      called,
+      {
+        type: "subagent.completed",
+        data: {
+          backgroundTask: { status: "working", taskId: "task_1" },
+          callId: "call_1",
+          output: "Continuing in the background",
+          subagentName: "researcher",
+        },
+        meta: { ...meta, id: "evt_02" },
+      },
+    ]);
+
+    if (!session) throw new Error("Expected a collected subagent session");
+
+    expect(getSubagentStatus([], session)).toBe("starting");
+    expect(
+      getSubagentStatus(
+        [
+          {
+            type: "turn.started",
+            data: { sequence: 0, turnId: "turn_2" },
+            meta: { ...meta, id: "evt_03" },
+          },
+        ],
+        session
+      )
+    ).toBe("working");
+  });
+
+  it.each([
+    ["turn.failed", "failed"],
+    ["turn.cancelled", "cancelled"],
+  ] as const)(
+    "preserves %s after the session returns to waiting",
+    (type, expected) => {
+      const [session] = collectSubagentSessions([called]);
+      if (!session) throw new Error("Expected a collected subagent session");
+      const turnBoundary =
+        type === "turn.failed"
+          ? {
+              type,
+              data: {
+                code: "failed",
+                message: "Failed",
+                sequence: 0,
+                turnId: "turn_1",
+              },
+              meta: { ...meta, id: "evt_02" },
+            }
+          : {
+              type,
+              data: { sequence: 0, turnId: "turn_1" },
+              meta: { ...meta, id: "evt_02" },
+            };
+      const events = [
+        turnBoundary,
+        {
+          type: "session.waiting",
+          data: {
+            continuationToken: "child_1",
+            wait: "next-user-message",
+          },
+          meta: { ...meta, id: "evt_03" },
+        },
+      ] satisfies readonly MessageStreamEvent[];
+
+      expect(getSubagentStatus(events, session)).toBe(expected);
+    }
+  );
+});
+
+describe("getSubagentTask", () => {
+  it("uses the latest task after a child session is continued", () => {
+    const events = [
+      {
+        type: "message.received",
+        data: { message: "First task", sequence: 0, turnId: "turn_1" },
+        meta,
+      },
+      {
+        type: "message.received",
+        data: { message: "Continued task", sequence: 1, turnId: "turn_2" },
+        meta: { ...meta, id: "evt_02" },
+      },
+    ] satisfies readonly MessageStreamEvent[];
+
+    expect(getSubagentTask(events)).toBe("Continued task");
+  });
+});

--- a/app/_lib/subagent-sessions.ts
+++ b/app/_lib/subagent-sessions.ts
@@ -1,0 +1,90 @@
+import type {
+  MessageStreamEvent,
+  SubagentCalledStreamEvent,
+  SubagentCompletedStreamEvent,
+} from "eve/client";
+
+export type SubagentSession = SubagentCalledStreamEvent["data"] & {
+  readonly completion?: SubagentCompletedStreamEvent["data"];
+};
+
+export type SubagentStatus =
+  | "cancelled"
+  | "complete"
+  | "failed"
+  | "ready"
+  | "starting"
+  | "working";
+
+export function collectSubagentSessions(
+  events: readonly MessageStreamEvent[]
+): readonly SubagentSession[] {
+  const completions = new Map<string, SubagentCompletedStreamEvent["data"]>();
+  const sessions = new Map<string, SubagentSession>();
+
+  for (const event of events) {
+    if (event.type === "subagent.completed") {
+      completions.set(event.data.callId, event.data);
+    }
+  }
+
+  for (const event of events) {
+    if (event.type !== "subagent.called") continue;
+
+    const session = {
+      ...event.data,
+      completion: completions.get(event.data.callId),
+    };
+    sessions.delete(session.childSessionId);
+    sessions.set(session.childSessionId, session);
+  }
+
+  return [...sessions.values()];
+}
+
+export function getSubagentSubscriptionKey(
+  sessions: readonly SubagentSession[]
+) {
+  return sessions
+    .map(
+      (session) =>
+        `${encodeURIComponent(session.childSessionId)}:${encodeURIComponent(session.callId)}`
+    )
+    .join("\n");
+}
+
+export function getSubagentStatus(
+  events: readonly MessageStreamEvent[],
+  session: SubagentSession
+): SubagentStatus {
+  const terminalSession = events
+    .toReversed()
+    .find((event) =>
+      ["session.completed", "session.failed"].includes(event.type)
+    );
+  if (terminalSession?.type === "session.completed") return "complete";
+  if (terminalSession?.type === "session.failed") return "failed";
+
+  const latestTurnBoundary = events
+    .toReversed()
+    .find((event) =>
+      [
+        "turn.cancelled",
+        "turn.completed",
+        "turn.failed",
+        "turn.started",
+      ].includes(event.type)
+    );
+  if (latestTurnBoundary?.type === "turn.failed") return "failed";
+  if (latestTurnBoundary?.type === "turn.cancelled") return "cancelled";
+  if (latestTurnBoundary?.type === "turn.completed") return "ready";
+  if (latestTurnBoundary?.type === "turn.started") return "working";
+  if (events.some((event) => event.type === "session.waiting")) return "ready";
+  if (session.completion && !session.completion.backgroundTask) return "ready";
+  return "starting";
+}
+
+export function getSubagentTask(events: readonly MessageStreamEvent[]) {
+  return events.findLast((event) => event.type === "message.received")?.data
+    .message;
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-(--card-spacing)", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none group-has-[:focus-visible]/field-label:border-transparent group-has-[:focus-visible]/field-label:ring-0 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/tests/agent-message.test.tsx
+++ b/tests/agent-message.test.tsx
@@ -135,41 +135,6 @@ describe("agent messages", () => {
     expect(markup).not.toContain("Hidden recipient");
   });
 
-  it("renders a matching child trace after its subagent tool", () => {
-    const message = {
-      id: "turn-3:assistant",
-      parts: [
-        {
-          input: { message: "Research this" },
-          output: { status: "working", taskId: "task-1" },
-          state: "output-available",
-          toolCallId: "call-agent",
-          toolName: "agent",
-          type: "dynamic-tool",
-        },
-      ],
-      role: "assistant",
-    } satisfies EveMessage;
-
-    const markup = renderToStaticMarkup(
-      <AgentMessage
-        afterToolCalls={
-          new Map([["call-agent", <div key="trace">Live child trace</div>]])
-        }
-        canRespond
-        isStreaming={false}
-        message={message}
-        onInputResponses={() => undefined}
-      />
-    );
-
-    expect(markup).toContain("agent");
-    expect(markup).toContain("Live child trace");
-    expect(markup.indexOf("Live child trace")).toBeGreaterThan(
-      markup.indexOf("agent")
-    );
-  });
-
   it("keeps a parked failed child visibly failed", () => {
     const events = [
       {


### PR DESCRIPTION
## Summary

- add a Codex-inspired floating activity card with live subagent task statuses and usage
- open selected subagent traces in a half-width desktop rail or mobile sheet instead of rendering traces inline
- use Eve child-session streams and the default message reducer for authoritative status and trace rendering
- simplify the chat header and full-trace control with shadcn Card and Switch primitives

## Validation

- `pnpm check` (33 files, 132 tests)
- `pnpm build`
- desktop and mobile browser verification with no Next.js error overlay
- `git diff --check`