### PR TITLE
fix(linq): split replies into message bubbles

### DIFF
--- a/agent/channels/linq.ts
+++ b/agent/channels/linq.ts
@@ -29,6 +29,21 @@ const cancelledWorkerTaskSchema = z.object({
 const workerCancellationsSchema = z.array(
   z.object({ sourceMessageId: z.string(), taskId: z.string() })
 );
+const markdownListItemPattern = /^\s*(?:[-+*]|\d+[.)])\s+/u;
+
+function splitLinqReply(message: string) {
+  return message
+    .trim()
+    .split(/\r?\n[\t ]*\r?\n/u)
+    .flatMap((block) => {
+      const lines = block.split(/\r?\n/u);
+      return lines.every((line) => markdownListItemPattern.test(line))
+        ? lines
+        : block;
+    })
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
 
 const credentials: LinqChannelCredentials = env.LINQ_CONNECTOR
   ? connectLinqCredentials(env.LINQ_CONNECTOR)
@@ -118,9 +133,9 @@ export default linqChannel({
       context.state.pendingToolCallMessage = null;
       if (!event.message || !context.thread) return;
 
-      // Eve's Linq adapter translates supported Markdown into native iMessage
-      // decorations, so recipients see styled text instead of literal markers.
-      await context.thread.post({ markdown: event.message });
+      for (const markdown of splitLinqReply(event.message)) {
+        await context.thread.post({ markdown });
+      }
     },
   },
   async onMessage(_context, message) {


### PR DESCRIPTION
## Summary

- send Markdown paragraphs as separate iMessage bubbles
- send short Markdown lists one item at a time
- keep each bubble on Eve/Linq native Markdown rendering

## Validation

- `pnpm check`
- `pnpm build` with non-secret build placeholders

No behavior-specific tests added, per request.