### PR TITLE
Tell the agent that deleting the writable browser is what saves the login

### DIFF
--- a/agent/subagents/worker/tools/manage_browsers.ts
+++ b/agent/subagents/worker/tools/manage_browsers.ts
@@ -18,6 +18,9 @@ import { requireWorkerScope } from "@/agent/subagents/worker/lib/access";
 import { requireOwnedBrowserSession } from "@/agent/subagents/worker/lib/owned-browser";
 
 const browserTimeoutFloorSeconds = 15 * 60;
+// Kernel saves profile changes only when the session ends, so a lingering
+// writable browser blocks persistence and the single-writer slot.
+const writableBrowserTimeoutSeconds = 10 * 60;
 
 const inputSchema = z.object({
   action: z.enum(["create", "update", "list", "get", "delete"]),
@@ -39,7 +42,7 @@ const inputSchema = z.object({
 
 export default defineTool({
   description:
-    'Manage browser sessions backed by the workspace persistent profile. Create read-only browsers by default so tasks can run in parallel. Immediately before a login, replace that task browser with one created using save_changes: true, then delete it after authentication so the session is saved. Only one profile writer may be active. Use "list" or "get" to inspect sessions.',
+    'Manage browser sessions backed by the workspace persistent profile. Create read-only browsers by default so tasks can run in parallel. Immediately before a login, replace that task browser with one created using save_changes: true, then delete it after authentication so the session is saved; writable browsers expire after 10 minutes regardless of timeout_seconds. Only one profile writer may be active. Use "list" or "get" to inspect sessions.',
   inputSchema,
   async execute(input, context) {
     const scope = await requireWorkerScope(context);
@@ -71,8 +74,9 @@ export default defineTool({
               },
               start_url: input.start_url,
               stealth: true,
-              timeout_seconds:
-                input.timeout_seconds ?? browserTimeoutFloorSeconds,
+              timeout_seconds: input.save_changes
+                ? writableBrowserTimeoutSeconds
+                : (input.timeout_seconds ?? browserTimeoutFloorSeconds),
               viewport: browserViewport(input),
             },
             { signal }
@@ -222,6 +226,11 @@ function lifecycleResult(browser: KernelBrowser) {
   return {
     browser: value,
     next_actions: [
+      ...(browser.profile_save_changes
+        ? [
+            `Login state persists to the workspace profile only when this browser is deleted. Delete session_id "${value.session_id}" as soon as authentication succeeds; it expires on its own after 10 minutes.`,
+          ]
+        : []),
       `Use execute_playwright_code with session_id "${value.session_id}" for deterministic browser automation.`,
       `Use computer_action with session_id "${value.session_id}" for visual browser control.`,
       `Use manage_browsers with action "delete" and session_id "${value.session_id}" when finished.`,

--- a/agent/subagents/worker/tools/manage_browsers.ts
+++ b/agent/subagents/worker/tools/manage_browsers.ts
@@ -18,9 +18,6 @@ import { requireWorkerScope } from "@/agent/subagents/worker/lib/access";
 import { requireOwnedBrowserSession } from "@/agent/subagents/worker/lib/owned-browser";
 
 const browserTimeoutFloorSeconds = 15 * 60;
-// Kernel saves profile changes only when the session ends, so a lingering
-// writable browser blocks persistence and the single-writer slot.
-const writableBrowserTimeoutSeconds = 10 * 60;
 
 const inputSchema = z.object({
   action: z.enum(["create", "update", "list", "get", "delete"]),
@@ -42,7 +39,7 @@ const inputSchema = z.object({
 
 export default defineTool({
   description:
-    'Manage browser sessions backed by the workspace persistent profile. Create read-only browsers by default so tasks can run in parallel. Immediately before a login, replace that task browser with one created using save_changes: true, then delete it after authentication so the session is saved; writable browsers expire after 10 minutes regardless of timeout_seconds. Only one profile writer may be active. Use "list" or "get" to inspect sessions.',
+    'Manage browser sessions backed by the workspace persistent profile. Create read-only browsers by default so tasks can run in parallel. Immediately before a login, replace that task browser with one created using save_changes: true, then delete it after authentication so the session is saved. Only one profile writer may be active. Use "list" or "get" to inspect sessions.',
   inputSchema,
   async execute(input, context) {
     const scope = await requireWorkerScope(context);
@@ -74,9 +71,8 @@ export default defineTool({
               },
               start_url: input.start_url,
               stealth: true,
-              timeout_seconds: input.save_changes
-                ? writableBrowserTimeoutSeconds
-                : (input.timeout_seconds ?? browserTimeoutFloorSeconds),
+              timeout_seconds:
+                input.timeout_seconds ?? browserTimeoutFloorSeconds,
               viewport: browserViewport(input),
             },
             { signal }
@@ -228,7 +224,7 @@ function lifecycleResult(browser: KernelBrowser) {
     next_actions: [
       ...(browser.profile_save_changes
         ? [
-            `Login state persists to the workspace profile only when this browser is deleted. Delete session_id "${value.session_id}" as soon as authentication succeeds; it expires on its own after 10 minutes.`,
+            `Login state persists to the workspace profile only when this browser is deleted. Delete session_id "${value.session_id}" as soon as authentication succeeds.`,
           ]
         : []),
       `Use execute_playwright_code with session_id "${value.session_id}" for deterministic browser automation.`,


### PR DESCRIPTION
## Summary

Kernel saves profile changes only when the browser session ends (no mid-session save API exists). An agent that skipped the delete-after-login step left the writable browser open, so logins never reached the workspace profile and fresh browsers started signed out — reproduced and verified live against Amazon.

- lead the writable create result's `next_actions` with the fact that deletion is what persists the login, so the reminder lands at the decision moment

No timeout cap: writable sessions keep the caller's `timeout_seconds`, since login flows may legitimately run long. The real fix is an explicit profile-save endpoint on Kernel; until then the delete step remains the trigger.

## Validation

- `pnpm check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mnvvBKSjkKrggysY5CmWr