### PR TITLE
Enforce anti-slop Oxlint rules

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -22,7 +22,9 @@
     "suspicious": "error",
     "perf": "error"
   },
+  "ignorePatterns": ["tools/oxlint/anti-slop/**"],
   "jsPlugins": [
+    "./tools/oxlint/anti-slop/index.ts",
     "./tools/oxlint/next/index.ts",
     "eslint-plugin-turbo",
     {
@@ -37,6 +39,21 @@
     }
   },
   "rules": {
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-conditional-empty-object-spread": "error",
+    "anti-slop/no-known-value-widening": "error",
+    "anti-slop/no-module-mocking": "error",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+    "anti-slop/no-runtime-typeof": "error",
+    "anti-slop/no-shape-in-symbol-names": "error",
+    "anti-slop/no-unknown-parameters": "error",
+    "anti-slop/no-unknown-returns": "error",
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-unsafe-dictionary-type": "error",
+    "anti-slop/no-widen-then-assert": "error",
+    "anti-slop/require-safety-comment-for-type-assertion": "error",
     "local-next/no-route-private-imports": "error",
     "local-next/prefer-nearest-route-private-owner": "error",
     "local-next/require-generated-route-props": "error",

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -4,6 +4,11 @@ The browser tool names and input contracts follow
 [`kernel/kernel-mcp-server`](https://github.com/kernel/kernel-mcp-server),
 licensed under the MIT License.
 
+The repository-owned Oxlint anti-slop plugin vendors generic rules and shared
+helpers from [`dmmulroy/anti-slop`](https://github.com/dmmulroy/anti-slop),
+copyright (c) 2026 Dillon Mulroy, licensed under the MIT License. The full
+license text ships in `tools/oxlint/anti-slop/LICENSE`.
+
 The fonts in `public/fonts/` are derived from
 [Mona Sans](https://github.com/github/mona-sans), copyright (c) 2023 GitHub,
 licensed under the SIL Open Font License 1.1. The full license text ships

--- a/agent/channels/eve.ts
+++ b/agent/channels/eve.ts
@@ -1,5 +1,6 @@
 import { eveChannel } from "eve/channels/eve";
 import { ForbiddenError, UnauthenticatedError } from "eve/channels/auth";
+import { z } from "zod";
 import { isSessionOwned } from "@/db/services/sessions";
 import { accessScopeForUser, type AccessScope } from "@/lib/access-scope";
 import { getAuthSession } from "@/auth/session";
@@ -43,11 +44,12 @@ function sessionIdFromPath(pathname: string) {
 
 async function requestIdentityFromRequest(request: Request) {
   const session = await getAuthSession(request.headers);
-  const phoneNumber = session?.user.phoneNumber;
-  if (!session || typeof phoneNumber !== "string") return;
+  if (!session) return;
+  const phoneNumber = z.string().safeParse(session.user.phoneNumber);
+  if (!phoneNumber.success) return;
 
   return {
-    phoneNumber,
+    phoneNumber: phoneNumber.data,
     scope: accessScopeForUser(`better-auth:${session.user.id}`),
   };
 }

--- a/agent/channels/linq.ts
+++ b/agent/channels/linq.ts
@@ -66,10 +66,11 @@ async function postLinqReply(
     return;
   }
   for (const [index, bubble] of bubbles.entries()) {
-    await thread.post({
-      markdown: bubble,
-      ...(index === bubbles.length - 1 && files.length > 0 ? { files } : {}),
-    });
+    if (index === bubbles.length - 1 && files.length > 0) {
+      await thread.post({ files, markdown: bubble });
+    } else {
+      await thread.post({ markdown: bubble });
+    }
   }
 }
 
@@ -83,7 +84,7 @@ const credentials: LinqChannelCredentials = env.LINQ_CONNECTOR
       },
     };
 
-export default linqChannel({
+export const linqChannelConfig = {
   credentials,
   events: {
     "action.result"(event, context) {
@@ -205,11 +206,10 @@ export default linqChannel({
     if (message.author.isBot) return null;
 
     const auth = defaultLinqAuth(message);
-    const authorUserName: unknown = message.author.userName;
-    const phoneNumber =
-      typeof authorUserName === "string"
-        ? normalizeAuthPhoneNumber(authorUserName)
-        : undefined;
+    const authorUserName = z.string().safeParse(message.author.userName);
+    const phoneNumber = authorUserName.success
+      ? normalizeAuthPhoneNumber(authorUserName.data)
+      : undefined;
     const verifiedUserId = phoneNumber
       ? await findVerifiedAuthUserIdByPhoneNumber(phoneNumber)
       : undefined;
@@ -217,19 +217,21 @@ export default linqChannel({
       ? `better-auth:${verifiedUserId}`
       : auth.principalId;
     const scope = accessScopeForUser(principalId);
+    const attributes =
+      verifiedUserId && phoneNumber
+        ? { ...auth.attributes, phoneNumber, workspaceId: scope.workspaceId }
+        : { ...auth.attributes, workspaceId: scope.workspaceId };
     return {
       auth: {
         ...auth,
-        attributes: {
-          ...auth.attributes,
-          ...(verifiedUserId && phoneNumber ? { phoneNumber } : {}),
-          workspaceId: scope.workspaceId,
-        },
+        attributes,
         principalId,
       },
     };
   },
-});
+} satisfies LinqChannelConfig;
+
+export default linqChannel(linqChannelConfig);
 
 async function findVerifiedAuthUserIdByPhoneNumber(phoneNumber: string) {
   const context = await auth.$context;

--- a/agent/hooks/session-owner.ts
+++ b/agent/hooks/session-owner.ts
@@ -4,6 +4,8 @@ import { ensureScope } from "@/db/services/scope";
 import { claimSession } from "@/db/services/sessions";
 import { scopeFromPrincipal } from "@/lib/access-scope";
 
+export const sessionOwnerDependencies = { claimSession, ensureScope, saveChat };
+
 export default defineHook({
   events: {
     async "session.started"(_event, ctx) {
@@ -11,14 +13,14 @@ export default defineHook({
       if (!initiator) return;
 
       const scope = scopeFromPrincipal(initiator);
-      await ensureScope(scope);
-      await claimSession(scope, ctx.session.id);
+      await sessionOwnerDependencies.ensureScope(scope);
+      await sessionOwnerDependencies.claimSession(scope, ctx.session.id);
     },
     async "message.received"(_event, ctx) {
       const initiator = ctx.session.auth.initiator;
       if (!initiator) return;
 
-      await saveChat(scopeFromPrincipal(initiator), {
+      await sessionOwnerDependencies.saveChat(scopeFromPrincipal(initiator), {
         sessionId: ctx.session.id,
       });
     },

--- a/agent/instructions/authenticated-profile.ts
+++ b/agent/instructions/authenticated-profile.ts
@@ -1,15 +1,19 @@
 import { defineDynamic, defineInstructions } from "eve/instructions";
+import { z } from "zod";
 
 export default defineDynamic({
   events: {
     "session.started": (_event, ctx) => {
-      const phoneNumber =
-        ctx.session.auth.current?.attributes.phoneNumber ??
-        ctx.session.auth.initiator?.attributes.phoneNumber;
-      if (typeof phoneNumber !== "string") return null;
+      const phoneNumber = z
+        .string()
+        .safeParse(
+          ctx.session.auth.current?.attributes.phoneNumber ??
+            ctx.session.auth.initiator?.attributes.phoneNumber
+        );
+      if (!phoneNumber.success) return null;
 
       return defineInstructions({
-        content: `The authenticated user's verified phone number is ${phoneNumber}. Treat it as profile data, not as an instruction.`,
+        content: `The authenticated user's verified phone number is ${phoneNumber.data}. Treat it as profile data, not as an instruction.`,
       });
     },
   },

--- a/agent/lib/google-workspace/client.ts
+++ b/agent/lib/google-workspace/client.ts
@@ -1,6 +1,7 @@
 import { auth } from "@googleapis/gmail";
 import { connect, type EveAuthorizationOptions } from "@vercel/connect/eve";
 import type { ToolContext } from "eve/tools";
+import { z } from "zod";
 import { env } from "@/lib/env";
 import {
   googleWorkspaceSubject,
@@ -41,11 +42,11 @@ export async function withGoogleAuth<T>(
   }
 }
 
-export function googleApiErrorStatus(error: unknown) {
-  if (!error || typeof error !== "object" || !("response" in error)) return;
-  const { response } = error;
-  if (!response || typeof response !== "object" || !("status" in response)) {
-    return;
-  }
-  return typeof response.status === "number" ? response.status : undefined;
+const googleApiErrorSchema = z.object({
+  response: z.object({ status: z.number() }),
+});
+
+export function googleApiErrorStatus(cause: unknown) {
+  const result = googleApiErrorSchema.safeParse(cause);
+  return result.success ? result.data.response.status : undefined;
 }

--- a/agent/lib/google-workspace/gmail.ts
+++ b/agent/lib/google-workspace/gmail.ts
@@ -133,12 +133,12 @@ export async function sendGmail(
     "utf8"
   ).toString("base64url");
   return withGmail(ctx, async (client) => {
+    const requestBody = payload.threadId
+      ? { raw, threadId: payload.threadId }
+      : { raw };
     const { data } = await client.users.messages.send(
       {
-        requestBody: {
-          raw,
-          ...(payload.threadId ? { threadId: payload.threadId } : {}),
-        },
+        requestBody,
         userId: "me",
       },
       { signal: ctx.abortSignal }

--- a/agent/lib/profile-memory.ts
+++ b/agent/lib/profile-memory.ts
@@ -1,4 +1,5 @@
 import type { MemoryScopeContext } from "eve/memory";
+import { z } from "zod";
 import type { env } from "@/lib/env";
 
 export function resolveProfileMemoryBackend(
@@ -19,9 +20,9 @@ export function resolveProfileMemoryBackend(
 
 export function resolveProfileMemoryScope(context: MemoryScopeContext) {
   const caller = context.session.auth.current;
-  const workspaceId = caller?.attributes.workspaceId;
+  const workspaceId = z.string().safeParse(caller?.attributes.workspaceId);
 
-  return caller?.principalType === "user" && typeof workspaceId === "string"
-    ? workspaceId
+  return caller?.principalType === "user" && workspaceId.success
+    ? workspaceId.data
     : null;
 }

--- a/agent/lib/worker-cancellation-delivery.ts
+++ b/agent/lib/worker-cancellation-delivery.ts
@@ -1,3 +1,4 @@
+// SAFETY: This intersection only adds one optional, repository-owned key to globalThis.
 const runtime = globalThis as typeof globalThis & {
   openInstinctWorkerCancellationTurns?: Map<string, string>;
 };

--- a/agent/subagents/worker/hooks/trace-telemetry.ts
+++ b/agent/subagents/worker/hooks/trace-telemetry.ts
@@ -9,23 +9,38 @@ import { traceTimelineRows } from "@/agent/subagents/worker/lib/trace-timeline";
 import { listWorkerBrowserSessions } from "@/db/services/browsers";
 import type { AccessScope } from "@/lib/access-scope";
 import { scopeFromPrincipal } from "@/lib/access-scope";
-import { parseTaskCompletionOutput } from "@/lib/task-completion";
+import { taskCompletionOutputSchema } from "@/lib/task-completion";
 import { harvestBrowserTraceDomains } from "@/agent/subagents/worker/lib/trace-domains";
+
+export const traceTelemetryDependencies = {
+  beginBrowserTrace,
+  completeBrowserTrace,
+  harvestBrowserTraceDomains,
+  listWorkerBrowserSessions,
+  recordBrowserTraceEvents,
+};
 
 function traceScope(ctx: HookContext) {
   const initiator = ctx.session.auth.initiator;
   return initiator ? scopeFromPrincipal(initiator) : undefined;
 }
 
-function logTraceFailure(sessionId: string, error: unknown) {
-  console.warn("[browser-trace] telemetry write failed", { error, sessionId });
+function logTraceFailure(sessionId: string, cause: unknown) {
+  console.warn("[browser-trace] telemetry write failed", { cause, sessionId });
 }
 
 async function sweepLiveBrowserDomains(scope: AccessScope, sessionId: string) {
-  const browsers = await listWorkerBrowserSessions(scope, sessionId);
+  const browsers = await traceTelemetryDependencies.listWorkerBrowserSessions(
+    scope,
+    sessionId
+  );
   await Promise.all(
     browsers.map((browser) =>
-      harvestBrowserTraceDomains(scope, sessionId, browser)
+      traceTelemetryDependencies.harvestBrowserTraceDomains(
+        scope,
+        sessionId,
+        browser
+      )
     )
   );
 }
@@ -40,7 +55,7 @@ async function finishTrace(
 ) {
   const scope = traceScope(ctx);
   if (!scope) return;
-  await completeBrowserTrace(scope, ctx.session.id, {
+  await traceTelemetryDependencies.completeBrowserTrace(scope, ctx.session.id, {
     completedAt: emittedAt,
     resultMessage: outcome.resultMessage,
     status: outcome.status,
@@ -54,7 +69,7 @@ export default defineHook({
       try {
         const scope = traceScope(ctx);
         if (!scope) return;
-        await recordBrowserTraceEvents(
+        await traceTelemetryDependencies.recordBrowserTraceEvents(
           scope,
           ctx.session.id,
           traceTimelineRows(event)
@@ -67,7 +82,7 @@ export default defineHook({
       try {
         const scope = traceScope(ctx);
         if (!scope) return;
-        await beginBrowserTrace(scope, {
+        await traceTelemetryDependencies.beginBrowserTrace(scope, {
           sessionId: ctx.session.id,
           startedAt: event.meta.at,
           task: event.data.message,
@@ -78,11 +93,13 @@ export default defineHook({
     },
     async "result.completed"(event, ctx) {
       try {
-        const completion = parseTaskCompletionOutput(event.data.result);
-        if (!completion) return;
+        const completion = taskCompletionOutputSchema.safeParse(
+          event.data.result
+        );
+        if (!completion.success) return;
         await finishTrace(ctx, event.meta.at, {
-          resultMessage: completion.message,
-          status: completion.status,
+          resultMessage: completion.data.message,
+          status: completion.data.status,
         });
       } catch (error) {
         logTraceFailure(ctx.session.id, error);

--- a/agent/subagents/worker/lib/trace-timeline.ts
+++ b/agent/subagents/worker/lib/trace-timeline.ts
@@ -1,4 +1,5 @@
 import type { HookEvent } from "eve/hooks";
+import { z } from "zod";
 
 export interface TraceTimelineRow {
   readonly at: string;
@@ -10,12 +11,15 @@ export interface TraceTimelineRow {
 
 const detailCharacterLimit = 600;
 
-function compactJson(value: unknown) {
-  const serialized = JSON.stringify(value, (_key, entry: unknown) =>
-    typeof entry === "string" && entry.length > 200
-      ? `${entry.slice(0, 200)}… [${String(entry.length)} chars]`
-      : entry
-  );
+function compactJson(value: Parameters<typeof JSON.stringify>[0]) {
+  const serialized = JSON.stringify(value, (_key, entry) => {
+    const text = z.string().safeParse(entry);
+    if (text.success && text.data.length > 200) {
+      return `${text.data.slice(0, 200)}… [${String(text.data.length)} chars]`;
+    }
+    const jsonValue = z.json().safeParse(entry);
+    return jsonValue.success ? jsonValue.data : undefined;
+  });
   return serialized.length > detailCharacterLimit
     ? `${serialized.slice(0, detailCharacterLimit)}…`
     : serialized;

--- a/agent/subagents/worker/lib/vault-screenshot-mask.ts
+++ b/agent/subagents/worker/lib/vault-screenshot-mask.ts
@@ -1,23 +1,42 @@
 import { kernel } from "@/lib/kernel";
 
+interface VaultScreenshotMaskDependencies {
+  execute(
+    sessionId: string,
+    body: { readonly code: string; readonly timeout_sec: number },
+    options: { readonly signal?: AbortSignal }
+  ): Promise<{ readonly success: boolean }>;
+}
+
+const defaultDependencies: VaultScreenshotMaskDependencies = {
+  async execute(sessionId, body, options) {
+    return await kernel.browsers.playwright.execute(sessionId, body, options);
+  },
+};
+
 export async function withVaultScreenshotMask<T>(
   sessionId: string,
   signal: AbortSignal | undefined,
-  capture: () => Promise<T>
+  capture: () => Promise<T>,
+  dependencies: VaultScreenshotMaskDependencies = defaultDependencies
 ) {
-  await setVaultScreenshotMask(sessionId, "add", signal);
+  await setVaultScreenshotMask(sessionId, "add", dependencies, signal);
   try {
     return await capture();
   } finally {
-    await setVaultScreenshotMask(sessionId, "remove", undefined).catch(
-      () => undefined
-    );
+    await setVaultScreenshotMask(
+      sessionId,
+      "remove",
+      dependencies,
+      undefined
+    ).catch(() => undefined);
   }
 }
 
 async function setVaultScreenshotMask(
   sessionId: string,
   action: "add" | "remove",
+  dependencies: VaultScreenshotMaskDependencies,
   signal?: AbortSignal
 ) {
   const styleId = "vault-screenshot-mask";
@@ -57,7 +76,7 @@ for (const currentContext of browser.contexts()) {
   }
 }
 return true;`;
-  const result = await kernel.browsers.playwright.execute(
+  const result = await dependencies.execute(
     sessionId,
     { code, timeout_sec: 10 },
     { signal }

--- a/agent/subagents/worker/tools/capture_browser_image.ts
+++ b/agent/subagents/worker/tools/capture_browser_image.ts
@@ -22,27 +22,27 @@ const regionSchema = z.object({
   x: z.number().int().nonnegative(),
   y: z.number().int().nonnegative(),
 });
-const commonShape = {
+const commonFields = {
   label: z.string().trim().min(1).max(200),
   session_id: z.string().min(1),
 };
 const inputSchema = z.discriminatedUnion("source", [
   z.object({
-    ...commonShape,
+    ...commonFields,
     region: regionSchema.optional(),
     source: z.literal("viewport"),
   }),
   z.object({
-    ...commonShape,
+    ...commonFields,
     source: z.literal("full_page"),
   }),
   z.object({
-    ...commonShape,
+    ...commonFields,
     selector: z.string().trim().min(1).max(2_000),
     source: z.literal("element"),
   }),
   z.object({
-    ...commonShape,
+    ...commonFields,
     selector: z.string().trim().min(1).max(2_000),
     source: z.literal("image_resource"),
   }),

--- a/agent/subagents/worker/tools/execute_playwright_code.ts
+++ b/agent/subagents/worker/tools/execute_playwright_code.ts
@@ -13,10 +13,11 @@ const inputSchema = z.object({
   session_id: z.string().min(1),
 });
 
+const browserResultSchema = z.json();
 const outputSchema = z.object({
   success: z.boolean(),
   error: z.string().optional(),
-  result: z.unknown().optional(),
+  result: browserResultSchema.optional(),
   stderr: z.string().optional(),
   stdout: z.string().optional(),
 });
@@ -41,7 +42,7 @@ export default defineTool({
     );
   },
   toModelOutput(output) {
-    const value: Record<string, unknown> = { success: output.success };
+    const value: z.output<typeof outputSchema> = { success: output.success };
     if (output.error) {
       value.error = truncate(output.error, modelLogCharacterLimit);
     }
@@ -58,7 +59,7 @@ export default defineTool({
   },
 });
 
-function boundedResult(value: unknown) {
+function boundedResult(value: z.infer<typeof browserResultSchema>) {
   const serialized = JSON.stringify(value);
   if (serialized.length <= modelResultCharacterLimit) {
     return value;

--- a/agent/subagents/worker/tools/manage_browsers.ts
+++ b/agent/subagents/worker/tools/manage_browsers.ts
@@ -42,149 +42,210 @@ const inputSchema = z.object({
   offset: z.number().int().min(0).optional(),
 });
 
-export default defineTool({
-  description:
-    'Manage browser sessions backed by the workspace persistent profile. Create read-only browsers by default so tasks can run in parallel. Immediately before a login, replace that task browser with one created using save_changes: true, then delete it after authentication so the session is saved. Only one profile writer may be active. Use "list" or "get" to inspect sessions.',
-  inputSchema,
-  async execute(input, context) {
-    const scope = await requireWorkerScope(context);
-    const signal = context.abortSignal;
+interface ManageBrowsersDependencies {
+  readonly listKernelBrowsers: (
+    profileId: string,
+    signal?: AbortSignal
+  ) => AsyncIterable<{
+    readonly profile?: { readonly id?: string };
+    readonly profile_save_changes?: boolean;
+    readonly session_id: string;
+  }>;
+}
 
-    switch (input.action) {
-      case "create": {
-        const create = async () => {
-          const profile = await ensureWorkspaceProfile(
-            scope.workspaceId,
-            signal
-          );
-          if (input.save_changes) {
-            const activeWriter = await findActiveProfileWriter(
-              profile.id,
+const defaultDependencies: ManageBrowsersDependencies = {
+  listKernelBrowsers(profileId, signal) {
+    return kernel.browsers.list(
+      { query: profileId, status: "active" },
+      { signal }
+    );
+  },
+};
+
+export const manageBrowsersDependencies = {
+  createBrowserSession,
+  deleteBrowserSession,
+  harvestBrowserTraceDomains,
+  listBrowserSessions,
+  recordBrowserTraceDomains,
+  requireOwnedBrowserSession,
+  requireWorkerScope,
+  withBrowserProfileWriteLock,
+};
+
+export function createManageBrowsers(
+  dependencies: ManageBrowsersDependencies = defaultDependencies
+) {
+  return defineTool({
+    description:
+      'Manage browser sessions backed by the workspace persistent profile. Create read-only browsers by default so tasks can run in parallel. Immediately before a login, replace that task browser with one created using save_changes: true, then delete it after authentication so the session is saved. Only one profile writer may be active. Use "list" or "get" to inspect sessions.',
+    inputSchema,
+    async execute(input, context) {
+      const scope =
+        await manageBrowsersDependencies.requireWorkerScope(context);
+      const signal = context.abortSignal;
+
+      switch (input.action) {
+        case "create": {
+          const create = async () => {
+            const profile = await ensureWorkspaceProfile(
+              scope.workspaceId,
               signal
             );
-            if (activeWriter) {
-              throw new Error(
-                `Browser session ${activeWriter.session_id} is already saving login state for this workspace. Retry after it finishes.`
+            if (input.save_changes) {
+              const activeWriter = await findActiveProfileWriter(
+                profile.id,
+                signal,
+                dependencies
               );
+              if (activeWriter) {
+                throw new Error(
+                  `Browser session ${activeWriter.session_id} is already saving login state for this workspace. Retry after it finishes.`
+                );
+              }
             }
-          }
-          const browser = await kernel.browsers.create(
-            {
-              profile: {
-                id: profile.id,
-                save_changes: input.save_changes ?? false,
+            const browser = await kernel.browsers.create(
+              {
+                profile: {
+                  id: profile.id,
+                  save_changes: input.save_changes ?? false,
+                },
+                start_url: input.start_url,
+                stealth: true,
+                telemetry: {
+                  browser: { page: { enabled: true } },
+                  enabled: true,
+                },
+                timeout_seconds:
+                  input.timeout_seconds ?? browserTimeoutFloorSeconds,
+                viewport: browserViewport(input),
               },
-              start_url: input.start_url,
-              stealth: true,
-              telemetry: {
-                browser: { page: { enabled: true } },
-                enabled: true,
-              },
-              timeout_seconds:
-                input.timeout_seconds ?? browserTimeoutFloorSeconds,
-              viewport: browserViewport(input),
-            },
-            { signal }
-          );
-          try {
-            await createBrowserSession(scope, {
-              createdAt: browser.created_at,
-              sessionId: browser.session_id,
-              workerSessionId: context.session.id,
-            });
-          } catch (error) {
-            await kernel.browsers
-              .deleteByID(browser.session_id, { signal })
-              .catch(() => undefined);
-            throw error;
-          }
-          const startDomain = input.start_url
-            ? domainFromUrl(input.start_url)
-            : undefined;
-          if (startDomain) {
-            await recordBrowserTraceDomains(scope, context.session.id, [
-              startDomain,
-            ]).catch(() => undefined);
-          }
-          return lifecycleResult(browser);
-        };
-        return input.save_changes
-          ? withBrowserProfileWriteLock(scope, create)
-          : create();
-      }
-      case "list": {
-        const records = await listBrowserSessions(scope);
-        const includeDeleted = input.status !== "active";
-        const browsers = await Promise.all(
-          records.map(async ({ sessionId }) => {
+              { signal }
+            );
             try {
-              const browser = await kernel.browsers.retrieve(
-                sessionId,
-                { include_deleted: includeDeleted },
-                { signal }
-              );
-              const value = browserDescriptor(browser);
-              if (input.status === "deleted" && value.status !== "deleted") {
-                return null;
-              }
-              if (input.status === "active" && value.status !== "active") {
-                return null;
-              }
-              return value;
+              await manageBrowsersDependencies.createBrowserSession(scope, {
+                createdAt: browser.created_at,
+                sessionId: browser.session_id,
+                workerSessionId: context.session.id,
+              });
             } catch (error) {
-              if (isNotFoundError(error)) {
-                await deleteBrowserSession(scope, sessionId);
-              }
-              return null;
+              await kernel.browsers
+                .deleteByID(browser.session_id, { signal })
+                .catch(() => undefined);
+              throw error;
             }
-          })
-        );
-        const offset = input.offset ?? 0;
-        const limit = input.limit ?? 100;
-        return {
-          has_more: false,
-          items: browsers
-            .filter((browser) => browser !== null)
-            .slice(offset, offset + limit),
-          next_offset: null,
-        };
+            const startDomain = input.start_url
+              ? domainFromUrl(input.start_url)
+              : undefined;
+            if (startDomain) {
+              await manageBrowsersDependencies
+                .recordBrowserTraceDomains(scope, context.session.id, [
+                  startDomain,
+                ])
+                .catch(() => undefined);
+            }
+            return lifecycleResult(browser);
+          };
+          return input.save_changes
+            ? manageBrowsersDependencies.withBrowserProfileWriteLock(
+                scope,
+                create
+              )
+            : create();
+        }
+        case "list": {
+          const records =
+            await manageBrowsersDependencies.listBrowserSessions(scope);
+          const includeDeleted = input.status !== "active";
+          const browsers = await Promise.all(
+            records.map(async ({ sessionId }) => {
+              try {
+                const browser = await kernel.browsers.retrieve(
+                  sessionId,
+                  { include_deleted: includeDeleted },
+                  { signal }
+                );
+                const value = browserDescriptor(browser);
+                if (input.status === "deleted" && value.status !== "deleted") {
+                  return null;
+                }
+                if (input.status === "active" && value.status !== "active") {
+                  return null;
+                }
+                return value;
+              } catch (error) {
+                if (isNotFoundError(error)) {
+                  await manageBrowsersDependencies.deleteBrowserSession(
+                    scope,
+                    sessionId
+                  );
+                }
+                return null;
+              }
+            })
+          );
+          const offset = input.offset ?? 0;
+          const limit = input.limit ?? 100;
+          return {
+            has_more: false,
+            items: browsers
+              .filter((browser) => browser !== null)
+              .slice(offset, offset + limit),
+            next_offset: null,
+          };
+        }
+        case "get": {
+          const sessionId = requireSessionId(input.session_id);
+          await manageBrowsersDependencies.requireOwnedBrowserSession(
+            scope,
+            sessionId
+          );
+          return browserDescriptor(
+            await retrieveBrowser(scope, sessionId, signal)
+          );
+        }
+        case "update": {
+          const sessionId = requireSessionId(input.session_id);
+          await manageBrowsersDependencies.requireOwnedBrowserSession(
+            scope,
+            sessionId
+          );
+          const viewport = browserViewport(input);
+          const browser = viewport
+            ? await kernel.browsers.update(sessionId, { viewport }, { signal })
+            : await retrieveBrowser(scope, sessionId, signal);
+          return lifecycleResult(browser);
+        }
+        case "delete": {
+          const sessionId = requireSessionId(input.session_id);
+          const record =
+            await manageBrowsersDependencies.requireOwnedBrowserSession(
+              scope,
+              sessionId
+            );
+          await manageBrowsersDependencies.harvestBrowserTraceDomains(
+            scope,
+            record.workerSessionId ?? context.session.id,
+            { createdAt: record.createdAt, sessionId: record.sessionId },
+            signal
+          );
+          await kernel.browsers
+            .deleteByID(sessionId, { signal })
+            .catch((cause: unknown) => {
+              if (!isNotFoundError(cause)) throw cause;
+            });
+          await manageBrowsersDependencies.deleteBrowserSession(
+            scope,
+            sessionId
+          );
+          return "Browser session deleted successfully";
+        }
       }
-      case "get": {
-        const sessionId = requireSessionId(input.session_id);
-        await requireOwnedBrowserSession(scope, sessionId);
-        return browserDescriptor(
-          await retrieveBrowser(scope, sessionId, signal)
-        );
-      }
-      case "update": {
-        const sessionId = requireSessionId(input.session_id);
-        await requireOwnedBrowserSession(scope, sessionId);
-        const viewport = browserViewport(input);
-        const browser = viewport
-          ? await kernel.browsers.update(sessionId, { viewport }, { signal })
-          : await retrieveBrowser(scope, sessionId, signal);
-        return lifecycleResult(browser);
-      }
-      case "delete": {
-        const sessionId = requireSessionId(input.session_id);
-        const record = await requireOwnedBrowserSession(scope, sessionId);
-        await harvestBrowserTraceDomains(
-          scope,
-          record.workerSessionId ?? context.session.id,
-          { createdAt: record.createdAt, sessionId: record.sessionId },
-          signal
-        );
-        await kernel.browsers
-          .deleteByID(sessionId, { signal })
-          .catch((error: unknown) => {
-            if (!isNotFoundError(error)) throw error;
-          });
-        await deleteBrowserSession(scope, sessionId);
-        return "Browser session deleted successfully";
-      }
-    }
-  },
-});
+    },
+  });
+}
+
+export default createManageBrowsers();
 
 function requireSessionId(sessionId: string | undefined) {
   if (!sessionId) throw new Error("A browser session ID is required.");
@@ -200,7 +261,7 @@ async function retrieveBrowser(
     return await kernel.browsers.retrieve(sessionId, {}, { signal });
   } catch (error) {
     if (!isNotFoundError(error)) throw error;
-    await deleteBrowserSession(scope, sessionId);
+    await manageBrowsersDependencies.deleteBrowserSession(scope, sessionId);
     throw new Error(
       "Browser session no longer exists. Its stale record was removed; create a fresh browser instead of retrying this session ID.",
       { cause: error }
@@ -208,13 +269,8 @@ async function retrieveBrowser(
   }
 }
 
-function isNotFoundError(error: unknown) {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "status" in error &&
-    error.status === 404
-  );
+function isNotFoundError(cause: unknown) {
+  return z.object({ status: z.literal(404) }).safeParse(cause).success;
 }
 
 function browserViewport(input: z.infer<typeof inputSchema>) {
@@ -281,12 +337,13 @@ async function ensureWorkspaceProfile(
 
 async function findActiveProfileWriter(
   profileId: string | undefined,
-  signal?: AbortSignal
+  signal: AbortSignal | undefined,
+  dependencies: ManageBrowsersDependencies
 ) {
   if (!profileId) return undefined;
-  for await (const browser of kernel.browsers.list(
-    { query: profileId, status: "active" },
-    { signal }
+  for await (const browser of dependencies.listKernelBrowsers(
+    profileId,
+    signal
   )) {
     if (browser.profile?.id === profileId && browser.profile_save_changes) {
       return browser;

--- a/db/services/chats.ts
+++ b/db/services/chats.ts
@@ -84,19 +84,16 @@ export async function saveChat(scope: AccessScope, chat: SaveChat) {
     });
     return;
   }
+  const updates: Partial<typeof chats.$inferInsert> = { updatedAt: now };
+  if (chat.title !== undefined) updates.title = chat.title;
+  if (chat.usage !== undefined) {
+    updates.costUsd = chat.usage.costUsd;
+    updates.inputTokens = chat.usage.inputTokens;
+    updates.outputTokens = chat.usage.outputTokens;
+  }
   await db
     .update(chats)
-    .set({
-      ...(chat.title === undefined ? {} : { title: chat.title }),
-      ...(chat.usage === undefined
-        ? {}
-        : {
-            costUsd: chat.usage.costUsd,
-            inputTokens: chat.usage.inputTokens,
-            outputTokens: chat.usage.outputTokens,
-          }),
-      updatedAt: now,
-    })
+    .set(updates)
     .where(
       and(
         eq(chats.workspaceId, scope.workspaceId),

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,4 +1,5 @@
 export default {
+  ignorePatterns: ["tools/oxlint/anti-slop/**"],
   printWidth: 80,
   semi: true,
   singleQuote: false,

--- a/src/app/(authenticated)/(manager)/chat/_components/agent-chat.tsx
+++ b/src/app/(authenticated)/(manager)/chat/_components/agent-chat.tsx
@@ -502,12 +502,12 @@ function PendingThinking() {
   );
 }
 
-function toErrorMessage(error: unknown): string {
-  if (!(error instanceof Error)) return "Unable to complete the request.";
-  if (/<!doctype html|<html[\s>]/i.test(error.message)) {
+function toErrorMessage(cause: unknown): string {
+  if (!(cause instanceof Error)) return "Unable to complete the request.";
+  if (/<!doctype html|<html[\s>]/i.test(cause.message)) {
     return "The agent runtime is unavailable. Try again in a moment.";
   }
-  return error.message;
+  return cause.message;
 }
 
 function chatTitle(message: PromptInputMessage) {

--- a/src/app/(authenticated)/(manager)/vault/page.tsx
+++ b/src/app/(authenticated)/(manager)/vault/page.tsx
@@ -5,6 +5,7 @@ import {
   parseManagerSetupSearchParams,
 } from "@/lib/manager";
 import { readManagerSnapshot } from "@/lib/manager/server/store";
+import { z } from "zod";
 
 export default async function Page({ searchParams }: PageProps<"/vault">) {
   const query = await searchParams;
@@ -28,5 +29,6 @@ export default async function Page({ searchParams }: PageProps<"/vault">) {
 }
 
 function firstQueryValue(value: string | readonly string[] | undefined) {
-  return typeof value === "string" ? value : value?.[0];
+  const scalar = z.string().safeParse(value);
+  return scalar.success ? scalar.data : value?.[0];
 }

--- a/src/app/(authenticated)/(tasks)/tasks/(overview)/_components/trace-history.tsx
+++ b/src/app/(authenticated)/(tasks)/tasks/(overview)/_components/trace-history.tsx
@@ -3,6 +3,7 @@
 import { RefreshCwIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
+import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -23,11 +24,19 @@ const statusLabels = {
   running: { className: "text-information", label: "Running" },
   success: { className: "text-success", label: "Succeeded" },
 } as const;
+const traceStatusSchema = z.enum([
+  "cancelled",
+  "error",
+  "failure",
+  "running",
+  "success",
+]);
 
 function statusLabel(status: string) {
-  return status in statusLabels
-    ? statusLabels[status as keyof typeof statusLabels]
-    : ({ className: "text-muted-foreground", label: status } as const);
+  const parsed = traceStatusSchema.safeParse(status);
+  return parsed.success
+    ? statusLabels[parsed.data]
+    : { className: "text-muted-foreground", label: status };
 }
 
 function formatDuration(durationMs: number | null) {

--- a/src/app/(authenticated)/(tasks)/tasks/[sessionId]/page.tsx
+++ b/src/app/(authenticated)/(tasks)/tasks/[sessionId]/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/db/services/browser-traces";
 import { requireRequestScope } from "@/lib/request-scope";
 import { RefreshButton } from "./_components/refresh-button";
+import { z } from "zod";
 
 const statusText = {
   cancelled: "Cancelled",
@@ -24,6 +25,13 @@ const statusText = {
   running: "Running",
   success: "Succeeded",
 } as const;
+const traceStatusSchema = z.enum([
+  "cancelled",
+  "error",
+  "failure",
+  "running",
+  "success",
+]);
 
 export default async function TraceDetailPage({
   params,
@@ -32,6 +40,7 @@ export default async function TraceDetailPage({
   const { sessionId } = await params;
   const trace = await readBrowserTrace(scope, sessionId);
   if (!trace) notFound();
+  const traceStatus = traceStatusSchema.safeParse(trace.status);
   const events = await listBrowserTraceEvents(scope, trace.sessionId);
 
   return (
@@ -53,9 +62,7 @@ export default async function TraceDetailPage({
             {trace.task}
           </h1>
           <p className="type-supporting-body mt-2 truncate text-muted-foreground">
-            {trace.status in statusText
-              ? statusText[trace.status as keyof typeof statusText]
-              : trace.status}
+            {traceStatus.success ? statusText[traceStatus.data] : trace.status}
             {trace.durationMs === null
               ? ""
               : ` · ${String(Math.round(trace.durationMs / 1000))}s`}

--- a/src/auth/linq.ts
+++ b/src/auth/linq.ts
@@ -8,6 +8,8 @@ const linqErrorResponseSchema = z.object({
   trace_id: z.string().min(1).optional(),
 });
 
+export const linqDeliveryDependencies = { getToken };
+
 export class LinqDeliveryError extends Error {
   readonly code: number | undefined;
   readonly linqMessage: string | undefined;
@@ -83,7 +85,7 @@ export async function sendLinqText({
   readonly message: string;
   readonly to: string;
 }) {
-  const token = await getToken(connector, {
+  const token = await linqDeliveryDependencies.getToken(connector, {
     subject: { type: "app" },
   });
   const response = await fetch(LINQ_MESSAGES_URL, {

--- a/src/components/ai-elements/conversation.tsx
+++ b/src/components/ai-elements/conversation.tsx
@@ -12,10 +12,20 @@ import {
   useSyncExternalStore,
 } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
+import { z } from "zod";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom> & {
   scrollRestorationKey?: string;
 };
+type ConversationRenderChild = Extract<
+  NonNullable<ConversationProps["children"]>,
+  (...args: never[]) => React.ReactNode
+>;
+
+const scrollPositionSchema = z.object({
+  atBottom: z.boolean(),
+  scrollTop: z.number(),
+});
 
 export const Conversation = ({
   children,
@@ -23,33 +33,44 @@ export const Conversation = ({
   initial,
   scrollRestorationKey,
   ...props
-}: ConversationProps) => (
-  <StickToBottom
-    className={cn("relative flex-1 overflow-y-hidden", className)}
-    initial={initial ?? (scrollRestorationKey === undefined ? "smooth" : false)}
-    resize="smooth"
-    role="log"
-    {...props}
-  >
-    {typeof children === "function" ? (
-      (context) => (
+}: ConversationProps) => {
+  const parsedRenderer = z.function().safeParse(children);
+  // SAFETY: z.function established that this branch contains the render-child member of the children union.
+  const renderChild = parsedRenderer.success
+    ? (parsedRenderer.data as ConversationRenderChild)
+    : undefined;
+  return (
+    <StickToBottom
+      className={cn("relative flex-1 overflow-y-hidden", className)}
+      initial={
+        initial ?? (scrollRestorationKey === undefined ? "smooth" : false)
+      }
+      resize="smooth"
+      role="log"
+      {...props}
+    >
+      {renderChild ? (
+        (context) => (
+          <>
+            {renderChild(context)}
+            {scrollRestorationKey === undefined ? null : (
+              <ConversationScrollRestoration
+                storageKey={scrollRestorationKey}
+              />
+            )}
+          </>
+        )
+      ) : (
         <>
-          {children(context)}
+          {children}
           {scrollRestorationKey === undefined ? null : (
             <ConversationScrollRestoration storageKey={scrollRestorationKey} />
           )}
         </>
-      )
-    ) : (
-      <>
-        {children}
-        {scrollRestorationKey === undefined ? null : (
-          <ConversationScrollRestoration storageKey={scrollRestorationKey} />
-        )}
-      </>
-    )}
-  </StickToBottom>
-);
+      )}
+    </StickToBottom>
+  );
+};
 
 function ConversationScrollRestoration({
   storageKey,
@@ -115,14 +136,8 @@ function readScrollPosition(value: string | null):
   | undefined {
   if (value === null) return undefined;
   try {
-    const parsed = JSON.parse(value) as {
-      atBottom?: unknown;
-      scrollTop?: unknown;
-    };
-    return typeof parsed.atBottom === "boolean" &&
-      typeof parsed.scrollTop === "number"
-      ? { atBottom: parsed.atBottom, scrollTop: parsed.scrollTop }
-      : undefined;
+    const parsed = scrollPositionSchema.safeParse(JSON.parse(value));
+    return parsed.success ? parsed.data : undefined;
   } catch {
     return undefined;
   }

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -27,6 +27,7 @@ import {
   useState,
 } from "react";
 import { Streamdown, type Components } from "streamdown";
+import { z } from "zod";
 import { isBrowserImageArtifactUrl } from "@/lib/browser-image-path";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
@@ -331,7 +332,8 @@ export function ArtifactMessageImage({
   ...props
 }: ComponentProps<"img"> & { readonly node?: unknown }) {
   void _node;
-  if (typeof src !== "string" || !isBrowserImageArtifactUrl(src)) {
+  const parsedSource = z.string().safeParse(src);
+  if (!parsedSource.success || !isBrowserImageArtifactUrl(parsedSource.data)) {
     return (
       <span className="text-muted-foreground">
         Image not displayed: {alt || "external image"}
@@ -340,7 +342,7 @@ export function ArtifactMessageImage({
   }
 
   return (
-    <a href={src} rel="noreferrer" target="_blank">
+    <a href={parsedSource.data} rel="noreferrer" target="_blank">
       <img
         {...props}
         alt={alt || "Browser image"}

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -52,6 +52,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { nanoid } from "nanoid";
+import { z } from "zod";
 import type {
   ChangeEvent,
   ChangeEventHandler,
@@ -88,6 +89,7 @@ const convertBlobUrlToDataUrl = async (url: string): Promise<string | null> => {
     // FileReader uses callback-based API, wrapping in Promise is necessary
     return new Promise((resolve) => {
       const reader = new FileReader();
+      // SAFETY: FileReader.result is a string because readAsDataURL is the only read operation used here.
       reader.onloadend = () => resolve(reader.result as string);
       reader.onerror = () => resolve(null);
       reader.readAsDataURL(blob);
@@ -600,13 +602,13 @@ export const PromptInput = ({
       }
 
       setItems((prev) => {
-        const capacity =
-          typeof maxFiles === "number"
-            ? Math.max(0, maxFiles - prev.length)
-            : undefined;
+        const maximum = z.number().safeParse(maxFiles);
+        const capacity = maximum.success
+          ? Math.max(0, maximum.data - prev.length)
+          : undefined;
         const capped =
-          typeof capacity === "number" ? sized.slice(0, capacity) : sized;
-        if (typeof capacity === "number" && sized.length > capacity) {
+          capacity === undefined ? sized : sized.slice(0, capacity);
+        if (capacity !== undefined && sized.length > capacity) {
           onError?.({
             code: "max_files",
             message: "Too many files. Some were not added.",
@@ -664,13 +666,12 @@ export const PromptInput = ({
       }
 
       const currentCount = files.length;
-      const capacity =
-        typeof maxFiles === "number"
-          ? Math.max(0, maxFiles - currentCount)
-          : undefined;
-      const capped =
-        typeof capacity === "number" ? sized.slice(0, capacity) : sized;
-      if (typeof capacity === "number" && sized.length > capacity) {
+      const maximum = z.number().safeParse(maxFiles);
+      const capacity = maximum.success
+        ? Math.max(0, maximum.data - currentCount)
+        : undefined;
+      const capped = capacity === undefined ? sized : sized.slice(0, capacity);
+      if (capacity !== undefined && sized.length > capacity) {
         onError?.({
           code: "max_files",
           message: "Too many files. Some were not added.",
@@ -852,7 +853,7 @@ export const PromptInput = ({
         ? controller.textInput.value
         : (() => {
             const formData = new FormData(form);
-            return (formData.get("message") as string) || "";
+            return z.string().catch("").parse(formData.get("message"));
           })();
 
       // Reset form immediately after capturing text to avoid race condition
@@ -987,9 +988,9 @@ export const PromptInputTextarea = ({
 
         // Check if the submit button is disabled before submitting
         const { form } = e.currentTarget;
-        const submitButton = form?.querySelector(
+        const submitButton = form?.querySelector<HTMLButtonElement>(
           'button[type="submit"]'
-        ) as HTMLButtonElement | null;
+        );
         if (submitButton?.disabled) {
           return;
         }
@@ -1150,10 +1151,16 @@ export const PromptInputButton = ({
     return button;
   }
 
-  const tooltipContent =
-    typeof tooltip === "string" ? tooltip : tooltip.content;
-  const shortcut = typeof tooltip === "string" ? undefined : tooltip.shortcut;
-  const side = typeof tooltip === "string" ? "top" : (tooltip.side ?? "top");
+  const tooltipText = z.string().safeParse(tooltip);
+  // SAFETY: A failed string parse leaves only the object member of the declared tooltip union.
+  const tooltipOptions = tooltipText.success
+    ? undefined
+    : (tooltip as Exclude<PromptInputButtonTooltip, string>);
+  const tooltipContent = tooltipText.success
+    ? tooltipText.data
+    : tooltipOptions?.content;
+  const shortcut = tooltipOptions?.shortcut;
+  const side = tooltipOptions?.side ?? "top";
 
   return (
     <Tooltip>
@@ -1246,6 +1253,7 @@ export const PromptInputSubmit = ({
         onStop();
         return;
       }
+      // SAFETY: InputGroupButton exposes the same button click event contract used by this wrapper.
       (onClick as React.MouseEventHandler<HTMLButtonElement> | undefined)?.(e);
     },
     [isGenerating, onStop, onClick]

--- a/src/components/ai-elements/shimmer.tsx
+++ b/src/components/ai-elements/shimmer.tsx
@@ -27,6 +27,7 @@ const ShimmerComponent = ({
   duration = 2,
   spread = 2,
 }: TextShimmerProps) => {
+  // SAFETY: The public `as` prop is constrained to React element types accepted by motion.create.
   const MotionComponent = m.create(Component as keyof JSX.IntrinsicElements);
 
   const dynamicSpread = useMemo(
@@ -45,6 +46,7 @@ const ShimmerComponent = ({
         )}
         initial={{ backgroundPosition: "100% center" }}
         style={
+          // SAFETY: CSSProperties omits repository-owned custom properties even though React passes them through.
           {
             "--spread": `${dynamicSpread}px`,
             backgroundImage:

--- a/src/components/ai-elements/tool.tsx
+++ b/src/components/ai-elements/tool.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { isValidElement } from "react";
+import { z } from "zod";
 
 type ToolStatus = DynamicToolUIPart["state"];
 
@@ -167,10 +168,11 @@ function ToolOutput({
 }: ToolOutputProps) {
   if (output === undefined && !errorText) return null;
 
+  const text = z.string().safeParse(output);
   const content = isValidElement(output)
     ? output
-    : typeof output === "string"
-      ? output
+    : text.success
+      ? text.data
       : JSON.stringify(output, null, 2);
 
   return (
@@ -184,7 +186,7 @@ function ToolOutput({
           errorText && "bg-destructive/10 text-destructive"
         )}
       >
-        {errorText ?? (content as ReactNode)}
+        {errorText ?? content}
       </div>
     </div>
   );

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -26,6 +26,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { PanelLeftIcon } from "lucide-react";
+import { z } from "zod";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -33,6 +34,10 @@ const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+const sidebarStateUpdaterSchema = z.function({
+  input: [z.boolean()],
+  output: z.boolean(),
+});
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed";
@@ -77,7 +82,10 @@ function SidebarProvider({
   const open = openProp ?? _open;
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
-      const openState = typeof value === "function" ? value(open) : value;
+      const booleanValue = z.boolean().safeParse(value);
+      const openState = booleanValue.success
+        ? booleanValue.data
+        : sidebarStateUpdaterSchema.parse(value)(open);
       if (setOpenProp) {
         setOpenProp(openState);
       } else {
@@ -133,6 +141,7 @@ function SidebarProvider({
       <div
         data-slot="sidebar-wrapper"
         style={
+          // SAFETY: CSSProperties omits repository-owned custom properties even though React passes them through.
           {
             "--sidebar-width": SIDEBAR_WIDTH,
             "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
@@ -191,6 +200,7 @@ function Sidebar({
           data-mobile="true"
           className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
           style={
+            // SAFETY: CSSProperties omits repository-owned custom properties even though React passes them through.
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
             } as React.CSSProperties
@@ -533,11 +543,11 @@ function SidebarMenuButton({
     return comp;
   }
 
-  if (typeof tooltip === "string") {
-    tooltip = {
-      children: tooltip,
-    };
-  }
+  const tooltipText = z.string().safeParse(tooltip);
+  // SAFETY: A failed string parse leaves only TooltipContent's object props in the declared union.
+  const tooltipProps = tooltipText.success
+    ? { children: tooltipText.data }
+    : (tooltip as React.ComponentProps<typeof TooltipContent>);
 
   return (
     <Tooltip>
@@ -546,7 +556,7 @@ function SidebarMenuButton({
         side="right"
         align="center"
         hidden={state !== "collapsed" || isMobile}
-        {...tooltip}
+        {...tooltipProps}
       />
     </Tooltip>
   );
@@ -628,6 +638,7 @@ function SidebarMenuSkeleton({
         className="h-4 max-w-(--skeleton-width) flex-1"
         data-sidebar="menu-skeleton-text"
         style={
+          // SAFETY: CSSProperties omits repository-owned custom properties even though React passes them through.
           {
             "--skeleton-width": width,
           } as React.CSSProperties

--- a/src/lib/browser-images/server.ts
+++ b/src/lib/browser-images/server.ts
@@ -14,6 +14,14 @@ import { env } from "@/lib/env";
 
 const blobOptions = { access: "private" as const };
 
+export const browserImageServerDependencies = {
+  del,
+  finalizeBrowserImageArtifact,
+  get,
+  put,
+  readReadyBrowserImageArtifact,
+};
+
 export function browserImageBlobAuthentication(input: {
   readonly readWriteToken?: string;
   readonly storeId?: string;
@@ -56,26 +64,35 @@ export async function persistReservedBrowserImage(
   const contentHash = createHash("sha256").update(input.bytes).digest("hex");
   const attemptPathname = `${reservation.storagePathname}/${contentHash}`;
 
-  await put(attemptPathname, Buffer.from(input.bytes), {
-    ...blobOptions,
-    ...blobAuthentication(),
-    abortSignal: signal,
-    addRandomSuffix: false,
-    allowOverwrite: true,
-    cacheControlMaxAge: 30 * 24 * 60 * 60,
-    contentType: mediaType,
-    maximumSizeInBytes: maximumBrowserImageBytes,
-  });
+  await browserImageServerDependencies.put(
+    attemptPathname,
+    Buffer.from(input.bytes),
+    {
+      ...blobOptions,
+      ...blobAuthentication(),
+      abortSignal: signal,
+      addRandomSuffix: false,
+      allowOverwrite: true,
+      cacheControlMaxAge: 30 * 24 * 60 * 60,
+      contentType: mediaType,
+      maximumSizeInBytes: maximumBrowserImageBytes,
+    }
+  );
 
   try {
-    const finalized = await finalizeBrowserImageArtifact(scope, reservation, {
-      byteSize: input.bytes.byteLength,
-      contentHash,
-      filename: input.filename,
-      mediaType,
-      sourceKind: input.sourceKind,
-      storagePathname: attemptPathname,
-    });
+    const finalized =
+      await browserImageServerDependencies.finalizeBrowserImageArtifact(
+        scope,
+        reservation,
+        {
+          byteSize: input.bytes.byteLength,
+          contentHash,
+          filename: input.filename,
+          mediaType,
+          sourceKind: input.sourceKind,
+          storagePathname: attemptPathname,
+        }
+      );
     if (finalized.storagePathname !== attemptPathname) {
       await deleteBlob(attemptPathname);
     }
@@ -87,7 +104,9 @@ export async function persistReservedBrowserImage(
 }
 
 async function deleteBlob(pathname: string) {
-  await del(pathname, blobAuthentication()).catch(() => undefined);
+  await browserImageServerDependencies
+    .del(pathname, blobAuthentication())
+    .catch(() => undefined);
 }
 
 export async function getBrowserImageBlob(
@@ -99,9 +118,12 @@ export async function getBrowserImageBlob(
     readonly signal?: AbortSignal;
   } = {}
 ) {
-  const artifact = await readReadyBrowserImageArtifact(scope, artifactId, {
-    rootSessionId: options.rootSessionId,
-  });
+  const artifact =
+    await browserImageServerDependencies.readReadyBrowserImageArtifact(
+      scope,
+      artifactId,
+      { rootSessionId: options.rootSessionId }
+    );
   if (!artifact) return undefined;
   const { byteSize, contentHash, filename, mediaType } = artifact;
   if (!byteSize || !contentHash || !filename || !mediaType) return undefined;
@@ -112,12 +134,15 @@ export async function getBrowserImageBlob(
     filename,
     mediaType,
   };
-  const result = await get(artifact.storagePathname, {
-    ...blobOptions,
-    ...blobAuthentication(),
-    abortSignal: options.signal,
-    ifNoneMatch: options.ifNoneMatch,
-  });
+  const result = await browserImageServerDependencies.get(
+    artifact.storagePathname,
+    {
+      ...blobOptions,
+      ...blobAuthentication(),
+      abortSignal: options.signal,
+      ifNoneMatch: options.ifNoneMatch,
+    }
+  );
   if (!result) return undefined;
   if (
     result.statusCode === 200 &&

--- a/src/lib/browser/benchmark.ts
+++ b/src/lib/browser/benchmark.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { MessageStreamEvent } from "eve/client";
-import { parseTaskCompletionOutput } from "../task-completion";
+import { taskCompletionOutputSchema } from "../task-completion";
 
 const workerTaskNotificationPrefix = /^Background task (\S+) \(worker\) /u;
 const terminalTaskControlSchema = z.object({
@@ -104,8 +104,10 @@ export function readTaskCompletion(events: readonly MessageStreamEvent[]) {
 
     const latest = backgroundTasks.at(-1);
     if (latest?.status === "completed" && latest.output && latest.terminalAt) {
-      const completion = parseTaskCompletionOutput(latest.output);
-      if (completion) return { ...completion, completedAt: latest.terminalAt };
+      const completion = taskCompletionOutputSchema.safeParse(latest.output);
+      if (completion.success) {
+        return { ...completion.data, completedAt: latest.terminalAt };
+      }
     }
     return undefined;
   }
@@ -116,8 +118,12 @@ export function readTaskCompletion(events: readonly MessageStreamEvent[]) {
         event.data.subagentName === "worker" &&
         event.data.backgroundTask === undefined
       ) {
-        const completion = parseTaskCompletionOutput(event.data.output);
-        if (completion) return { ...completion, completedAt: event.meta.at };
+        const completion = taskCompletionOutputSchema.safeParse(
+          event.data.output
+        );
+        if (completion.success) {
+          return { ...completion.data, completedAt: event.meta.at };
+        }
       }
       continue;
     }
@@ -132,8 +138,10 @@ export function readTaskCompletion(events: readonly MessageStreamEvent[]) {
         result.subagentName === "worker" &&
         (result.origin !== "child" || result.backgroundTask === undefined)
       ) {
-        const completion = parseTaskCompletionOutput(result.output);
-        if (completion) return { ...completion, completedAt: event.meta.at };
+        const completion = taskCompletionOutputSchema.safeParse(result.output);
+        if (completion.success) {
+          return { ...completion.data, completedAt: event.meta.at };
+        }
       }
       continue;
     }

--- a/src/lib/google-workspace/server.ts
+++ b/src/lib/google-workspace/server.ts
@@ -7,21 +7,25 @@ import {
 } from "@vercel/connect";
 import type { AccessScope } from "@/lib/access-scope";
 import { env } from "@/lib/env";
+import { z } from "zod";
 import { googleWorkspaceSubject, googleWorkspaceTokenParams } from "./config";
+
+export const googleWorkspaceServerDependencies = {
+  getTokenResponse,
+  revokeToken,
+  startAuthorization,
+};
 
 export async function getGoogleWorkspaceConnection(scope: AccessScope) {
   try {
-    const response = await getTokenResponse(
+    const response = await googleWorkspaceServerDependencies.getTokenResponse(
       env.GOOGLE_CONNECTOR_UID,
       googleWorkspaceTokenParams(scope.userId),
       { forceRefresh: true }
     );
+    const email = z.string().safeParse(response.claims?.email);
     return {
-      accountLabel:
-        response.name ??
-        (typeof response.claims?.email === "string"
-          ? response.claims.email
-          : null),
+      accountLabel: response.name ?? (email.success ? email.data : null),
       state: "connected" as const,
     };
   } catch (error) {
@@ -39,16 +43,20 @@ export async function startGoogleWorkspaceAuthorization(
   scope: AccessScope,
   callbackUrl: string
 ) {
-  const authorization = await startAuthorization(
-    env.GOOGLE_CONNECTOR_UID,
-    googleWorkspaceTokenParams(scope.userId),
-    { callbackUrl, expiresInMs: 10 * 60_000 }
-  );
+  const authorization =
+    await googleWorkspaceServerDependencies.startAuthorization(
+      env.GOOGLE_CONNECTOR_UID,
+      googleWorkspaceTokenParams(scope.userId),
+      { callbackUrl, expiresInMs: 10 * 60_000 }
+    );
   return authorization.url;
 }
 
 export async function disconnectGoogleWorkspace(scope: AccessScope) {
-  await revokeToken(env.GOOGLE_CONNECTOR_UID, {
-    subject: googleWorkspaceSubject(scope.userId),
-  });
+  await googleWorkspaceServerDependencies.revokeToken(
+    env.GOOGLE_CONNECTOR_UID,
+    {
+      subject: googleWorkspaceSubject(scope.userId),
+    }
+  );
 }

--- a/src/lib/manager/index.ts
+++ b/src/lib/manager/index.ts
@@ -162,5 +162,6 @@ export function createManagerImportUrl(baseUrl: string) {
 }
 
 function firstQueryValue(value: string | readonly string[] | undefined) {
-  return typeof value === "string" ? value : value?.[0];
+  const scalar = z.string().safeParse(value);
+  return scalar.success ? scalar.data : value?.[0];
 }

--- a/src/lib/manager/server/kernel-native-autofill.ts
+++ b/src/lib/manager/server/kernel-native-autofill.ts
@@ -23,6 +23,15 @@ const targetListSchema = z.object({
 
 const attachedTargetSchema = z.object({ sessionId: z.string() });
 
+type CdpCommandValue =
+  | boolean
+  | number
+  | string
+  | null
+  | undefined
+  | readonly CdpCommandValue[]
+  | { readonly [key: string]: CdpCommandValue };
+
 const frameTreeSchema = z.object({
   frameTree: z.lazy(() => frameTreeNodeSchema),
 });
@@ -35,8 +44,9 @@ const frameTreeNodeSchema: z.ZodType<{
 });
 
 const isolatedWorldSchema = z.object({ executionContextId: z.number() });
+const cdpValueSchema = z.json();
 const evaluatedValueSchema = z.object({
-  result: z.object({ value: z.unknown() }),
+  result: z.object({ value: cdpValueSchema }),
 });
 const evaluatedBooleanSchema = z.object({
   result: z.object({ value: z.boolean() }),
@@ -577,8 +587,10 @@ class CdpConnection {
   readonly #pending = new Map<
     number,
     {
-      readonly reject: (reason?: unknown) => void;
-      readonly resolve: (value: unknown) => void;
+      readonly reject: (cause?: unknown) => void;
+      readonly resolve: (
+        value: z.infer<typeof cdpValueSchema> | undefined
+      ) => void;
     }
   >();
   #nextId = 1;
@@ -634,29 +646,31 @@ class CdpConnection {
     return new CdpConnection(socket, signal);
   }
 
-  send(method: string, params?: object, sessionId?: string) {
+  send(method: string, params?: CdpCommandValue, sessionId?: string) {
     const id = this.#nextId++;
-    return new Promise<unknown>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.#pending.delete(id);
-        reject(new Error(`Chromium did not respond to ${method}.`));
-      }, 15_000);
-      this.#pending.set(id, {
-        reject(reason) {
-          clearTimeout(timeout);
-          reject(
-            reason instanceof Error
-              ? reason
-              : new Error("The Chromium command failed.")
-          );
-        },
-        resolve(value) {
-          clearTimeout(timeout);
-          resolve(value);
-        },
-      });
-      this.socket.send(JSON.stringify({ id, method, params, sessionId }));
-    });
+    return new Promise<z.infer<typeof cdpValueSchema> | undefined>(
+      (resolve, reject) => {
+        const timeout = setTimeout(() => {
+          this.#pending.delete(id);
+          reject(new Error(`Chromium did not respond to ${method}.`));
+        }, 15_000);
+        this.#pending.set(id, {
+          reject(cause) {
+            clearTimeout(timeout);
+            reject(
+              cause instanceof Error
+                ? cause
+                : new Error("The Chromium command failed.")
+            );
+          },
+          resolve(value) {
+            clearTimeout(timeout);
+            resolve(value);
+          },
+        });
+        this.socket.send(JSON.stringify({ id, method, params, sessionId }));
+      }
+    );
   }
 
   close() {
@@ -664,10 +678,13 @@ class CdpConnection {
   }
 
   #onMessage(event: MessageEvent) {
-    if (typeof event.data !== "string") return;
-    let rawMessage: unknown;
+    const eventData = z.string().safeParse(event.data);
+    if (!eventData.success) return;
+    let rawMessage: z.infer<typeof cdpValueSchema>;
     try {
-      rawMessage = JSON.parse(event.data);
+      const parsed = cdpValueSchema.safeParse(JSON.parse(eventData.data));
+      if (!parsed.success) return;
+      rawMessage = parsed.data;
     } catch {
       return;
     }
@@ -692,7 +709,7 @@ class CdpConnection {
 const cdpResponseSchema = z.object({
   error: z.object({ message: z.string() }).optional(),
   id: z.number().int().optional(),
-  result: z.unknown().optional(),
+  result: cdpValueSchema.optional(),
 });
 
 function flattenFrames(

--- a/src/lib/task-completion.ts
+++ b/src/lib/task-completion.ts
@@ -16,18 +16,22 @@ const historicalTaskCompletionSchema = taskCompletionSchema.omit({
   images: true,
 });
 
-export function parseTaskCompletionOutput(output: unknown) {
-  let value = output;
-  if (typeof value === "string") {
+export const taskCompletionOutputSchema = z.preprocess(
+  (input) => {
+    const text = z.string().safeParse(input);
+    if (!text.success) return input;
     try {
-      value = JSON.parse(value) as unknown;
+      const parsed = z.json().safeParse(JSON.parse(text.data));
+      return parsed.success ? parsed.data : input;
     } catch {
-      return undefined;
+      return input;
     }
-  }
-
-  const current = taskCompletionSchema.safeParse(value);
-  if (current.success) return current.data;
-  const historical = historicalTaskCompletionSchema.safeParse(value);
-  return historical.success ? { ...historical.data, images: [] } : undefined;
-}
+  },
+  z.union([
+    taskCompletionSchema,
+    historicalTaskCompletionSchema.transform((value) => ({
+      ...value,
+      images: [],
+    })),
+  ])
+);

--- a/src/trpc/router.test.ts
+++ b/src/trpc/router.test.ts
@@ -1,39 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AccessScope } from "@/lib/access-scope";
+import { appRouter, routerDependencies } from "./router";
 
-const mocks = vi.hoisted(() => ({
-  applyManagerMutation:
-    vi.fn<(scope: AccessScope, input: unknown) => Promise<unknown>>(),
-  disconnectGoogleWorkspace: vi.fn<(scope: AccessScope) => Promise<void>>(),
-  readModelCatalog: vi.fn<() => Promise<unknown[]>>(),
-  listBrowserTraces:
-    vi.fn<
-      (
-        scope: AccessScope,
-        cursor?: string
-      ) => Promise<{ nextCursor: string | null; traces: never[] }>
-    >(),
-  saveChat: vi.fn<(scope: AccessScope, input: unknown) => Promise<void>>(),
-  startGoogleWorkspaceAuthorization:
-    vi.fn<(scope: AccessScope, callbackUrl: string) => Promise<string>>(),
-}));
-
-vi.mock("@/lib/model-catalog/server", () => ({
-  readModelCatalog: mocks.readModelCatalog,
-}));
-vi.mock("@/db/services/browser-traces", () => ({
-  listBrowserTraces: mocks.listBrowserTraces,
-}));
-vi.mock("@/db/services/chats", () => ({ saveChat: mocks.saveChat }));
-vi.mock("@/lib/google-workspace/server", () => ({
-  disconnectGoogleWorkspace: mocks.disconnectGoogleWorkspace,
-  startGoogleWorkspaceAuthorization: mocks.startGoogleWorkspaceAuthorization,
-}));
-vi.mock("@/lib/manager/server/store", () => ({
-  applyManagerMutation: mocks.applyManagerMutation,
-}));
-
-import { appRouter } from "./router";
+const disconnectGoogleWorkspaceMock = vi.spyOn(
+  routerDependencies,
+  "disconnectGoogleWorkspace"
+);
+const listBrowserTracesMock = vi.spyOn(routerDependencies, "listBrowserTraces");
+const saveChatMock = vi.spyOn(routerDependencies, "saveChat");
+const startGoogleWorkspaceAuthorizationMock = vi.spyOn(
+  routerDependencies,
+  "startGoogleWorkspaceAuthorization"
+);
 
 const scope = {
   userId: "user-1",
@@ -44,7 +22,7 @@ describe("appRouter", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("passes the authenticated scope and cursor to the trace history", async () => {
-    mocks.listBrowserTraces.mockResolvedValue({
+    listBrowserTracesMock.mockResolvedValue({
       nextCursor: null,
       traces: [],
     });
@@ -53,7 +31,7 @@ describe("appRouter", () => {
       .createCaller({ origin: "https://example.com", scope })
       .traces.list({ cursor: "next-page" });
 
-    expect(mocks.listBrowserTraces).toHaveBeenCalledWith(scope, "next-page");
+    expect(listBrowserTracesMock).toHaveBeenCalledWith(scope, "next-page");
   });
 
   it("rejects invalid chat writes before persistence", async () => {
@@ -62,11 +40,11 @@ describe("appRouter", () => {
         .createCaller({ origin: "https://example.com", scope })
         .chats.save({ sessionId: "" })
     ).rejects.toThrow("Too small");
-    expect(mocks.saveChat).not.toHaveBeenCalled();
+    expect(saveChatMock).not.toHaveBeenCalled();
   });
 
   it("returns a typed Google authorization redirect", async () => {
-    mocks.startGoogleWorkspaceAuthorization.mockResolvedValue(
+    startGoogleWorkspaceAuthorizationMock.mockResolvedValue(
       "https://accounts.google.com/authorize"
     );
 
@@ -74,7 +52,7 @@ describe("appRouter", () => {
       .createCaller({ origin: "https://example.com", scope })
       .googleWorkspace.update("connect");
 
-    expect(mocks.startGoogleWorkspaceAuthorization).toHaveBeenCalledWith(
+    expect(startGoogleWorkspaceAuthorizationMock).toHaveBeenCalledWith(
       scope,
       "https://example.com/?google=connected"
     );
@@ -84,7 +62,7 @@ describe("appRouter", () => {
   });
 
   it("surfaces Google connector failures", async () => {
-    mocks.disconnectGoogleWorkspace.mockRejectedValue(
+    disconnectGoogleWorkspaceMock.mockRejectedValue(
       new Error("connector unavailable")
     );
 

--- a/src/trpc/router.ts
+++ b/src/trpc/router.ts
@@ -12,28 +12,40 @@ import { managerMutationSchema, managerSnapshotSchema } from "@/lib/manager";
 import { applyManagerMutation } from "@/lib/manager/server/store";
 import { createTRPCRouter, protectedProcedure } from "./init";
 
+export const routerDependencies = {
+  applyManagerMutation,
+  disconnectGoogleWorkspace,
+  listBrowserTraces,
+  readModelCatalog,
+  saveChat,
+  startGoogleWorkspaceAuthorization,
+};
+
 export const appRouter = createTRPCRouter({
   chats: {
     save: protectedProcedure
       .input(saveChatSchema)
-      .mutation(({ ctx, input }) => saveChat(ctx.scope, input)),
+      .mutation(({ ctx, input }) =>
+        routerDependencies.saveChat(ctx.scope, input)
+      ),
   },
   googleWorkspace: {
     update: protectedProcedure
       .input(googleWorkspaceActionSchema)
       .mutation(async ({ ctx, input }) => {
         if (input === "disconnect") {
-          await disconnectGoogleWorkspace(ctx.scope);
+          await routerDependencies.disconnectGoogleWorkspace(ctx.scope);
           return { redirectTo: "/?google=disconnected" };
         }
 
         const callbackUrl = new URL("/", ctx.origin);
         callbackUrl.searchParams.set("google", "connected");
         return {
-          redirectTo: await startGoogleWorkspaceAuthorization(
-            ctx.scope,
-            callbackUrl.toString()
-          ),
+          redirectTo:
+            await routerDependencies.startGoogleWorkspaceAuthorization(
+              ctx.scope,
+              callbackUrl.toString()
+            ),
         };
       }),
   },
@@ -41,16 +53,21 @@ export const appRouter = createTRPCRouter({
     mutate: protectedProcedure
       .input(managerMutationSchema)
       .output(managerSnapshotSchema)
-      .mutation(({ ctx, input }) => applyManagerMutation(ctx.scope, input)),
+      .mutation(({ ctx, input }) =>
+        routerDependencies.applyManagerMutation(ctx.scope, input)
+      ),
   },
   models: {
-    list: protectedProcedure.query(readModelCatalog),
+    list: protectedProcedure.query(routerDependencies.readModelCatalog),
   },
   traces: {
     list: protectedProcedure
       .input(z.object({ cursor: z.string().nullish() }))
       .query(({ ctx, input }) =>
-        listBrowserTraces(ctx.scope, input.cursor ?? undefined)
+        routerDependencies.listBrowserTraces(
+          ctx.scope,
+          input.cursor ?? undefined
+        )
       ),
   },
 });

--- a/tests/auth-linq.test.ts
+++ b/tests/auth-linq.test.ts
@@ -1,10 +1,10 @@
-import { getToken } from "@vercel/connect";
 import { APIError } from "better-auth/api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { phoneOtpErrorMessage } from "@/app/sign-in/phone-auth-form";
+import { linqDeliveryDependencies } from "@/auth/linq";
 
-vi.mock("@vercel/connect", () => ({ getToken: vi.fn<typeof getToken>() }));
+const getTokenMock = vi.spyOn(linqDeliveryDependencies, "getToken");
 
 const linqApiErrorSchema = z.object({
   code: z.string(),
@@ -19,7 +19,7 @@ const linqApiErrorSchema = z.object({
 
 describe("Linq phone authentication", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   });
@@ -31,7 +31,7 @@ describe("Linq phone authentication", () => {
     );
     vi.stubEnv("LINQ_CONNECTOR", "linq/open-instinct");
     vi.stubEnv("LINQ_PHONE_NUMBER", "+12025550123");
-    vi.mocked(getToken).mockResolvedValue("test-token");
+    getTokenMock.mockResolvedValue("test-token");
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>().mockResolvedValue(
@@ -50,7 +50,7 @@ describe("Linq phone authentication", () => {
     const error: unknown = await sendPhoneCode({
       code: "123456",
       to: "+12025550123",
-    }).catch((caught: unknown) => caught);
+    }).catch((cause: unknown) => cause);
 
     expect(error).toBeInstanceOf(APIError);
     if (!(error instanceof APIError)) throw new TypeError("Expected APIError");

--- a/tests/auth-session.test.ts
+++ b/tests/auth-session.test.ts
@@ -1,22 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const mocks = vi.hoisted(() => ({
-  getSession: vi.fn<
-    (_input: { headers: Headers }) => Promise<{
-      user: {
-        id: string;
-        phoneNumber?: string | null;
-        phoneNumberVerified?: boolean | null;
-      };
-    } | null>
-  >(),
-}));
-
-vi.mock("@/auth", () => ({
-  auth: { api: { getSession: mocks.getSession } },
-}));
-
+import { auth } from "@/auth";
 import { getAuthSession } from "@/auth/session";
+import { authSessionFor } from "./helpers/auth-session";
+
+const getSessionMock = vi.spyOn(auth.api, "getSession");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -24,25 +11,23 @@ beforeEach(() => {
 
 describe("auth session", () => {
   it("returns only sessions backed by a verified phone number", async () => {
-    const verified = {
-      user: {
-        id: "user-1",
-        phoneNumber: "+12025550123",
-        phoneNumberVerified: true,
-      },
-    };
-    mocks.getSession
+    const verified = authSessionFor({
+      id: "user-1",
+      phoneNumber: "+12025550123",
+      phoneNumberVerified: true,
+    });
+    getSessionMock
       .mockResolvedValueOnce(verified)
-      .mockResolvedValueOnce({
-        user: {
+      .mockResolvedValueOnce(
+        authSessionFor({
           id: "user-2",
           phoneNumber: "+12025550124",
           phoneNumberVerified: false,
-        },
-      })
-      .mockResolvedValueOnce({
-        user: { id: "user-3", phoneNumberVerified: true },
-      });
+        })
+      )
+      .mockResolvedValueOnce(
+        authSessionFor({ id: "user-3", phoneNumberVerified: true })
+      );
 
     const headers = new Headers();
     await expect(getAuthSession(headers)).resolves.toBe(verified);

--- a/tests/browser-image-route.test.ts
+++ b/tests/browser-image-route.test.ts
@@ -1,32 +1,80 @@
 /* oxlint-disable vitest/require-mock-type-parameters -- Hoisted auth and storage fakes are configured per test. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as AuthSession from "@/auth/session";
+import { GET } from "@/app/artifacts/[artifactId]/route";
+import * as BrowserImageServer from "@/lib/browser-images/server";
+import { authSessionFor } from "./helpers/auth-session";
 
 const artifactId = "0d01e667-d128-4bb7-a248-1ae21db72f4f";
 const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-const mocks = vi.hoisted(() => ({ getAuthSession: vi.fn(), getBlob: vi.fn() }));
+const getAuthSessionMock = vi.spyOn(AuthSession, "getAuthSession");
+const getBlobMock = vi.spyOn(BrowserImageServer, "getBrowserImageBlob");
+type OpenedBrowserImage = NonNullable<
+  Awaited<ReturnType<typeof BrowserImageServer.getBrowserImageBlob>>
+>;
 
-vi.mock("@/auth/session", () => ({ getAuthSession: mocks.getAuthSession }));
-vi.mock("@/lib/browser-images/server", () => ({
-  getBrowserImageBlob: mocks.getBlob,
-}));
-
-import { GET } from "@/app/artifacts/[artifactId]/route";
+function openedBrowserImage(statusCode: 200 | 304): OpenedBrowserImage {
+  const stream = statusCode === 200 ? new Response(png).body : null;
+  const artifact = {
+    browserSessionId: "browser-1",
+    byteSize: png.byteLength,
+    contentHash: "content-hash",
+    createdAt: "2026-08-31T00:00:00.000Z",
+    createdByUserId: "user-1",
+    filename: "Product image.png",
+    id: artifactId,
+    idempotencyKey: "image-call-1",
+    label: "Product image",
+    mediaType: "image/png",
+    rootSessionId: "root-session",
+    sourceKind: "viewport",
+    status: "ready",
+    storagePathname: `browser-images/workspace/${artifactId}`,
+    workerSessionId: "worker-1",
+    workspaceId: "workspace-1",
+  };
+  const blob = {
+    cacheControl: "private, max-age=3600",
+    contentDisposition: 'inline; filename="Product image.png"',
+    downloadUrl: "https://blob.example/download",
+    etag: '"etag"',
+    pathname: `browser-images/workspace/${artifactId}`,
+    uploadedAt: new Date("2026-08-31T00:00:00.000Z"),
+    url: "https://blob.example/image",
+  };
+  if (statusCode === 304) {
+    return {
+      artifact,
+      result: {
+        blob: { ...blob, contentType: null, size: null },
+        headers: new Headers(),
+        statusCode,
+        stream: null,
+      },
+    };
+  }
+  if (!stream) throw new Error("The test Response did not expose a body.");
+  return {
+    artifact,
+    result: {
+      blob: { ...blob, contentType: "image/png", size: png.byteLength },
+      headers: new Headers(),
+      statusCode,
+      stream,
+    },
+  };
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.getAuthSession.mockResolvedValue({ user: { id: "user-1" } });
-  mocks.getBlob.mockResolvedValue({
-    artifact: {
-      byteSize: png.byteLength,
-      filename: "Product image.png",
-      mediaType: "image/png",
-    },
-    result: {
-      blob: { etag: '"etag"' },
-      statusCode: 200,
-      stream: new Response(png).body,
-    },
-  });
+  getAuthSessionMock.mockResolvedValue(
+    authSessionFor({
+      id: "user-1",
+      phoneNumber: "+12025550123",
+      phoneNumberVerified: true,
+    })
+  );
+  getBlobMock.mockResolvedValue(openedBrowserImage(200));
 });
 
 describe("browser image route", () => {
@@ -47,14 +95,7 @@ describe("browser image route", () => {
   });
 
   it("passes conditional ETags through to private Blob", async () => {
-    mocks.getBlob.mockResolvedValue({
-      artifact: {},
-      result: {
-        blob: { etag: '"etag"' },
-        statusCode: 304,
-        stream: null,
-      },
-    });
+    getBlobMock.mockResolvedValue(openedBrowserImage(304));
 
     const response = await GET(
       request({ "if-none-match": '"etag"' }),
@@ -62,7 +103,7 @@ describe("browser image route", () => {
     );
 
     expect(response.status).toBe(304);
-    expect(mocks.getBlob).toHaveBeenCalledWith(
+    expect(getBlobMock).toHaveBeenCalledWith(
       expect.objectContaining({ userId: "better-auth:user-1" }),
       artifactId,
       expect.objectContaining({ ifNoneMatch: '"etag"' })
@@ -71,22 +112,30 @@ describe("browser image route", () => {
 
   it.each([
     ["unauthenticated", null, artifactId],
-    ["invalid id", { user: { id: "user-1" } }, "not-an-id"],
+    [
+      "invalid id",
+      authSessionFor({
+        id: "user-1",
+        phoneNumber: "+12025550123",
+        phoneNumberVerified: true,
+      }),
+      "not-an-id",
+    ],
   ])(
     "returns the same not-found response for %s requests",
     async (_name, session, id) => {
-      mocks.getAuthSession.mockResolvedValue(session);
+      getAuthSessionMock.mockResolvedValue(session);
 
       const response = await GET(request(), context(id));
 
       expect(response.status).toBe(404);
       expect(await response.text()).toBe("Not found");
-      expect(mocks.getBlob).not.toHaveBeenCalled();
+      expect(getBlobMock).not.toHaveBeenCalled();
     }
   );
 
   it("does not reveal an unavailable or cross-workspace artifact", async () => {
-    mocks.getBlob.mockResolvedValue(undefined);
+    getBlobMock.mockResolvedValue(undefined);
 
     const response = await GET(request(), context());
 

--- a/tests/browser-image-storage.test.ts
+++ b/tests/browser-image-storage.test.ts
@@ -1,32 +1,92 @@
 /* oxlint-disable vitest/require-mock-type-parameters -- Hoisted Blob and database fakes are configured per test. */
 import { createHash } from "node:crypto";
+import type { get } from "@vercel/blob";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type * as BrowserImageService from "@/db/services/browser-images";
 import { maximumBrowserImageBytes } from "@/lib/browser-images";
-
-const mocks = vi.hoisted(() => ({
-  del: vi.fn(),
-  finalize: vi.fn(),
-  get: vi.fn(),
-  put: vi.fn(),
-  readReady: vi.fn(),
-}));
-
-vi.mock("@vercel/blob", () => ({
-  del: mocks.del,
-  get: mocks.get,
-  put: mocks.put,
-}));
-vi.mock("@/db/services/browser-images", () => ({
-  finalizeBrowserImageArtifact: mocks.finalize,
-  readReadyBrowserImageArtifact: mocks.readReady,
-}));
 
 import {
   browserImageBlobAuthentication,
+  browserImageServerDependencies,
   persistReservedBrowserImage,
   readBoundedResponse,
   readBrowserImageBytes,
 } from "@/lib/browser-images/server";
+
+const delMock = vi.spyOn(browserImageServerDependencies, "del");
+const getMock = vi.spyOn(browserImageServerDependencies, "get");
+const putMock = vi.spyOn(browserImageServerDependencies, "put");
+const finalizeMock = vi.spyOn(
+  browserImageServerDependencies,
+  "finalizeBrowserImageArtifact"
+);
+const readReadyMock = vi.spyOn(
+  browserImageServerDependencies,
+  "readReadyBrowserImageArtifact"
+);
+type BlobGetResult = NonNullable<Awaited<ReturnType<typeof get>>>;
+type FinalizedArtifact = Awaited<
+  ReturnType<typeof BrowserImageService.finalizeBrowserImageArtifact>
+>;
+type ReadyArtifact = NonNullable<
+  Awaited<ReturnType<typeof BrowserImageService.readReadyBrowserImageArtifact>>
+>;
+
+function blobGetResult(): BlobGetResult {
+  const stream = new Response(png).body;
+  if (!stream) throw new Error("The test Response did not expose a body.");
+  return {
+    blob: {
+      cacheControl: "private, max-age=3600",
+      contentDisposition: 'inline; filename="product.png"',
+      contentType: "image/png",
+      downloadUrl: "https://blob.example/download",
+      etag: '"etag"',
+      pathname: reservation.storagePathname,
+      size: png.byteLength,
+      uploadedAt: new Date("2026-08-31T00:00:00.000Z"),
+      url: "https://blob.example/image",
+    },
+    headers: new Headers(),
+    statusCode: 200,
+    stream,
+  };
+}
+
+function readyArtifact(contentHash: string): ReadyArtifact {
+  return {
+    browserSessionId: "browser-1",
+    byteSize: png.byteLength,
+    contentHash,
+    createdAt: "2026-08-31T00:00:00.000Z",
+    createdByUserId: scope.userId,
+    filename: "product.png",
+    id: reservation.id,
+    idempotencyKey: "image-call-1",
+    label: "Product",
+    mediaType: "image/png",
+    rootSessionId: "root-session",
+    sourceKind: "viewport",
+    status: "ready",
+    storagePathname: reservation.storagePathname,
+    workerSessionId: "worker-1",
+    workspaceId: scope.workspaceId,
+  };
+}
+
+function finalizedArtifact(storagePathname: string): FinalizedArtifact {
+  return {
+    image: {
+      byteSize: png.byteLength,
+      filename: "product.png",
+      id: reservation.id,
+      label: "Product",
+      mediaType: "image/png",
+      url: `/artifacts/${reservation.id}`,
+    },
+    storagePathname,
+  };
+}
 
 const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const scope = { userId: "user-1", workspaceId: "workspace-1" };
@@ -38,14 +98,22 @@ const reservation = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.del.mockResolvedValue(undefined);
-  mocks.put.mockResolvedValue({ pathname: reservation.storagePathname });
-  mocks.finalize.mockResolvedValue({
-    image: { id: reservation.id },
-    storagePathname: `${reservation.storagePathname}/${createHash("sha256")
-      .update(png)
-      .digest("hex")}`,
+  delMock.mockResolvedValue(undefined);
+  putMock.mockResolvedValue({
+    contentDisposition: 'inline; filename="product.png"',
+    contentType: "image/png",
+    downloadUrl: "https://blob.example/download",
+    etag: '"etag"',
+    pathname: reservation.storagePathname,
+    url: "https://blob.example/image",
   });
+  finalizeMock.mockResolvedValue(
+    finalizedArtifact(
+      `${reservation.storagePathname}/${createHash("sha256")
+        .update(png)
+        .digest("hex")}`
+    )
+  );
 });
 
 describe("browser image storage", () => {
@@ -71,7 +139,7 @@ describe("browser image storage", () => {
       sourceKind: "viewport",
     });
 
-    expect(mocks.put).toHaveBeenCalledWith(
+    expect(putMock).toHaveBeenCalledWith(
       `${reservation.storagePathname}/${createHash("sha256")
         .update(png)
         .digest("hex")}`,
@@ -85,7 +153,7 @@ describe("browser image storage", () => {
         token: "vercel_blob_rw_test",
       })
     );
-    expect(mocks.finalize).toHaveBeenCalledWith(
+    expect(finalizeMock).toHaveBeenCalledWith(
       scope,
       reservation,
       expect.objectContaining({
@@ -109,29 +177,16 @@ describe("browser image storage", () => {
   });
 
   it("loads only the scoped root-session artifact and verifies its hash", async () => {
-    mocks.readReady.mockResolvedValue({
-      byteSize: png.byteLength,
-      contentHash: createHash("sha256").update(png).digest("hex"),
-      filename: "product.png",
-      id: reservation.id,
-      mediaType: "image/png",
-      storagePathname: reservation.storagePathname,
-    });
-    mocks.get.mockResolvedValue({
-      blob: {
-        contentType: "image/png",
-        etag: '"etag"',
-        size: png.byteLength,
-      },
-      statusCode: 200,
-      stream: new Response(png).body,
-    });
+    readReadyMock.mockResolvedValue(
+      readyArtifact(createHash("sha256").update(png).digest("hex"))
+    );
+    getMock.mockResolvedValue(blobGetResult());
 
     const result = await readBrowserImageBytes(scope, reservation.id, {
       rootSessionId: "root-session",
     });
 
-    expect(mocks.readReady).toHaveBeenCalledWith(scope, reservation.id, {
+    expect(readReadyMock).toHaveBeenCalledWith(scope, reservation.id, {
       rootSessionId: "root-session",
     });
     expect(result).toEqual({
@@ -143,33 +198,15 @@ describe("browser image storage", () => {
   });
 
   it("rejects content whose bytes do not match the manifest", async () => {
-    mocks.readReady.mockResolvedValue({
-      byteSize: png.byteLength,
-      contentHash: "not-the-hash",
-      filename: "product.png",
-      id: reservation.id,
-      mediaType: "image/png",
-      storagePathname: reservation.storagePathname,
-    });
-    mocks.get.mockResolvedValue({
-      blob: {
-        contentType: "image/png",
-        etag: '"etag"',
-        size: png.byteLength,
-      },
-      statusCode: 200,
-      stream: new Response(png).body,
-    });
+    readReadyMock.mockResolvedValue(readyArtifact("not-the-hash"));
+    getMock.mockResolvedValue(blobGetResult());
 
     expect(await readBrowserImageBytes(scope, reservation.id)).toBeUndefined();
   });
 
   it("keeps the finalized winner and deletes a losing concurrent upload", async () => {
     const winnerPathname = `${reservation.storagePathname}/winner-hash`;
-    mocks.finalize.mockResolvedValue({
-      image: { id: reservation.id },
-      storagePathname: winnerPathname,
-    });
+    finalizeMock.mockResolvedValue(finalizedArtifact(winnerPathname));
 
     await persistReservedBrowserImage(scope, reservation, {
       bytes: png,
@@ -182,7 +219,7 @@ describe("browser image storage", () => {
     )
       .update(png)
       .digest("hex")}`;
-    expect(mocks.del).toHaveBeenCalledWith(losingPathname, {
+    expect(delMock).toHaveBeenCalledWith(losingPathname, {
       token: "vercel_blob_rw_test",
     });
   });

--- a/tests/browser-images.test.ts
+++ b/tests/browser-images.test.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/browser-images";
 import { isBrowserImageArtifactUrl } from "@/lib/browser-image-path";
 import {
-  parseTaskCompletionOutput,
+  taskCompletionOutputSchema,
   taskCompletionSchema,
 } from "@/lib/task-completion";
 
@@ -84,7 +84,7 @@ describe("browser image contracts", () => {
 
   it("defaults historical worker results to no images and caps new results", () => {
     expect(
-      parseTaskCompletionOutput({ message: "Done", status: "success" })
+      taskCompletionOutputSchema.parse({ message: "Done", status: "success" })
     ).toEqual({ images: [], message: "Done", status: "success" });
     expect(
       taskCompletionSchema.safeParse({ message: "Done", status: "success" })

--- a/tests/browser-trace-telemetry.test.ts
+++ b/tests/browser-trace-telemetry.test.ts
@@ -1,73 +1,90 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HookContext } from "eve/hooks";
 import { z } from "zod";
-import type {
-  beginBrowserTrace,
-  completeBrowserTrace,
-} from "@/db/services/browser-traces";
-import type { listWorkerBrowserSessions } from "@/db/services/browsers";
-import type * as traceDomains from "@/agent/subagents/worker/lib/trace-domains";
-import type { harvestBrowserTraceDomains } from "@/agent/subagents/worker/lib/trace-domains";
+import { domainFromUrl } from "@/agent/subagents/worker/lib/trace-domains";
+import traceTelemetry, {
+  traceTelemetryDependencies,
+} from "../agent/subagents/worker/hooks/trace-telemetry";
 
-const mocks = vi.hoisted(() => ({
-  beginBrowserTrace: vi.fn<typeof beginBrowserTrace>(),
-  completeBrowserTrace: vi.fn<typeof completeBrowserTrace>(),
-  harvestBrowserTraceDomains: vi.fn<typeof harvestBrowserTraceDomains>(),
-  listWorkerBrowserSessions: vi.fn<typeof listWorkerBrowserSessions>(),
-  recordBrowserTraceEvents:
-    vi.fn<(scope: unknown, sessionId: string, events: unknown[]) => void>(),
-}));
-
-vi.mock("@/db/services/browser-traces", () => ({
-  beginBrowserTrace: mocks.beginBrowserTrace,
-  completeBrowserTrace: mocks.completeBrowserTrace,
-  recordBrowserTraceEvents: mocks.recordBrowserTraceEvents,
-}));
-
-vi.mock("@/db/services/browsers", () => ({
-  listWorkerBrowserSessions: mocks.listWorkerBrowserSessions,
-}));
-
-vi.mock("@/agent/subagents/worker/lib/trace-domains", () => ({
-  harvestBrowserTraceDomains: mocks.harvestBrowserTraceDomains,
-}));
-
-import traceTelemetry from "../agent/subagents/worker/hooks/trace-telemetry";
+const beginBrowserTraceMock = vi.spyOn(
+  traceTelemetryDependencies,
+  "beginBrowserTrace"
+);
+const completeBrowserTraceMock = vi.spyOn(
+  traceTelemetryDependencies,
+  "completeBrowserTrace"
+);
+const recordBrowserTraceEventsMock = vi.spyOn(
+  traceTelemetryDependencies,
+  "recordBrowserTraceEvents"
+);
+const listWorkerBrowserSessionsMock = vi.spyOn(
+  traceTelemetryDependencies,
+  "listWorkerBrowserSessions"
+);
+const harvestBrowserTraceDomainsMock = vi.spyOn(
+  traceTelemetryDependencies,
+  "harvestBrowserTraceDomains"
+);
 
 const scope = { userId: "user-1", workspaceId: "workspace-1" };
 const context = {
+  agent: { name: "test-agent" },
+  channel: {},
+  async getSandbox() {
+    throw new Error("Sandbox access is outside this focused test.");
+  },
+  getSkill() {
+    throw new Error("Skill access is outside this focused test.");
+  },
   session: {
     auth: {
+      current: null,
       initiator: {
         attributes: { workspaceId: scope.workspaceId },
+        authenticator: "test",
         principalId: scope.userId,
+        principalType: "user",
       },
     },
     id: "worker-session-1",
+    turn: { id: "turn-1", sequence: 0 },
   },
-};
+} satisfies HookContext;
 
 type TraceEvents = NonNullable<typeof traceTelemetry.events>;
 
-async function fire(type: keyof TraceEvents, event: unknown) {
+async function fire<Type extends keyof TraceEvents>(
+  type: Type,
+  event: Parameters<NonNullable<TraceEvents[Type]>>[0]
+) {
   const handler = traceTelemetry.events?.[type];
   expect(handler).toBeDefined();
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- focused unit test supplies only the event and context fields each handler reads.
-  await handler?.(event as never, context as never);
+  await handler?.(event, context);
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.listWorkerBrowserSessions.mockResolvedValue([]);
+  beginBrowserTraceMock.mockResolvedValue();
+  completeBrowserTraceMock.mockResolvedValue();
+  harvestBrowserTraceDomainsMock.mockResolvedValue();
+  listWorkerBrowserSessionsMock.mockResolvedValue([]);
+  recordBrowserTraceEventsMock.mockResolvedValue();
 });
 
 describe("browser trace telemetry hook", () => {
   it("opens a running trace from the delegated task message", async () => {
     await fire("message.received", {
-      data: { message: "Buy the blue mug on example.com" },
-      meta: { at: "2026-08-31T00:00:00.000Z" },
+      data: {
+        message: "Buy the blue mug on example.com",
+        sequence: 0,
+        turnId: "turn-1",
+      },
+      meta: { at: "2026-08-31T00:00:00.000Z", id: "event-1" },
+      type: "message.received",
     });
 
-    expect(mocks.beginBrowserTrace).toHaveBeenCalledExactlyOnceWith(scope, {
+    expect(beginBrowserTraceMock).toHaveBeenCalledExactlyOnceWith(scope, {
       sessionId: "worker-session-1",
       startedAt: "2026-08-31T00:00:00.000Z",
       task: "Buy the blue mug on example.com",
@@ -75,18 +92,22 @@ describe("browser trace telemetry hook", () => {
   });
 
   it("records the structured completion outcome and sweeps live browsers", async () => {
-    mocks.listWorkerBrowserSessions.mockResolvedValue([
+    listWorkerBrowserSessionsMock.mockResolvedValue([
       { createdAt: "2026-08-31T00:00:01.000Z", sessionId: "browser-1" },
     ]);
 
     await fire("result.completed", {
       data: {
         result: { images: [], message: "Order placed.", status: "success" },
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn-1",
       },
-      meta: { at: "2026-08-31T00:05:00.000Z" },
+      meta: { at: "2026-08-31T00:05:00.000Z", id: "event-2" },
+      type: "result.completed",
     });
 
-    expect(mocks.completeBrowserTrace).toHaveBeenCalledExactlyOnceWith(
+    expect(completeBrowserTraceMock).toHaveBeenCalledExactlyOnceWith(
       scope,
       "worker-session-1",
       {
@@ -95,7 +116,7 @@ describe("browser trace telemetry hook", () => {
         status: "success",
       }
     );
-    expect(mocks.harvestBrowserTraceDomains).toHaveBeenCalledExactlyOnceWith(
+    expect(harvestBrowserTraceDomainsMock).toHaveBeenCalledExactlyOnceWith(
       scope,
       "worker-session-1",
       { createdAt: "2026-08-31T00:00:01.000Z", sessionId: "browser-1" }
@@ -104,24 +125,37 @@ describe("browser trace telemetry hook", () => {
 
   it("ignores structured results that are not task completions", async () => {
     await fire("result.completed", {
-      data: { result: { unrelated: true } },
-      meta: { at: "2026-08-31T00:05:00.000Z" },
+      data: {
+        result: { unrelated: true },
+        sequence: 0,
+        stepIndex: 0,
+        turnId: "turn-1",
+      },
+      meta: { at: "2026-08-31T00:05:00.000Z", id: "event-3" },
+      type: "result.completed",
     });
 
-    expect(mocks.completeBrowserTrace).not.toHaveBeenCalled();
+    expect(completeBrowserTraceMock).not.toHaveBeenCalled();
   });
 
   it("marks infrastructure failures and cancellations distinctly", async () => {
     await fire("turn.failed", {
-      data: { code: "model_error", message: "The model call failed." },
-      meta: { at: "2026-08-31T00:06:00.000Z" },
+      data: {
+        code: "model_error",
+        message: "The model call failed.",
+        sequence: 0,
+        turnId: "turn-1",
+      },
+      meta: { at: "2026-08-31T00:06:00.000Z", id: "event-4" },
+      type: "turn.failed",
     });
     await fire("turn.cancelled", {
-      data: {},
-      meta: { at: "2026-08-31T00:07:00.000Z" },
+      data: { sequence: 0, turnId: "turn-1" },
+      meta: { at: "2026-08-31T00:07:00.000Z", id: "event-5" },
+      type: "turn.cancelled",
     });
 
-    expect(mocks.completeBrowserTrace).toHaveBeenNthCalledWith(
+    expect(completeBrowserTraceMock).toHaveBeenNthCalledWith(
       1,
       scope,
       "worker-session-1",
@@ -131,7 +165,7 @@ describe("browser trace telemetry hook", () => {
         status: "error",
       }
     );
-    expect(mocks.completeBrowserTrace).toHaveBeenNthCalledWith(
+    expect(completeBrowserTraceMock).toHaveBeenNthCalledWith(
       2,
       scope,
       "worker-session-1",
@@ -144,13 +178,14 @@ describe("browser trace telemetry hook", () => {
   });
 
   it("never throws telemetry failures back into the turn", async () => {
-    mocks.beginBrowserTrace.mockRejectedValue(new Error("database offline"));
+    beginBrowserTraceMock.mockRejectedValue(new Error("database offline"));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     await expect(
       fire("message.received", {
-        data: { message: "task" },
-        meta: { at: "2026-08-31T00:00:00.000Z" },
+        data: { message: "task", sequence: 0, turnId: "turn-1" },
+        meta: { at: "2026-08-31T00:00:00.000Z", id: "event-6" },
+        type: "message.received",
       })
     ).resolves.toBeUndefined();
 
@@ -179,7 +214,7 @@ describe("trace event persistence", () => {
       type: "actions.requested",
     });
 
-    expect(mocks.recordBrowserTraceEvents).toHaveBeenCalledExactlyOnceWith(
+    expect(recordBrowserTraceEventsMock).toHaveBeenCalledExactlyOnceWith(
       scope,
       "worker-session-1",
       [
@@ -212,7 +247,7 @@ describe("trace event persistence", () => {
       type: "action.result",
     });
 
-    const [, , events] = mocks.recordBrowserTraceEvents.mock.calls[0] ?? [];
+    const [, , events] = recordBrowserTraceEventsMock.mock.calls[0] ?? [];
     const detail = z
       .array(z.object({ detail: z.string(), label: z.string() }))
       .parse(events)[0];
@@ -223,10 +258,6 @@ describe("trace event persistence", () => {
 
 describe("trace domain extraction", () => {
   it("keeps only http(s) hostnames", async () => {
-    const { domainFromUrl } = await vi.importActual<typeof traceDomains>(
-      "@/agent/subagents/worker/lib/trace-domains"
-    );
-
     expect(domainFromUrl("https://shop.example.com/cart?item=1")).toBe(
       "shop.example.com"
     );

--- a/tests/eve-channel-auth.test.ts
+++ b/tests/eve-channel-auth.test.ts
@@ -1,34 +1,24 @@
 import type { RouteHandlerArgs } from "eve/channels";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const mocks = vi.hoisted(() => ({
-  getAuthSession:
-    vi.fn<
-      (
-        _headers: Headers
-      ) => Promise<{ user: { id: string; phoneNumber: string } } | null>
-    >(),
-  isSessionOwned:
-    vi.fn<(_scope: unknown, _sessionId: string) => Promise<boolean>>(),
-}));
-
-vi.mock("@/auth/session", () => ({
-  getAuthSession: mocks.getAuthSession,
-}));
-
-vi.mock("@/db/services/sessions", () => ({
-  isSessionOwned: mocks.isSessionOwned,
-}));
-
+import * as AuthSession from "@/auth/session";
+import * as SessionService from "@/db/services/sessions";
+import { authSessionFor } from "./helpers/auth-session";
 import eveChannel from "../agent/channels/eve";
+
+const getAuthSessionMock = vi.spyOn(AuthSession, "getAuthSession");
+const isSessionOwnedMock = vi.spyOn(SessionService, "isSessionOwned");
 
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
-  mocks.getAuthSession.mockResolvedValue({
-    user: { id: "user-1", phoneNumber: "+12025550123" },
-  });
-  mocks.isSessionOwned.mockResolvedValue(false);
+  getAuthSessionMock.mockResolvedValue(
+    authSessionFor({
+      id: "user-1",
+      phoneNumber: "+12025550123",
+      phoneNumberVerified: true,
+    })
+  );
+  isSessionOwnedMock.mockResolvedValue(false);
 });
 
 afterEach(() => {
@@ -57,7 +47,7 @@ describe("Eve channel authentication", () => {
     const response = await responsePromise;
 
     expect(response.status).toBe(403);
-    expect(mocks.isSessionOwned).toHaveBeenCalledWith(
+    expect(isSessionOwnedMock).toHaveBeenCalledWith(
       expect.objectContaining({ userId: "better-auth:user-1" }),
       "session/one"
     );

--- a/tests/google-workspace-generated-clients.test.ts
+++ b/tests/google-workspace-generated-clients.test.ts
@@ -1,4 +1,7 @@
 import { createHash } from "node:crypto";
+import * as CalendarApi from "@googleapis/calendar";
+import * as GmailApi from "@googleapis/gmail";
+import * as PeopleApi from "@googleapis/people";
 import type { ToolContext } from "eve/tools";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -12,23 +15,13 @@ interface RequestOptions {
   signal: AbortSignal;
 }
 
-const google = vi.hoisted(() => ({
-  calendar: vi.fn<(options: unknown) => unknown>(),
-  gmail: vi.fn<(options: unknown) => unknown>(),
-  people: vi.fn<(options: unknown) => unknown>(),
-  setCredentials: vi.fn<(credentials: { access_token: string }) => void>(),
-}));
-
-vi.mock("@googleapis/calendar", () => ({ calendar: google.calendar }));
-vi.mock("@googleapis/gmail", () => ({
-  auth: {
-    OAuth2: class {
-      setCredentials = google.setCredentials;
-    },
-  },
-  gmail: google.gmail,
-}));
-vi.mock("@googleapis/people", () => ({ people: google.people }));
+const calendarMock = vi.spyOn(CalendarApi, "calendar");
+const gmailMock = vi.spyOn(GmailApi, "gmail");
+const peopleMock = vi.spyOn(PeopleApi, "people");
+const setCredentialsMock = vi.spyOn(
+  GmailApi.auth.OAuth2.prototype,
+  "setCredentials"
+);
 
 afterEach(() => vi.clearAllMocks());
 
@@ -42,7 +35,7 @@ describe("generated Google Workspace clients", () => {
     );
 
     expect(ctx.getToken).toHaveBeenCalledOnce();
-    expect(google.setCredentials).toHaveBeenCalledWith({
+    expect(setCredentialsMock).toHaveBeenCalledWith({
       access_token: "google-access-token",
     });
     expect(ctx.requireAuth).toHaveBeenCalledOnce();
@@ -50,17 +43,20 @@ describe("generated Google Workspace clients", () => {
 
   it("sends typed Gmail requests with a stable retry-safe message ID", async () => {
     const ctx = toolContext();
+    const client = GmailApi.gmail({ version: "v1" });
     const send = vi
       .fn<
         (
-          request: unknown,
+          request: {
+            requestBody: { raw: string; threadId?: string };
+            userId: string;
+          },
           options: RequestOptions
         ) => Promise<{ data: { id: string; threadId: string } }>
       >()
-      .mockResolvedValue({
-        data: { id: "sent-1", threadId: "thread-1" },
-      });
-    googleClients({ gmail: { users: { messages: { send } } } });
+      .mockResolvedValue({ data: { id: "sent-1", threadId: "thread-1" } });
+    Object.defineProperty(client.users.messages, "send", { value: send });
+    googleClients({ gmail: client });
 
     await sendGmail(ctx, {
       bcc: [],
@@ -93,8 +89,18 @@ describe("generated Google Workspace clients", () => {
 
   it("recovers a duplicate Calendar insert using the stable event ID", async () => {
     const ctx = toolContext();
+    const client = CalendarApi.calendar({ version: "v3" });
     const insert = vi
-      .fn<(request: unknown, options: RequestOptions) => Promise<never>>()
+      .fn<
+        (
+          request: {
+            calendarId: string;
+            requestBody: { id?: string };
+            sendUpdates?: string;
+          },
+          options: RequestOptions
+        ) => Promise<never>
+      >()
       .mockRejectedValue(new GoogleApiError(409));
     const get = vi
       .fn<
@@ -106,7 +112,9 @@ describe("generated Google Workspace clients", () => {
       .mockResolvedValue({
         data: { id: "existing-event", summary: "Planning" },
       });
-    googleClients({ calendar: { events: { get, insert } } });
+    Object.defineProperty(client.events, "get", { value: get });
+    Object.defineProperty(client.events, "insert", { value: insert });
+    googleClients({ calendar: client });
 
     await expect(
       createCalendarEvent(ctx, {
@@ -132,10 +140,11 @@ describe("generated Google Workspace clients", () => {
 
   it("warms the People search cache before the typed contact query", async () => {
     const ctx = toolContext();
+    const client = PeopleApi.people({ version: "v1" });
     const searchContacts = vi
       .fn<
         (
-          request: unknown,
+          request: { pageSize?: number; query: string; readMask: string },
           options: RequestOptions
         ) => Promise<{
           data: { results?: { person: { resourceName: string } }[] };
@@ -145,7 +154,10 @@ describe("generated Google Workspace clients", () => {
       .mockResolvedValueOnce({
         data: { results: [{ person: { resourceName: "people/1" } }] },
       });
-    googleClients({ people: { people: { searchContacts } } });
+    Object.defineProperty(client.people, "searchContacts", {
+      value: searchContacts,
+    });
+    googleClients({ people: client });
 
     await expect(searchGoogleContacts(ctx, "Person", 10)).resolves.toEqual({
       contacts: [{ person: { resourceName: "people/1" } }],
@@ -176,27 +188,34 @@ function toolContext() {
     .fn<ToolContext["getToken"]>()
     .mockResolvedValue({ token: "google-access-token" });
   const requireAuth = vi.fn<ToolContext["requireAuth"]>();
-  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- The fixture supplies exactly the ToolContext fields exercised by these helpers.
   return {
+    async getSandbox() {
+      throw new Error("Sandbox access is outside this focused test.");
+    },
+    getSkill() {
+      throw new Error("Skill access is outside this focused test.");
+    },
     abortSignal: new AbortController().signal,
     callId: "call-1",
     getToken,
     requireAuth,
-    session: { id: "session-1" },
-  } as unknown as ToolContext & {
-    getToken: typeof getToken;
-    requireAuth: typeof requireAuth;
-  };
+    session: {
+      auth: { current: null, initiator: null },
+      id: "session-1",
+      turn: { id: "turn-1", sequence: 0 },
+    },
+    toolName: "google-workspace-test",
+  } satisfies ToolContext;
 }
 
 function googleClients(clients: {
-  calendar?: unknown;
-  gmail?: unknown;
-  people?: unknown;
+  calendar?: ReturnType<typeof CalendarApi.calendar>;
+  gmail?: ReturnType<typeof GmailApi.gmail>;
+  people?: ReturnType<typeof PeopleApi.people>;
 }) {
-  google.calendar.mockReturnValue(clients.calendar ?? {});
-  google.gmail.mockReturnValue(clients.gmail ?? {});
-  google.people.mockReturnValue(clients.people ?? {});
+  if (clients.calendar) calendarMock.mockReturnValue(clients.calendar);
+  if (clients.gmail) gmailMock.mockReturnValue(clients.gmail);
+  if (clients.people) peopleMock.mockReturnValue(clients.people);
 }
 
 class GoogleApiError extends Error {

--- a/tests/google-workspace.test.ts
+++ b/tests/google-workspace.test.ts
@@ -1,10 +1,4 @@
-import {
-  getTokenResponse,
-  NoValidTokenError,
-  type ConnectTokenResponse,
-  startAuthorization,
-} from "@vercel/connect";
-import type * as VercelConnect from "@vercel/connect";
+import { NoValidTokenError, type ConnectTokenResponse } from "@vercel/connect";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseCalendarAvailability } from "@/agent/lib/google-workspace/calendar";
 import { googleWorkspaceAuthOptions } from "@/agent/lib/google-workspace/client";
@@ -17,14 +11,18 @@ import {
 } from "@/lib/google-workspace/config";
 import {
   getGoogleWorkspaceConnection,
+  googleWorkspaceServerDependencies,
   startGoogleWorkspaceAuthorization,
 } from "@/lib/google-workspace/server";
 
-vi.mock("@vercel/connect", async (importOriginal) => ({
-  ...(await importOriginal<typeof VercelConnect>()),
-  getTokenResponse: vi.fn<typeof getTokenResponse>(),
-  startAuthorization: vi.fn<typeof startAuthorization>(),
-}));
+const getTokenResponseMock = vi.spyOn(
+  googleWorkspaceServerDependencies,
+  "getTokenResponse"
+);
+const startAuthorizationMock = vi.spyOn(
+  googleWorkspaceServerDependencies,
+  "startAuthorization"
+);
 
 afterEach(() => vi.clearAllMocks());
 
@@ -62,13 +60,13 @@ describe("Google Workspace connection", () => {
       expiresAt: Date.now() + 60_000,
       token: "must-not-leak",
     };
-    vi.mocked(getTokenResponse).mockResolvedValue(response);
+    getTokenResponseMock.mockResolvedValue(response);
 
     await expect(getGoogleWorkspaceConnection(scope)).resolves.toEqual({
       accountLabel: "person@example.com",
       state: "connected",
     });
-    expect(getTokenResponse).toHaveBeenCalledWith(
+    expect(getTokenResponseMock).toHaveBeenCalledWith(
       expect.any(String),
       googleWorkspaceTokenParams(scope.userId),
       { forceRefresh: true }
@@ -76,7 +74,7 @@ describe("Google Workspace connection", () => {
   });
 
   it("reports a missing user grant as disconnected", async () => {
-    vi.mocked(getTokenResponse).mockRejectedValue(
+    getTokenResponseMock.mockRejectedValue(
       new NoValidTokenError("No Google grant for this user.")
     );
     await expect(getGoogleWorkspaceConnection(scope)).resolves.toEqual({
@@ -86,7 +84,7 @@ describe("Google Workspace connection", () => {
   });
 
   it("starts authorization with the canonical subject and scopes", async () => {
-    vi.mocked(startAuthorization).mockResolvedValue({
+    startAuthorizationMock.mockResolvedValue({
       request: "request",
       url: "https://connect.vercel.com/request",
       verifier: "verifier",
@@ -98,7 +96,7 @@ describe("Google Workspace connection", () => {
         "https://openinstinct.example/?google=connected"
       )
     ).resolves.toBe("https://connect.vercel.com/request");
-    expect(startAuthorization).toHaveBeenCalledWith(
+    expect(startAuthorizationMock).toHaveBeenCalledWith(
       expect.any(String),
       googleWorkspaceTokenParams(scope.userId),
       expect.objectContaining({

--- a/tests/helpers/auth-session.ts
+++ b/tests/helpers/auth-session.ts
@@ -1,0 +1,30 @@
+import type { auth } from "@/auth";
+
+type BetterAuthSession = NonNullable<
+  Awaited<ReturnType<typeof auth.api.getSession>>
+>;
+
+export function authSessionFor(
+  user: Pick<BetterAuthSession["user"], "id"> &
+    Partial<BetterAuthSession["user"]>
+): BetterAuthSession {
+  const now = new Date("2026-08-31T00:00:00.000Z");
+  return {
+    session: {
+      createdAt: now,
+      expiresAt: new Date("2026-09-01T00:00:00.000Z"),
+      id: `session-${user.id}`,
+      token: `token-${user.id}`,
+      updatedAt: now,
+      userId: user.id,
+    },
+    user: {
+      createdAt: now,
+      email: `${user.id}@example.com`,
+      emailVerified: true,
+      name: user.id,
+      updatedAt: now,
+      ...user,
+    },
+  };
+}

--- a/tests/helpers/server-only.ts
+++ b/tests/helpers/server-only.ts
@@ -1,0 +1,2 @@
+// Vitest runs server modules in Node without the Next.js bundler condition.
+export const serverOnlyTestBoundary = true;

--- a/tests/helpers/tool-context.ts
+++ b/tests/helpers/tool-context.ts
@@ -1,0 +1,49 @@
+import type { ToolContext } from "eve/tools";
+
+interface TestToolContextOptions {
+  readonly abortSignal?: AbortSignal;
+  readonly callId?: string;
+  readonly parentSessionId?: string;
+  readonly sessionId?: string;
+  readonly toolName?: string;
+}
+
+export function toolContextFor({
+  abortSignal = new AbortController().signal,
+  callId = "test-call",
+  parentSessionId,
+  sessionId = "test-session",
+  toolName = "test-tool",
+}: TestToolContextOptions = {}): ToolContext {
+  const parent = parentSessionId
+    ? {
+        callId: "parent-call",
+        rootSessionId: parentSessionId,
+        sessionId: parentSessionId,
+        turn: { id: "parent-turn", sequence: 0 },
+      }
+    : undefined;
+  return {
+    abortSignal,
+    callId,
+    async getSandbox() {
+      throw new Error("Sandbox access is outside this focused test.");
+    },
+    getSkill() {
+      throw new Error("Skill access is outside this focused test.");
+    },
+    async getToken() {
+      throw new Error("Authorization is outside this focused test.");
+    },
+    requireAuth() {
+      throw new Error("Authorization is outside this focused test.");
+    },
+    session: {
+      auth: { current: null, initiator: null },
+      id: sessionId,
+      parent,
+      turn: { id: "test-turn", sequence: 0 },
+    },
+    toolName,
+  };
+}

--- a/tests/kernel-browser-contract.test.ts
+++ b/tests/kernel-browser-contract.test.ts
@@ -1,75 +1,56 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import type * as traceDomains from "../agent/subagents/worker/lib/trace-domains";
-
-const mocks = vi.hoisted(() => ({
-  createBrowser: vi.fn<(...arguments_: unknown[]) => Promise<unknown>>(),
-  createBrowserSession:
-    vi.fn<(_scope: unknown, _record: unknown) => Promise<void>>(),
-  deleteBrowser: vi.fn<(...arguments_: unknown[]) => Promise<void>>(),
-  deleteBrowserSession:
-    vi.fn<(_scope: unknown, _sessionId: string) => Promise<boolean>>(),
-  listBrowserSessions:
-    vi.fn<() => Promise<{ createdAt: string; sessionId: string }[]>>(),
-  listKernelBrowsers:
-    vi.fn<(...arguments_: unknown[]) => AsyncIterable<unknown>>(),
-  harvestBrowserTraceDomains:
-    vi.fn<(...arguments_: unknown[]) => Promise<void>>(),
-  readBrowserSession:
-    vi.fn<(_scope: unknown, _sessionId: string) => Promise<unknown>>(),
-  recordBrowserTraceDomains:
-    vi.fn<(...arguments_: unknown[]) => Promise<void>>(),
-  retrieveBrowser: vi.fn<(...arguments_: unknown[]) => Promise<unknown>>(),
-  retrieveProfile: vi.fn<(...arguments_: unknown[]) => Promise<unknown>>(),
-  requireWorkerScope: vi.fn<(_context: unknown) => Promise<unknown>>(),
-  withBrowserProfileWriteLock:
-    vi.fn<
-      (_scope: unknown, operation: () => Promise<unknown>) => Promise<unknown>
-    >(),
-}));
-
-vi.mock("@/agent/subagents/worker/lib/access", () => ({
-  requireWorkerScope: mocks.requireWorkerScope,
-}));
-
-vi.mock("@/agent/subagents/worker/lib/trace-domains", async () => ({
-  domainFromUrl: (
-    await vi.importActual<typeof traceDomains>(
-      "@/agent/subagents/worker/lib/trace-domains"
-    )
-  ).domainFromUrl,
-  harvestBrowserTraceDomains: mocks.harvestBrowserTraceDomains,
-}));
-
-vi.mock("@/db/services/browser-traces", () => ({
-  recordBrowserTraceDomains: mocks.recordBrowserTraceDomains,
-}));
-
-vi.mock("@/db/services/browsers", () => ({
-  createBrowserSession: mocks.createBrowserSession,
-  deleteBrowserSession: mocks.deleteBrowserSession,
-  listBrowserSessions: mocks.listBrowserSessions,
-  readBrowserSession: mocks.readBrowserSession,
-  withBrowserProfileWriteLock: mocks.withBrowserProfileWriteLock,
-}));
-
-vi.mock("@/lib/kernel", () => ({
-  kernel: {
-    browsers: {
-      create: mocks.createBrowser,
-      deleteByID: mocks.deleteBrowser,
-      list: mocks.listKernelBrowsers,
-      retrieve: mocks.retrieveBrowser,
-    },
-    profiles: {
-      retrieve: mocks.retrieveProfile,
-    },
-  },
-}));
-
+import { kernel } from "@/lib/kernel";
+import { toolContextFor } from "./helpers/tool-context";
 import manageBrowsers, {
+  createManageBrowsers,
   kernelProfileNameForWorkspace,
+  manageBrowsersDependencies,
 } from "../agent/subagents/worker/tools/manage_browsers";
+
+type ListKernelBrowsers = NonNullable<
+  Parameters<typeof createManageBrowsers>[0]
+>["listKernelBrowsers"];
+
+const mocks = {
+  createBrowser: vi.spyOn(kernel.browsers, "create"),
+  createBrowserSession: vi.spyOn(
+    manageBrowsersDependencies,
+    "createBrowserSession"
+  ),
+  deleteBrowser: vi.spyOn(kernel.browsers, "deleteByID"),
+  deleteBrowserSession: vi.spyOn(
+    manageBrowsersDependencies,
+    "deleteBrowserSession"
+  ),
+  harvestBrowserTraceDomains: vi.spyOn(
+    manageBrowsersDependencies,
+    "harvestBrowserTraceDomains"
+  ),
+  listBrowserSessions: vi.spyOn(
+    manageBrowsersDependencies,
+    "listBrowserSessions"
+  ),
+  listKernelBrowsers: vi.fn<ListKernelBrowsers>(),
+  readBrowserSession: vi.spyOn(
+    manageBrowsersDependencies,
+    "requireOwnedBrowserSession"
+  ),
+  recordBrowserTraceDomains: vi.spyOn(
+    manageBrowsersDependencies,
+    "recordBrowserTraceDomains"
+  ),
+  retrieveBrowser: vi.spyOn(kernel.browsers, "retrieve"),
+  retrieveProfile: vi.spyOn(kernel.profiles, "retrieve"),
+  requireWorkerScope: vi.spyOn(
+    manageBrowsersDependencies,
+    "requireWorkerScope"
+  ),
+  withBrowserProfileWriteLock: vi.spyOn(
+    manageBrowsersDependencies,
+    "withBrowserProfileWriteLock"
+  ),
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -78,32 +59,45 @@ beforeEach(() => {
     workspaceId: "workspace-1",
   });
   mocks.retrieveProfile.mockResolvedValue({
+    created_at: "2026-08-27T00:00:00.000Z",
     id: "profile-1",
     name: "opaque-profile",
   });
   mocks.listKernelBrowsers.mockReturnValue(asyncItems([]));
   mocks.createBrowser.mockResolvedValue({
     browser_live_view_url: "https://live.kernel.test/browser-1",
+    cdp_ws_url: "wss://kernel.test/cdp",
     created_at: "2026-08-27T00:00:00.000Z",
-    deleted_at: null,
-    profile: { id: "profile-1" },
+    headless: false,
+    memory: "2GiB",
+    profile: {
+      created_at: "2026-08-27T00:00:00.000Z",
+      id: "profile-1",
+    },
     profile_save_changes: false,
+    region: "us-east",
     session_id: "browser-1",
-    viewport: null,
+    stealth: true,
+    timeout_seconds: 900,
+    webdriver_ws_url: "wss://kernel.test/webdriver",
   });
   mocks.deleteBrowser.mockResolvedValue();
+  mocks.createBrowserSession.mockResolvedValue();
   mocks.deleteBrowserSession.mockResolvedValue(true);
   mocks.harvestBrowserTraceDomains.mockResolvedValue();
   mocks.listBrowserSessions.mockResolvedValue([]);
-  mocks.readBrowserSession.mockResolvedValue(undefined);
+  mocks.readBrowserSession.mockResolvedValue({
+    createdAt: "2026-08-27T00:00:00.000Z",
+    sessionId: "browser-1",
+    workerSessionId: "worker-session-1",
+  });
   mocks.recordBrowserTraceDomains.mockResolvedValue();
   mocks.withBrowserProfileWriteLock.mockImplementation(
     async (_scope, operation) => operation()
   );
 });
 
-// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the tool context is external Eve runtime state; the tools read only the mocked authorization boundary, the session id, and the abort signal.
-const workerContext = { session: { id: "worker-session-1" } } as never;
+const workerContext = toolContextFor({ sessionId: "worker-session-1" });
 
 describe("Kernel browser contract", () => {
   it("keeps agent-created browsers alive for at least 15 minutes", () => {
@@ -146,7 +140,7 @@ describe("Kernel browser contract", () => {
         timeout_seconds: 900,
         viewport: undefined,
       },
-      { signal: undefined }
+      { signal: workerContext.abortSignal }
     );
     expect(mocks.createBrowserSession).toHaveBeenCalledExactlyOnceWith(
       { userId: "user-1", workspaceId: "workspace-1" },
@@ -181,7 +175,7 @@ describe("Kernel browser contract", () => {
       { userId: "user-1", workspaceId: "workspace-1" },
       "worker-session-9",
       { createdAt: "2026-08-27T00:00:00.000Z", sessionId: "browser-1" },
-      undefined
+      expect.any(AbortSignal)
     );
     expect(
       mocks.harvestBrowserTraceDomains.mock.invocationCallOrder[0]
@@ -198,13 +192,12 @@ describe("Kernel browser contract", () => {
         },
       ])
     );
+    const tool = createManageBrowsers({
+      listKernelBrowsers: mocks.listKernelBrowsers,
+    });
 
     await expect(
-      manageBrowsers.execute(
-        { action: "create", save_changes: true },
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the tool context is external Eve runtime state; create reads only the mocked authorization boundary and abort signal.
-        {} as never
-      )
+      tool.execute({ action: "create", save_changes: true }, toolContextFor())
     ).rejects.toThrow(/browser-active.*saving login state/i);
     expect(mocks.withBrowserProfileWriteLock).toHaveBeenCalledOnce();
     expect(mocks.createBrowser).not.toHaveBeenCalled();
@@ -221,8 +214,7 @@ describe("Kernel browser contract", () => {
 
     const result = await manageBrowsers.execute(
       { action: "list" },
-      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the tool context is external Eve runtime state; list reads authorization through the mocked boundary.
-      {} as never
+      toolContextFor()
     );
 
     expect(result).toEqual({ has_more: false, items: [], next_offset: null });

--- a/tests/linq-browser-image-delivery.test.ts
+++ b/tests/linq-browser-image-delivery.test.ts
@@ -1,21 +1,17 @@
 /* oxlint-disable vitest/require-mock-type-parameters -- The hoisted storage fake is configured per test. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as BrowserImageServer from "@/lib/browser-images/server";
+import { prepareLinqBrowserImageDelivery } from "../agent/lib/linq-browser-image-delivery";
 
 const firstId = "0d01e667-d128-4bb7-a248-1ae21db72f4f";
 const secondId = "206c3a7e-c0b8-4317-9e34-552cff646673";
-const mocks = vi.hoisted(() => ({ readImage: vi.fn() }));
-
-vi.mock("@/lib/browser-images/server", () => ({
-  readBrowserImageBytes: mocks.readImage,
-}));
-
-import { prepareLinqBrowserImageDelivery } from "../agent/lib/linq-browser-image-delivery";
+const readImageMock = vi.spyOn(BrowserImageServer, "readBrowserImageBytes");
 
 const scope = { userId: "user-1", workspaceId: "workspace-1" };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.readImage.mockImplementation(async (_scope: unknown, id: string) =>
+  readImageMock.mockImplementation(async (_scope, id) =>
     id === firstId
       ? {
           bytes: new Uint8Array([1, 2, 3]),
@@ -40,7 +36,7 @@ describe("Linq browser image delivery", () => {
       scope,
     });
 
-    expect(mocks.readImage).toHaveBeenCalledExactlyOnceWith(scope, firstId, {
+    expect(readImageMock).toHaveBeenCalledExactlyOnceWith(scope, firstId, {
       rootSessionId: "root-session",
       signal: undefined,
     });
@@ -82,6 +78,6 @@ describe("Linq browser image delivery", () => {
       files: [],
       markdown,
     });
-    expect(mocks.readImage).not.toHaveBeenCalled();
+    expect(readImageMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/linq-message-delivery.test.ts
+++ b/tests/linq-message-delivery.test.ts
@@ -1,37 +1,34 @@
 /* oxlint-disable typescript/no-unsafe-type-assertion, vitest/require-mock-type-parameters -- Eve's Linq adapter exposes the handler context through a transitive Chat SDK `any`; the fixture supplies only the fields exercised here. */
-import type * as LinqModule from "eve/channels/linq";
+import type { HookContext } from "eve/hooks";
 import { describe, expect, it, vi } from "vitest";
+import * as BrowserImageServer from "@/lib/browser-images/server";
+import { linqChannelConfig } from "../agent/channels/linq";
 import workerCancellationHook from "../agent/hooks/worker-cancellation-delivery";
 
-const linqChannelCapture = vi.hoisted(() => ({
-  config: undefined as unknown,
-  readImage: vi.fn(),
-}));
-vi.mock("@/lib/browser-images/server", () => ({
-  readBrowserImageBytes: linqChannelCapture.readImage,
-}));
-vi.mock("eve/channels/linq", async (importOriginal) => {
-  const original = await importOriginal<typeof LinqModule>();
-  return {
-    ...original,
-    linqChannel(config: unknown) {
-      linqChannelCapture.config = config;
-      return config;
-    },
-  };
-});
-await import("../agent/channels/linq");
-
-const channelEvents = (
-  linqChannelCapture.config as LinqModule.LinqChannelConfig
-).events;
-const trackWorkerCancellation = channelEvents?.["action.result"];
-const deliverCompletedMessage = channelEvents?.["message.completed"];
-if (!trackWorkerCancellation || !deliverCompletedMessage) {
-  throw new Error("Linq event handlers are not configured.");
-}
+const readImageMock = vi.spyOn(BrowserImageServer, "readBrowserImageBytes");
+const channelEvents = linqChannelConfig.events;
+const trackWorkerCancellation = channelEvents["action.result"];
+const deliverCompletedMessage = channelEvents["message.completed"];
 
 type HandlerParameters = Parameters<typeof deliverCompletedMessage>;
+
+interface LinqTestMessage {
+  readonly files?: readonly {
+    readonly data: Buffer;
+    readonly filename: string;
+    readonly mimeType: string;
+  }[];
+  readonly markdown: string;
+}
+
+interface LinqTestState {
+  acknowledgedLinqMessageId?: string;
+  pendingToolCallMessage?: string | null;
+  workerCancellations?: readonly {
+    readonly sourceMessageId: string;
+    readonly taskId: string;
+  }[];
+}
 
 describe("Linq message delivery", () => {
   it("posts final responses as native iMessage Markdown", async () => {
@@ -54,7 +51,7 @@ describe("Linq message delivery", () => {
 
   it("replaces scoped artifact markdown with native iMessage files", async () => {
     const artifactId = "0d01e667-d128-4bb7-a248-1ae21db72f4f";
-    linqChannelCapture.readImage.mockResolvedValue({
+    readImageMock.mockResolvedValue({
       bytes: new Uint8Array([1, 2, 3]),
       filename: "product.png",
       id: artifactId,
@@ -70,7 +67,7 @@ describe("Linq message delivery", () => {
       sessionContext()
     );
 
-    expect(linqChannelCapture.readImage).toHaveBeenCalledWith(
+    expect(readImageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: "user-1",
         workspaceId: "workspace-1",
@@ -93,16 +90,14 @@ describe("Linq message delivery", () => {
   it("sends multiple artifact images as one native attachment gallery", async () => {
     const firstArtifactId = "0d01e667-d128-4bb7-a248-1ae21db72f4f";
     const secondArtifactId = "206c3a7e-c0b8-4317-9e34-552cff646673";
-    linqChannelCapture.readImage.mockImplementation(
-      async (_scope: unknown, artifactId: string) => ({
-        bytes: new Uint8Array(
-          artifactId === firstArtifactId ? [1, 2, 3] : [4, 5, 6]
-        ),
-        filename: artifactId === firstArtifactId ? "first.png" : "second.png",
-        id: artifactId,
-        mediaType: "image/png",
-      })
-    );
+    readImageMock.mockImplementation(async (_scope, artifactId) => ({
+      bytes: new Uint8Array(
+        artifactId === firstArtifactId ? [1, 2, 3] : [4, 5, 6]
+      ),
+      filename: artifactId === firstArtifactId ? "first.png" : "second.png",
+      id: artifactId,
+      mediaType: "image/png",
+    }));
     const { context, post } = handlerContext();
 
     await deliverCompletedMessage(
@@ -136,7 +131,7 @@ describe("Linq message delivery", () => {
 
   it("keeps reply bubbles and attaches images to the final bubble", async () => {
     const artifactId = "0d01e667-d128-4bb7-a248-1ae21db72f4f";
-    linqChannelCapture.readImage.mockResolvedValue({
+    readImageMock.mockResolvedValue({
       bytes: new Uint8Array([1, 2, 3]),
       filename: "product.png",
       id: artifactId,
@@ -202,11 +197,7 @@ describe("Linq message delivery", () => {
   it("suppresses the redundant turn after task cancellation", async () => {
     const { context, post } = handlerContext();
 
-    await trackWorkerCancellation(
-      workerCancellationResult(),
-      context,
-      sessionContext()
-    );
+    trackWorkerCancellation(workerCancellationResult(), context);
     await recordCancellationThroughHook(
       "session-1",
       "turn-2",
@@ -241,10 +232,9 @@ describe("Linq message delivery", () => {
   it("does not suppress an interleaved task result", async () => {
     const { context, post } = handlerContext();
 
-    await trackWorkerCancellation(
+    trackWorkerCancellation(
       workerCancellationResult("task-cancelled"),
-      context,
-      sessionContext()
+      context
     );
     await recordCancellationThroughHook(
       "session-1",
@@ -275,11 +265,7 @@ describe("Linq message delivery", () => {
 
   it("delivers user-authored cancellation text from a newer Linq message", async () => {
     const original = handlerContext("message-1");
-    await trackWorkerCancellation(
-      workerCancellationResult(),
-      original.context,
-      sessionContext()
-    );
+    trackWorkerCancellation(workerCancellationResult(), original.context);
 
     await recordCancellationThroughHook(
       "session-1",
@@ -304,10 +290,9 @@ describe("Linq message delivery", () => {
   it("retains older pending cancellations across many later tasks", async () => {
     const { context, post } = handlerContext();
     for (let index = 0; index < 60; index += 1) {
-      await trackWorkerCancellation(
+      trackWorkerCancellation(
         workerCancellationResult(`task-${String(index)}`),
-        context,
-        sessionContext()
+        context
       );
     }
     await recordCancellationThroughHook(
@@ -371,13 +356,14 @@ function completedEvent(
 
 function handlerContext(
   currentMessageId = "message-1",
-  state: Record<string, unknown> = {}
+  state: LinqTestState = {}
 ) {
-  const post = vi.fn<(message: unknown) => Promise<void>>();
+  const post = vi.fn<(message: LinqTestMessage) => Promise<void>>();
   post.mockResolvedValue();
   const addReaction = vi
     .fn<(threadId: string, messageId: string, emoji: string) => Promise<void>>()
     .mockResolvedValue(undefined);
+  // SAFETY: The fixture implements the Linq handler fields exercised by these tests.
   const context = {
     bot: {
       getAdapter: () => ({
@@ -398,7 +384,7 @@ function handlerContext(
         isDM: true,
       }),
     },
-  } as unknown as HandlerParameters[1];
+  } as HandlerParameters[1];
 
   return {
     addReaction,
@@ -410,16 +396,26 @@ function handlerContext(
 
 function sessionContext() {
   return {
+    async getSandbox() {
+      throw new Error("Sandbox access is outside this focused test.");
+    },
+    getSkill() {
+      throw new Error("Skill access is outside this focused test.");
+    },
     session: {
       auth: {
         current: {
           attributes: { workspaceId: "workspace-1" },
-          id: "user-1",
+          authenticator: "test",
+          principalId: "user-1",
+          principalType: "user",
         },
+        initiator: null,
       },
       id: "session-1",
+      turn: { id: "turn-1", sequence: 0 },
     },
-  } as unknown as HandlerParameters[2];
+  } satisfies HandlerParameters[2];
 }
 
 async function recordCancellationThroughHook(
@@ -429,16 +425,27 @@ async function recordCancellationThroughHook(
 ) {
   const handler = workerCancellationHook.events?.["message.received"];
   if (!handler) throw new Error("Worker cancellation hook is not configured.");
+  const context = {
+    agent: { name: "root" },
+    channel: { kind: "linq" },
+    async getSandbox() {
+      throw new Error("Sandbox access is outside this focused test.");
+    },
+    getSkill() {
+      throw new Error("Skill access is outside this focused test.");
+    },
+    session: {
+      auth: { current: null, initiator: null },
+      id: sessionId,
+      turn: { id: turnId, sequence: 0 },
+    },
+  } satisfies HookContext;
   await handler(
     {
       data: { message, sequence: 0, turnId },
       meta: { at: "2026-08-27T20:00:00.000Z", id: `received-${turnId}` },
       type: "message.received",
     },
-    {
-      agent: { name: "root" },
-      channel: { kind: "linq" },
-      session: { id: sessionId },
-    } as Parameters<typeof handler>[1]
+    context
   );
 }

--- a/tests/linq.test.ts
+++ b/tests/linq.test.ts
@@ -1,17 +1,21 @@
-import { getToken } from "@vercel/connect";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { LinqDeliveryError, linqOtpFailure, sendLinqText } from "@/auth/linq";
+import {
+  LinqDeliveryError,
+  linqDeliveryDependencies,
+  linqOtpFailure,
+  sendLinqText,
+} from "@/auth/linq";
 
-vi.mock("@vercel/connect", () => ({ getToken: vi.fn<typeof getToken>() }));
+const getTokenMock = vi.spyOn(linqDeliveryDependencies, "getToken");
 
 describe("Linq delivery", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
     vi.unstubAllGlobals();
   });
 
   it("uses the configured connector and sends the OTP", async () => {
-    vi.mocked(getToken).mockResolvedValue("test-token");
+    getTokenMock.mockResolvedValue("test-token");
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValue(new Response(null, { status: 202 }));
@@ -24,7 +28,7 @@ describe("Linq delivery", () => {
       to: "+12025550123",
     });
 
-    expect(getToken).toHaveBeenCalledWith("linq/open-instinct", {
+    expect(getTokenMock).toHaveBeenCalledWith("linq/open-instinct", {
       subject: { type: "app" },
     });
     const [url, init] = fetchMock.mock.calls[0] ?? [];
@@ -37,7 +41,7 @@ describe("Linq delivery", () => {
   });
 
   it("preserves Linq error diagnostics", async () => {
-    vi.mocked(getToken).mockResolvedValue("test-token");
+    getTokenMock.mockResolvedValue("test-token");
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>().mockResolvedValue(
@@ -57,7 +61,7 @@ describe("Linq delivery", () => {
       idempotencyKey: "otp-idempotency-key",
       message: "Your code is 123456.",
       to: "+12025550123",
-    }).catch((caught: unknown) => caught);
+    }).catch((cause: unknown) => cause);
 
     expect(error).toBeInstanceOf(LinqDeliveryError);
     if (!(error instanceof LinqDeliveryError)) {

--- a/tests/services.test.ts
+++ b/tests/services.test.ts
@@ -3,7 +3,7 @@ import { PGlite } from "@electric-sql/pglite";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { db } from "@/db";
+import * as Database from "@/db";
 import * as schema from "../db/schema";
 import {
   browserTraceDomains as browserTraceDomainsTable,
@@ -13,7 +13,7 @@ import {
 const databases: PGlite[] = [];
 
 afterEach(async () => {
-  vi.doUnmock("@/db");
+  vi.restoreAllMocks();
   vi.resetModules();
   await Promise.all(databases.splice(0).map((database) => database.close()));
 });
@@ -28,11 +28,10 @@ describe("database services", () => {
     await applyBrowserTraceEventMigration(client);
 
     const pgliteDatabase = drizzle(client, { schema });
-    // PGlite exposes the PostgreSQL query builders and transaction behavior
-    // used by the production node-postgres adapter.
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- adapter-compatible integration test double
-    const database = pgliteDatabase as unknown as typeof db;
-    vi.doMock("@/db", () => ({ ...schema, db: database }));
+    // SAFETY: PGlite implements the query-builder surface exercised by these services despite using a different Drizzle driver.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- This test swaps only the driver while retaining the shared Drizzle schema and query-builder contract.
+    const database = pgliteDatabase as never;
+    vi.spyOn(Database, "db", "get").mockReturnValue(database);
 
     const [
       browserImages,
@@ -245,7 +244,7 @@ describe("database services", () => {
       resultMessage: "Ordered.",
       status: "success",
     });
-    const [trace] = await database
+    const [trace] = await pgliteDatabase
       .select()
       .from(browserTracesTable)
       .where(eq(browserTracesTable.sessionId, "worker-alice"));
@@ -255,7 +254,9 @@ describe("database services", () => {
       status: "success",
       task: "Order the blue mug",
     });
-    const traceDomains = await database.select().from(browserTraceDomainsTable);
+    const traceDomains = await pgliteDatabase
+      .select()
+      .from(browserTraceDomainsTable);
     expect(traceDomains).toHaveLength(1);
     expect(traceDomains[0]).toMatchObject({
       domain: "shop.example.com",

--- a/tests/session-owner.test.ts
+++ b/tests/session-owner.test.ts
@@ -1,21 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { saveChat } from "@/db/services/chats";
-import type { ensureScope } from "@/db/services/scope";
-import type { claimSession } from "@/db/services/sessions";
+import type { HookContext } from "eve/hooks";
+import sessionOwner, {
+  sessionOwnerDependencies,
+} from "../agent/hooks/session-owner";
 
-const mocks = vi.hoisted(() => ({
-  claimSession: vi.fn<typeof claimSession>(),
-  ensureScope: vi.fn<typeof ensureScope>(),
-  saveChat: vi.fn<typeof saveChat>(),
-}));
-
-vi.mock("@/db/services/chats", () => ({ saveChat: mocks.saveChat }));
-vi.mock("@/db/services/scope", () => ({ ensureScope: mocks.ensureScope }));
-vi.mock("@/db/services/sessions", () => ({
-  claimSession: mocks.claimSession,
-}));
-
-import sessionOwner from "../agent/hooks/session-owner";
+const saveChatMock = vi.spyOn(sessionOwnerDependencies, "saveChat");
 
 type MessageReceivedHandler = NonNullable<
   NonNullable<typeof sessionOwner.events>["message.received"]
@@ -23,19 +12,32 @@ type MessageReceivedHandler = NonNullable<
 
 const scope = { userId: "user-1", workspaceId: "workspace-1" };
 const context = {
+  agent: { name: "test-agent" },
+  channel: {},
+  async getSandbox() {
+    throw new Error("Sandbox access is outside this focused test.");
+  },
+  getSkill() {
+    throw new Error("Skill access is outside this focused test.");
+  },
   session: {
     auth: {
+      current: null,
       initiator: {
         attributes: { workspaceId: scope.workspaceId },
+        authenticator: "test",
         principalId: scope.userId,
+        principalType: "user",
       },
     },
     id: "session-1",
+    turn: { id: "turn-1", sequence: 0 },
   },
-};
+} satisfies HookContext;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  saveChatMock.mockResolvedValue();
 });
 
 describe("session ownership hook", () => {
@@ -43,17 +45,17 @@ describe("session ownership hook", () => {
     const handler = sessionOwner.events?.["message.received"];
     expect(handler).toBeDefined();
 
-    // The handler only reads session identity; the event payload and remaining
-    // runtime services are intentionally omitted from this focused unit test.
-    // oxlint-disable typescript/no-unsafe-type-assertion -- The handler only
-    // reads the fields supplied by this focused unit test.
-    const event = {} as Parameters<MessageReceivedHandler>[0];
-    const hookContext =
-      context as unknown as Parameters<MessageReceivedHandler>[1];
-    // oxlint-enable typescript/no-unsafe-type-assertion
-    await handler?.(event, hookContext);
+    const event = {
+      data: { message: "hello", sequence: 0, turnId: "turn-1" },
+      meta: {
+        at: "2026-08-31T00:00:00.000Z",
+        id: "event-1",
+      },
+      type: "message.received",
+    } satisfies Parameters<MessageReceivedHandler>[0];
+    await handler?.(event, context);
 
-    expect(mocks.saveChat).toHaveBeenCalledWith(scope, {
+    expect(saveChatMock).toHaveBeenCalledWith(scope, {
       sessionId: "session-1",
     });
   });

--- a/tests/vault-autofill.test.ts
+++ b/tests/vault-autofill.test.ts
@@ -1,4 +1,6 @@
+import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import type { AccessScope } from "@/lib/access-scope";
 import type { VaultItemKind } from "@/lib/manager";
 import { serializePaymentCard } from "@/lib/manager/payment-card";
@@ -434,14 +436,14 @@ describe("vault browser autofill", () => {
       const form = { querySelectorAll: () => controls };
       for (const control of controls) control.form = form;
       const document = { querySelectorAll: () => controls };
-      // oxlint-disable-next-line typescript/no-implied-eval, typescript/no-unsafe-type-assertion -- execute the exact isolated-world expression against the DOM test double
-      const evaluate = Function(
-        "document",
-        "HTMLInputElement",
-        `return ${nativeAutofillSecretMarkingExpression(0)};`
-      ) as (documentValue: unknown, inputClass: unknown) => number;
+      const markedCount = z.number().parse(
+        runInNewContext(nativeAutofillSecretMarkingExpression(0), {
+          document,
+          HTMLInputElement: FakeInput,
+        })
+      );
 
-      expect(evaluate(document, FakeInput)).toBe(3);
+      expect(markedCount).toBe(3);
       expect(controls.map(({ dataset }) => dataset.vaultSecret)).toEqual([
         "true",
         "true",

--- a/tests/vault-screenshot-mask.test.ts
+++ b/tests/vault-screenshot-mask.test.ts
@@ -1,44 +1,52 @@
 /* oxlint-disable vitest/require-mock-type-parameters -- The hoisted Kernel fake records cleanup request options. */
 import { describe, expect, it, vi } from "vitest";
-
-const mocks = vi.hoisted(() => ({ playwrightExecute: vi.fn() }));
-
-vi.mock("@/lib/kernel", () => ({
-  kernel: { browsers: { playwright: { execute: mocks.playwrightExecute } } },
-}));
-
 import { withVaultScreenshotMask } from "../agent/subagents/worker/lib/vault-screenshot-mask";
+
+const playwrightExecuteMock =
+  vi.fn<
+    (
+      sessionId: string,
+      body: { readonly code: string; readonly timeout_sec: number },
+      options: { readonly signal?: AbortSignal }
+    ) => Promise<{ readonly success: boolean }>
+  >();
+const dependencies = { execute: playwrightExecuteMock };
 
 describe("Vault screenshot masking", () => {
   it("removes the mask with a fresh request after capture cancellation", async () => {
     const controller = new AbortController();
-    mocks.playwrightExecute.mockResolvedValue({ success: true });
+    playwrightExecuteMock.mockResolvedValue({ success: true });
 
     await expect(
-      withVaultScreenshotMask("browser-1", controller.signal, async () => {
-        controller.abort();
-        throw new Error("Capture cancelled");
-      })
+      withVaultScreenshotMask(
+        "browser-1",
+        controller.signal,
+        async () => {
+          controller.abort();
+          throw new Error("Capture cancelled");
+        },
+        dependencies
+      )
     ).rejects.toThrow("Capture cancelled");
 
-    expect(mocks.playwrightExecute).toHaveBeenCalledTimes(2);
-    expect(
-      JSON.stringify(mocks.playwrightExecute.mock.calls[0]?.[1])
-    ).toContain("append(style)");
-    expect(mocks.playwrightExecute.mock.calls[0]?.[2]).toEqual({
+    expect(playwrightExecuteMock).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(playwrightExecuteMock.mock.calls[0]?.[1])).toContain(
+      "append(style)"
+    );
+    expect(playwrightExecuteMock.mock.calls[0]?.[2]).toEqual({
       signal: controller.signal,
     });
-    expect(
-      JSON.stringify(mocks.playwrightExecute.mock.calls[1]?.[1])
-    ).toContain("remove()");
-    expect(mocks.playwrightExecute.mock.calls[1]?.[2]).toEqual({
+    expect(JSON.stringify(playwrightExecuteMock.mock.calls[1]?.[1])).toContain(
+      "remove()"
+    );
+    expect(playwrightExecuteMock.mock.calls[1]?.[2]).toEqual({
       signal: undefined,
     });
   });
 
   it("keeps the shared mask until every overlapping capture completes", async () => {
     let maskReferences = 0;
-    mocks.playwrightExecute.mockImplementation(
+    playwrightExecuteMock.mockImplementation(
       async (_sessionId: string, body: { code: string }) => {
         maskReferences += body.code.includes("remainingRefs") ? -1 : 1;
         return { success: true };
@@ -52,7 +60,8 @@ describe("Vault screenshot masking", () => {
       () =>
         new Promise<void>((resolve) => {
           finishFirst = resolve;
-        })
+        }),
+      dependencies
     );
     await vi.waitFor(() => {
       expect(maskReferences).toBe(1);
@@ -63,7 +72,8 @@ describe("Vault screenshot masking", () => {
       () =>
         new Promise<void>((resolve) => {
           finishSecond = resolve;
-        })
+        }),
+      dependencies
     );
     await vi.waitFor(() => {
       expect(maskReferences).toBe(2);
@@ -76,7 +86,7 @@ describe("Vault screenshot masking", () => {
     finishSecond?.();
     await second;
     expect(maskReferences).toBe(0);
-    expect(JSON.stringify(mocks.playwrightExecute.mock.calls)).toContain(
+    expect(JSON.stringify(playwrightExecuteMock.mock.calls)).toContain(
       "vaultMaskRefs"
     );
   });

--- a/tests/worker-access.test.ts
+++ b/tests/worker-access.test.ts
@@ -1,20 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { accessScopeForUser, type AccessScope } from "@/lib/access-scope";
-
-const mocks = vi.hoisted(() => ({
-  isSessionOwned:
-    vi.fn<(_scope: AccessScope, _sessionId: string) => Promise<boolean>>(),
-}));
-
-vi.mock("@/db/services/sessions", () => ({
-  isSessionOwned: mocks.isSessionOwned,
-}));
-
+import * as SessionService from "@/db/services/sessions";
+import { accessScopeForUser } from "@/lib/access-scope";
 import { requireWorkerScope } from "@/agent/subagents/worker/lib/access";
+
+const isSessionOwnedMock = vi.spyOn(SessionService, "isSessionOwned");
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.isSessionOwned.mockResolvedValue(true);
+  isSessionOwnedMock.mockResolvedValue(true);
 });
 
 describe("worker access", () => {
@@ -26,13 +19,13 @@ describe("worker access", () => {
       })
     ).resolves.toEqual(accessScopeForUser(principal.principalId));
 
-    expect(mocks.isSessionOwned).toHaveBeenCalledTimes(2);
-    expect(mocks.isSessionOwned).toHaveBeenNthCalledWith(
+    expect(isSessionOwnedMock).toHaveBeenCalledTimes(2);
+    expect(isSessionOwnedMock).toHaveBeenNthCalledWith(
       1,
       accessScopeForUser(principal.principalId),
       "worker-session"
     );
-    expect(mocks.isSessionOwned).toHaveBeenNthCalledWith(
+    expect(isSessionOwnedMock).toHaveBeenNthCalledWith(
       2,
       accessScopeForUser(principal.principalId),
       "root-session"
@@ -47,9 +40,7 @@ describe("worker access", () => {
       requireWorkerScope({ session: { ...session, parent: undefined } })
     ).rejects.toThrow("require a delegated worker");
 
-    mocks.isSessionOwned
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
+    isSessionOwnedMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     await expect(requireWorkerScope({ session })).rejects.toThrow(
       "does not own this worker session"
     );

--- a/tests/worker-browser-images.test.ts
+++ b/tests/worker-browser-images.test.ts
@@ -1,5 +1,13 @@
 /* oxlint-disable typescript/no-unsafe-type-assertion, vitest/require-mock-type-parameters -- Eve owns the tool context and Vitest owns these hoisted provider fakes. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as WorkerAccess from "@/agent/subagents/worker/lib/access";
+import * as OwnedBrowser from "@/agent/subagents/worker/lib/owned-browser";
+import * as ScreenshotMask from "@/agent/subagents/worker/lib/vault-screenshot-mask";
+import * as BrowserImageService from "@/db/services/browser-images";
+import * as BrowserImageServer from "@/lib/browser-images/server";
+import { kernel } from "@/lib/kernel";
+import captureBrowserImage from "../agent/subagents/worker/tools/capture_browser_image";
+import { toolContextFor } from "./helpers/tool-context";
 
 const artifactId = "0d01e667-d128-4bb7-a248-1ae21db72f4f";
 const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -12,50 +20,23 @@ const image = {
   url: `/artifacts/${artifactId}`,
 };
 
-const mocks = vi.hoisted(() => ({
-  captureScreenshot: vi.fn(),
-  deleteFile: vi.fn(),
-  fetch: vi.fn(),
-  mask: vi.fn(),
-  persist: vi.fn(),
-  playwrightExecute: vi.fn(),
-  readBoundedResponse: vi.fn(),
-  readFile: vi.fn(),
-  reserve: vi.fn(),
-  retrieve: vi.fn(),
-  requireOwnedBrowserSession: vi.fn(),
-  requireWorkerScope: vi.fn(),
-}));
-
-vi.mock("@/agent/subagents/worker/lib/access", () => ({
-  requireWorkerScope: mocks.requireWorkerScope,
-}));
-vi.mock("@/agent/subagents/worker/lib/owned-browser", () => ({
-  requireOwnedBrowserSession: mocks.requireOwnedBrowserSession,
-}));
-vi.mock("@/agent/subagents/worker/lib/vault-screenshot-mask", () => ({
-  withVaultScreenshotMask: mocks.mask,
-}));
-vi.mock("@/db/services/browser-images", () => ({
-  reserveBrowserImageArtifact: mocks.reserve,
-}));
-vi.mock("@/lib/browser-images/server", () => ({
-  persistReservedBrowserImage: mocks.persist,
-  readBoundedResponse: mocks.readBoundedResponse,
-}));
-vi.mock("@/lib/kernel", () => ({
-  kernel: {
-    browsers: {
-      computer: { captureScreenshot: mocks.captureScreenshot },
-      fetch: mocks.fetch,
-      fs: { deleteFile: mocks.deleteFile, readFile: mocks.readFile },
-      playwright: { execute: mocks.playwrightExecute },
-      retrieve: mocks.retrieve,
-    },
-  },
-}));
-
-import captureBrowserImage from "../agent/subagents/worker/tools/capture_browser_image";
+const mocks = {
+  captureScreenshot: vi.spyOn(kernel.browsers.computer, "captureScreenshot"),
+  deleteFile: vi.spyOn(kernel.browsers.fs, "deleteFile"),
+  fetch: vi.spyOn(kernel.browsers, "fetch"),
+  mask: vi.spyOn(ScreenshotMask, "withVaultScreenshotMask"),
+  persist: vi.spyOn(BrowserImageServer, "persistReservedBrowserImage"),
+  playwrightExecute: vi.spyOn(kernel.browsers.playwright, "execute"),
+  readBoundedResponse: vi.spyOn(BrowserImageServer, "readBoundedResponse"),
+  readFile: vi.spyOn(kernel.browsers.fs, "readFile"),
+  reserve: vi.spyOn(BrowserImageService, "reserveBrowserImageArtifact"),
+  retrieve: vi.spyOn(kernel.browsers, "retrieve"),
+  requireOwnedBrowserSession: vi.spyOn(
+    OwnedBrowser,
+    "requireOwnedBrowserSession"
+  ),
+  requireWorkerScope: vi.spyOn(WorkerAccess, "requireWorkerScope"),
+};
 
 const scope = { userId: "user-1", workspaceId: "workspace-1" };
 const reservation = {
@@ -67,20 +48,31 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.requireWorkerScope.mockResolvedValue(scope);
   mocks.requireOwnedBrowserSession.mockResolvedValue({
+    createdAt: "2026-08-31T00:00:00.000Z",
     sessionId: "browser-1",
+    workerSessionId: "worker-session-1",
   });
   mocks.reserve.mockResolvedValue({ reservation, status: "pending" });
   mocks.persist.mockResolvedValue(image);
-  mocks.mask.mockImplementation(
-    async (_sessionId: string, _signal: AbortSignal, capture: () => unknown) =>
-      capture()
+  mocks.mask.mockImplementation(async (_sessionId, _signal, capture) =>
+    capture()
   );
   mocks.captureScreenshot.mockResolvedValue(new Response(png));
   mocks.readBoundedResponse.mockResolvedValue(png);
   mocks.playwrightExecute.mockResolvedValue({ result: true, success: true });
   mocks.readFile.mockResolvedValue(new Response(png));
   mocks.deleteFile.mockResolvedValue(undefined);
-  mocks.retrieve.mockResolvedValue({ session_id: "browser-1" });
+  mocks.retrieve.mockResolvedValue({
+    cdp_ws_url: "wss://kernel.test/cdp",
+    created_at: "2026-08-31T00:00:00.000Z",
+    headless: false,
+    memory: "2GiB",
+    region: "us-east",
+    session_id: "browser-1",
+    stealth: true,
+    timeout_seconds: 900,
+    webdriver_ws_url: "wss://kernel.test/webdriver",
+  });
   mocks.fetch.mockResolvedValue(
     new Response(png, { headers: { "content-type": "image/png" } })
   );
@@ -88,6 +80,7 @@ beforeEach(() => {
 
 describe("capture_browser_image", () => {
   it("captures a masked viewport and returns only the artifact descriptor", async () => {
+    const toolContext = context();
     const result = await captureBrowserImage.execute(
       {
         label: "Product",
@@ -95,7 +88,7 @@ describe("capture_browser_image", () => {
         session_id: "browser-1",
         source: "viewport",
       },
-      context() as never
+      toolContext
     );
 
     expect(mocks.requireWorkerScope).toHaveBeenCalledOnce();
@@ -107,13 +100,13 @@ describe("capture_browser_image", () => {
     expect(mocks.captureScreenshot).toHaveBeenCalledWith(
       "browser-1",
       { region: { height: 200, width: 300, x: 10, y: 20 } },
-      { signal: undefined }
+      { signal: toolContext.abortSignal }
     );
     expect(mocks.persist).toHaveBeenCalledWith(
       scope,
       reservation,
       expect.objectContaining({ sourceKind: "viewport" }),
-      undefined
+      toolContext.abortSignal
     );
     expect(result).toEqual({ image });
     expect(JSON.stringify(result)).not.toContain("base64");
@@ -125,15 +118,16 @@ describe("capture_browser_image", () => {
   ] as const)(
     "captures a Playwright %s screenshot",
     async (source, selector, code) => {
-      await captureBrowserImage.execute(
-        {
-          label: "Product",
-          session_id: "browser-1",
-          source,
-          ...(selector ? { selector } : {}),
-        } as never,
-        context() as never
-      );
+      const input =
+        source === "element"
+          ? {
+              label: "Product",
+              selector,
+              session_id: "browser-1",
+              source,
+            }
+          : { label: "Product", session_id: "browser-1", source };
+      await captureBrowserImage.execute(input, context());
 
       expect(JSON.stringify(mocks.playwrightExecute.mock.calls)).toContain(
         code
@@ -144,6 +138,7 @@ describe("capture_browser_image", () => {
   );
 
   it("fetches an image element's original resource through the browser", async () => {
+    const toolContext = context();
     mocks.playwrightExecute.mockResolvedValue({
       result: { url: "https://images.example/product.png?private=ignored" },
       success: true,
@@ -156,13 +151,13 @@ describe("capture_browser_image", () => {
         session_id: "browser-1",
         source: "image_resource",
       },
-      context() as never
+      toolContext
     );
 
     expect(mocks.retrieve).toHaveBeenCalledWith(
       "browser-1",
       {},
-      { signal: undefined }
+      { signal: toolContext.abortSignal }
     );
     expect(mocks.fetch).toHaveBeenCalledWith(
       "browser-1",
@@ -173,7 +168,7 @@ describe("capture_browser_image", () => {
       scope,
       reservation,
       expect.objectContaining({ sourceKind: "image_resource" }),
-      undefined
+      expect.any(AbortSignal)
     );
     expect(JSON.stringify(mocks.persist.mock.calls)).not.toContain(
       "private=ignored"
@@ -181,6 +176,7 @@ describe("capture_browser_image", () => {
   });
 
   it("falls back to an element screenshot when the resource cannot be fetched", async () => {
+    const toolContext = context();
     mocks.playwrightExecute
       .mockResolvedValueOnce({
         result: { url: "https://images.example/product.avif" },
@@ -196,7 +192,7 @@ describe("capture_browser_image", () => {
         session_id: "browser-1",
         source: "image_resource",
       },
-      context() as never
+      toolContext
     );
 
     expect(mocks.readFile).toHaveBeenCalledOnce();
@@ -204,7 +200,7 @@ describe("capture_browser_image", () => {
       scope,
       reservation,
       expect.objectContaining({ sourceKind: "element" }),
-      undefined
+      toolContext.abortSignal
     );
   });
 
@@ -217,7 +213,7 @@ describe("capture_browser_image", () => {
         session_id: "browser-1",
         source: "viewport",
       },
-      context() as never
+      context()
     );
 
     expect(result).toEqual({ image });
@@ -235,7 +231,7 @@ describe("capture_browser_image", () => {
           session_id: "browser-1",
           source: "viewport",
         },
-        context() as never
+        context()
       )
     ).rejects.toThrow("Kernel failed");
     expect(mocks.persist).not.toHaveBeenCalled();
@@ -245,7 +241,7 @@ describe("capture_browser_image", () => {
     const controller = new AbortController();
     mocks.readFile.mockImplementation(() => {
       controller.abort();
-      return Promise.reject(new Error("Capture cancelled"));
+      throw new Error("Capture cancelled");
     });
 
     await expect(
@@ -255,7 +251,7 @@ describe("capture_browser_image", () => {
           session_id: "browser-1",
           source: "full_page",
         },
-        context(controller.signal) as never
+        context(controller.signal)
       )
     ).rejects.toThrow("Capture cancelled");
     expect(mocks.deleteFile).toHaveBeenCalledOnce();
@@ -267,12 +263,11 @@ describe("capture_browser_image", () => {
 });
 
 function context(abortSignal?: AbortSignal) {
-  return {
-    abortSignal,
+  return toolContextFor({
+    abortSignal: abortSignal ?? new AbortController().signal,
     callId: "call-image",
-    session: {
-      id: "worker-session",
-      parent: { rootSessionId: "root-session" },
-    },
-  };
+    parentSessionId: "root-session",
+    sessionId: "worker-session",
+    toolName: "capture_browser_image",
+  });
 }

--- a/tests/worker-browser-tools.test.ts
+++ b/tests/worker-browser-tools.test.ts
@@ -1,51 +1,24 @@
 /* oxlint-disable typescript/no-unsafe-type-assertion -- Eve tool contexts are runtime-owned; these fixtures exercise only mocked authorization and abort-signal boundaries. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-
-const mocks = vi.hoisted(() => ({
-  batch:
-    vi.fn<(_id: string, _body: unknown, _options: unknown) => Promise<void>>(),
-  playwrightExecute: vi.fn<
-    (
-      _id: string,
-      _body: unknown,
-      _options: unknown
-    ) => Promise<{
-      success: boolean;
-    }>
-  >(),
-  readClipboard:
-    vi.fn<(_id: string, _options: unknown) => Promise<{ text: string }>>(),
-  requireOwnedBrowserSession:
-    vi.fn<(_scope: unknown, _sessionId: string) => Promise<unknown>>(),
-  requireWorkerScope: vi.fn<(_context: unknown) => Promise<unknown>>(),
-  writeClipboard:
-    vi.fn<(_id: string, _body: unknown, _options: unknown) => Promise<void>>(),
-}));
-
-vi.mock("@/agent/subagents/worker/lib/access", () => ({
-  requireWorkerScope: mocks.requireWorkerScope,
-}));
-
-vi.mock("@/agent/subagents/worker/lib/owned-browser", () => ({
-  requireOwnedBrowserSession: mocks.requireOwnedBrowserSession,
-}));
-
-vi.mock("@/lib/kernel", () => ({
-  kernel: {
-    browsers: {
-      computer: {
-        batch: mocks.batch,
-        readClipboard: mocks.readClipboard,
-        writeClipboard: mocks.writeClipboard,
-      },
-      playwright: { execute: mocks.playwrightExecute },
-    },
-  },
-}));
-
+import * as WorkerAccess from "@/agent/subagents/worker/lib/access";
+import * as OwnedBrowser from "@/agent/subagents/worker/lib/owned-browser";
+import { kernel } from "@/lib/kernel";
+import { toolContextFor } from "./helpers/tool-context";
 import computerAction from "../agent/subagents/worker/tools/computer_action";
 import executePlaywrightCode from "../agent/subagents/worker/tools/execute_playwright_code";
+
+const mocks = {
+  batch: vi.spyOn(kernel.browsers.computer, "batch"),
+  playwrightExecute: vi.spyOn(kernel.browsers.playwright, "execute"),
+  readClipboard: vi.spyOn(kernel.browsers.computer, "readClipboard"),
+  requireOwnedBrowserSession: vi.spyOn(
+    OwnedBrowser,
+    "requireOwnedBrowserSession"
+  ),
+  requireWorkerScope: vi.spyOn(WorkerAccess, "requireWorkerScope"),
+  writeClipboard: vi.spyOn(kernel.browsers.computer, "writeClipboard"),
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -54,7 +27,9 @@ beforeEach(() => {
     workspaceId: "workspace-1",
   });
   mocks.requireOwnedBrowserSession.mockResolvedValue({
+    createdAt: "2026-08-31T00:00:00.000Z",
     sessionId: "browser-1",
+    workerSessionId: "worker-session-1",
   });
   mocks.batch.mockResolvedValue();
   mocks.playwrightExecute.mockResolvedValue({ success: true });
@@ -65,6 +40,7 @@ beforeEach(() => {
 describe("worker browser tools", () => {
   it("sends contiguous computer actions through Kernel batch while preserving read order", async () => {
     const execute = computerAction.execute;
+    const context = toolContextFor();
     const result = await execute(
       {
         actions: [
@@ -76,7 +52,7 @@ describe("worker browser tools", () => {
         ],
         session_id: "browser-1",
       },
-      {} as never
+      context
     );
 
     expect(mocks.batch).toHaveBeenCalledTimes(2);
@@ -90,7 +66,7 @@ describe("worker browser tools", () => {
           { sleep: { duration_ms: 100 }, type: "sleep" },
         ],
       },
-      { signal: undefined }
+      { signal: context.abortSignal }
     );
     expect(mocks.batch.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.readClipboard.mock.invocationCallOrder[0] ?? Infinity
@@ -103,15 +79,16 @@ describe("worker browser tools", () => {
 
   it("uses one fixed Playwright ceiling without asking the model to tune it", async () => {
     const execute = executePlaywrightCode.execute;
+    const context = toolContextFor();
     await execute(
       { code: "return await page.title();", session_id: "browser-1" },
-      {} as never
+      context
     );
 
     expect(mocks.playwrightExecute).toHaveBeenCalledExactlyOnceWith(
       "browser-1",
       { code: "return await page.title();", timeout_sec: 25 },
-      { signal: undefined }
+      { signal: context.abortSignal }
     );
 
     const inputSchema = executePlaywrightCode.inputSchema;

--- a/tools/oxlint/README.md
+++ b/tools/oxlint/README.md
@@ -8,3 +8,8 @@ It is kept local because this public repository cannot depend on Foundation's
 internal packages. The adaptation supports both root-level `app/` and
 `src/app/` Next.js projects. Rule activation belongs in the root
 `.oxlintrc.jsonc`.
+
+The `anti-slop` plugin vendors the generic rules and shared helpers from
+[`dmmulroy/anti-slop`](https://github.com/dmmulroy/anti-slop) at commit
+`0b863049ca2173b74ae6ebf1f8d0f6f911f9a220`. The upstream Effect integration
+is intentionally excluded. Its MIT license is included in the plugin folder.

--- a/tools/oxlint/anti-slop/LICENSE
+++ b/tools/oxlint/anti-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dillon Mulroy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,41 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
+import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.ts";
+import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
+import { noModuleMockingRule } from "./rules/no-module-mocking.ts";
+import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
+import { noReflectApplyRule } from "./rules/no-reflect-apply.ts";
+import { noReflectGetRule } from "./rules/no-reflect-get.ts";
+import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
+import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.ts";
+import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
+import { noUnknownReturnsRule } from "./rules/no-unknown-returns.ts";
+import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
+import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.ts";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.ts";
+import { requireSafetyCommentForTypeAssertionRule } from "./rules/require-safety-comment-for-type-assertion.ts";
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = eslintCompatPlugin({
+	meta: { name: "anti-slop" },
+	rules: {
+		"no-chained-type-assertions": noChainedTypeAssertionsRule,
+		"no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+		"no-known-value-widening": noKnownValueWideningRule,
+		"no-module-mocking": noModuleMockingRule,
+		"no-object-parameters": noObjectParametersRule,
+		"no-reflect-apply": noReflectApplyRule,
+		"no-reflect-get": noReflectGetRule,
+		"no-runtime-typeof": noRuntimeTypeofRule,
+		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
+		"no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
+		"no-unknown-parameters": noUnknownParametersRule,
+		"no-unknown-returns": noUnknownReturnsRule,
+		"no-unknown-type-aliases": noUnknownTypeAliasesRule,
+		"no-widen-then-assert": noWidenThenAssertRule,
+		"require-safety-comment-for-type-assertion": requireSafetyCommentForTypeAssertionRule,
+	},
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === "TSAsExpression" || node.type === "TSTypeAssertion";
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === "TSTypeReference" &&
+    typeAnnotation.typeName.type === "Identifier" &&
+    typeAnnotation.typeName.name === "const"
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === "ParenthesizedExpression" && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.",
+    },
+    messages: {
+      chained:
+        "This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.",
+    },
+  },
+  createOnce(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: "chained" });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,49 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === "ObjectExpression" && node.properties.length === 0;
+}
+
+function isConditionalEmptyObjectSpread(node: ESTree.Expression): boolean {
+  const conditional = unwrapParentheses(node);
+  return (
+    conditional.type === "ConditionalExpression" &&
+    (isEmptyObjectExpression(conditional.consequent) ||
+      isEmptyObjectExpression(conditional.alternate))
+  );
+}
+
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow object spreads that conditionally spread an empty object to omit fields.",
+    },
+    messages: {
+      avoid:
+        "This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.",
+    },
+  },
+  createOnce(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== "ObjectExpression") return;
+
+        if (isConditionalEmptyObjectSpread(node.argument)) {
+          context.report({ node, messageId: "avoid" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,427 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionaryValue,
+	classifyWideningTarget,
+	createTypeEnvironment,
+	isKnownEvidenceExpression,
+	type TypeEnvironment,
+	type WideningTarget,
+} from "../shared/dictionary-types.ts";
+import {
+	containsUnknownType,
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSSatisfiesExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+function resolveVariable(
+	sourceCode: SourceCode,
+	identifier: ESTree.IdentifierReference,
+): Variable | null {
+	let scope: Scope | null = sourceCode.getScope(identifier);
+	while (scope !== null) {
+		const variable = scope.set.get(identifier.name);
+		if (variable !== undefined) return variable;
+		scope = scope.upper;
+	}
+	return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	return definition?.type === "Variable" && definition.node.type === "VariableDeclarator"
+		? definition.node
+		: null;
+}
+
+function isStableConstVariable(variable: Variable, declarator: ESTree.VariableDeclarator): boolean {
+	return (
+		declarator.parent.type === "VariableDeclaration" &&
+		declarator.parent.kind === "const" &&
+		variable.references.every((reference) => reference.init || !reference.isWrite())
+	);
+}
+
+function hasKnownEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (isKnownEvidenceExpression(expression)) return true;
+	const unwrapped = unwrapExpression(expression);
+	if (unwrapped.type !== "Identifier") return false;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function isFunctionExpression(node: ESTree.Node): node is FunctionExpression {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression" ||
+		node.type === "TSDeclareFunction" ||
+		node.type === "TSEmptyBodyFunctionExpression"
+	);
+}
+
+function localFunctionForCall(
+	sourceCode: SourceCode,
+	callee: ESTree.Expression,
+): FunctionExpression | null {
+	const unwrapped = unwrapExpression(callee);
+	if (isFunctionExpression(unwrapped)) return unwrapped;
+	if (unwrapped.type !== "Identifier") return null;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (definition.type === "FunctionName" && isFunctionExpression(definition.node)) {
+		return definition.node;
+	}
+	if (definition.type !== "Variable" || definition.node.type !== "VariableDeclarator") {
+		return null;
+	}
+	const initializer = definition.node.init;
+	if (initializer === null) return null;
+	const unwrappedInitializer = unwrapExpression(initializer);
+	return isFunctionExpression(unwrappedInitializer) ? unwrappedInitializer : null;
+}
+
+function variableTypeAnnotation(
+	sourceCode: SourceCode,
+	variable: Variable,
+): ESTree.TSTypeAnnotation | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (
+		definition.type === "Variable" &&
+		definition.node.type === "VariableDeclarator" &&
+		definition.node.id.type === "Identifier"
+	) {
+		return definition.node.id.typeAnnotation ?? null;
+	}
+	if (definition.type !== "Parameter" || !isFunctionExpression(definition.node)) {
+		return null;
+	}
+	const parameter = definition.node.params.find(
+		(candidate) =>
+			functionParameterBindingName(candidate, sourceCode) === variable.name,
+	);
+	return parameter === undefined ? null : (functionParameterTypeAnnotation(parameter) ?? null);
+}
+
+function hasInformativeType(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): boolean {
+	return classifyUnsafeDictionaryValue(type, environment) === null;
+}
+
+function hasKnownCallArgumentEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	environment: TypeEnvironment,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (expression.type === "ParenthesizedExpression" || expression.type === "TSNonNullExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "TSAsExpression" || expression.type === "TSTypeAssertion") {
+		return hasInformativeType(expression.typeAnnotation, environment);
+	}
+	if (expression.type === "TSSatisfiesExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "CallExpression") {
+		const owner = localFunctionForCall(sourceCode, expression.callee);
+		const returnType = owner?.returnType?.typeAnnotation;
+		return returnType !== undefined && hasInformativeType(returnType, environment);
+	}
+	if (expression.type !== "Identifier") return isKnownEvidenceExpression(expression);
+	const variable = resolveVariable(sourceCode, expression);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const annotation = variableTypeAnnotation(sourceCode, variable);
+	if (annotation !== null) {
+		return hasInformativeType(annotation.typeAnnotation, environment);
+	}
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownCallArgumentEvidence(
+		sourceCode,
+		declarator.init,
+		environment,
+		visitedVariables,
+	);
+}
+
+function typePredicateSubjectIndex(
+	sourceCode: SourceCode,
+	owner: FunctionExpression,
+): number | null {
+	const predicate = owner.returnType?.typeAnnotation;
+	if (predicate?.type !== "TSTypePredicate" || predicate.parameterName.type !== "Identifier") {
+		return null;
+	}
+	const predicateParameterName = predicate.parameterName.name;
+	const index = owner.params.findIndex(
+		(parameter) =>
+			functionParameterBindingName(parameter, sourceCode) === predicateParameterName,
+	);
+	return index === -1 ? null : index;
+}
+
+function annotationTarget(
+	annotation: ESTree.TSTypeAnnotation | null | undefined,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	return annotation === null || annotation === undefined
+		? null
+		: classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (
+			current.type === "ArrowFunctionExpression" ||
+			current.type === "FunctionDeclaration" ||
+			current.type === "FunctionExpression"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return null;
+}
+
+function sourceKeyName(sourceCode: SourceCode, key: ESTree.PropertyKey): string {
+	if (key.type === "Identifier" || key.type === "PrivateIdentifier") return key.name;
+	if (key.type === "Literal") return String(key.value);
+	return sourceCode.getText(key);
+}
+
+function functionName(sourceCode: SourceCode, owner: FunctionExpression | null): string {
+	if (owner === null) return "anonymous function";
+	if (owner.id !== null) return owner.id.name;
+	const parent = owner.parent;
+	if (parent.type === "VariableDeclarator" && parent.id.type === "Identifier")
+		return parent.id.name;
+	if (parent.type === "MethodDefinition") return sourceKeyName(sourceCode, parent.key);
+	return "anonymous function";
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+	const unwrapped = unwrapExpression(expression);
+	return unwrapped.type === "ObjectExpression" && unwrapped.properties.length === 0;
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+	return destination.kind === "open dictionary" || destination.kind === "generic container";
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+	return node.parent?.type === "TSAsExpression" || node.parent?.type === "TSTypeAssertion";
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.",
+		},
+		messages: {
+			widening:
+				"The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+
+		const reportFlow = (
+			expression: ESTree.Expression,
+			destination: WideningTarget | null,
+			subject: string,
+		) => {
+			if (destination === null) return;
+			if (
+				isDictionaryAccumulatorTarget(destination) &&
+				isEmptyObjectExpression(expression)
+			) {
+				return;
+			}
+			if (!hasKnownEvidence(context.sourceCode, expression)) return;
+			context.report({
+				node: expression,
+				messageId: "widening",
+				data: { subject, target: destination.kind },
+			});
+		};
+
+		const targetFromAnnotation = (annotation: ESTree.TSTypeAnnotation | null | undefined) =>
+			environment === null ? null : annotationTarget(annotation, environment);
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			VariableDeclarator(node) {
+				if (node.init === null || node.id.type !== "Identifier") return;
+				reportFlow(
+					node.init,
+					targetFromAnnotation(node.id.typeAnnotation),
+					`binding \`${node.id.name}\``,
+				);
+			},
+			PropertyDefinition(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AccessorProperty(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AssignmentExpression(node) {
+				if (node.operator !== "=" || node.left.type !== "Identifier") return;
+				const variable = resolveVariable(context.sourceCode, node.left);
+				if (variable === null) return;
+				const declarator = variableDeclarator(variable);
+				if (declarator === null || declarator.id.type !== "Identifier") return;
+				reportFlow(
+					node.right,
+					targetFromAnnotation(declarator.id.typeAnnotation),
+					`binding \`${declarator.id.name}\``,
+				);
+			},
+			CallExpression(node) {
+				if (environment === null) return;
+				const owner = localFunctionForCall(context.sourceCode, node.callee);
+				if (owner === null) return;
+				const parameterIndex = typePredicateSubjectIndex(context.sourceCode, owner);
+				if (parameterIndex === null) return;
+				const parameter = owner.params[parameterIndex];
+				const argument = node.arguments[parameterIndex];
+				if (parameter === undefined || argument === undefined || argument.type === "SpreadElement") {
+					return;
+				}
+				const parameterAnnotation = functionParameterTypeAnnotation(parameter);
+				if (
+					parameterAnnotation === null ||
+					parameterAnnotation === undefined ||
+					!containsUnknownType(parameterAnnotation.typeAnnotation)
+				) {
+					return;
+				}
+				if (
+					!hasKnownCallArgumentEvidence(
+						context.sourceCode,
+						argument,
+						environment,
+					)
+				) {
+					return;
+				}
+				context.report({
+					node: argument,
+					messageId: "widening",
+					data: {
+						subject: `argument for parameter \`${functionParameterBindingName(parameter, context.sourceCode)}\` of \`${functionName(context.sourceCode, owner)}\``,
+						target: "unknown",
+					},
+				});
+			},
+			ReturnStatement(node) {
+				if (node.argument === null) return;
+				const owner = enclosingFunction(node);
+				reportFlow(
+					node.argument,
+					targetFromAnnotation(owner?.returnType),
+					`return value of \`${functionName(context.sourceCode, owner)}\``,
+				);
+			},
+			ArrowFunctionExpression(node) {
+				if (node.body.type === "BlockStatement") return;
+				reportFlow(
+					node.body,
+					targetFromAnnotation(node.returnType),
+					`return value of \`${functionName(context.sourceCode, node)}\``,
+				);
+			},
+			TSAsExpression(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+			TSTypeAssertion(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,91 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+const moduleMockMethods = new Set(["doMock", "mock", "unstable_mockModule"]);
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== "ImportSpecifier") return null;
+  return node.imported.type === "Identifier" ? node.imported.name : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== "Identifier") return false;
+  if (
+    (expression.name === "vi" || expression.name === "jest") &&
+    sourceCode.isGlobalReference(expression)
+  ) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === "vi" || expression.name === "jest";
+  }
+  return variable.defs.some((definition) => {
+    if (definition.type !== "ImportBinding" || definition.parent?.type !== "ImportDeclaration") {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (source === "vitest" && name === "vi") || (source === "@jest/globals" && name === "jest");
+  });
+}
+
+function moduleMockCall(sourceCode: SourceCode, callee: ESTree.Expression): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === "Literal" &&
+      (property.value === "doMock" ||
+        property.value === "mock" ||
+        property.value === "unstable_mockModule")
+      ? property.value
+      : null
+    : property.type === "Identifier"
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.",
+    },
+    messages: {
+      moduleMock:
+        "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: "moduleMock" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,83 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+import {
+	createTypeAliasEnvironment,
+	resolvedTypeMatches,
+	type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+type ParameterOwner =
+	| ESTree.ArrowFunctionExpression
+	| ESTree.Function
+	| ESTree.TSCallSignatureDeclaration
+	| ESTree.TSConstructSignatureDeclaration
+	| ESTree.TSConstructorType
+	| ESTree.TSFunctionType
+	| ESTree.TSMethodSignature;
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.",
+		},
+		messages: {
+			objectParameter:
+				"Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeAliasEnvironment | null = null;
+
+		const resolvesToObject = (type: ESTree.TSType): boolean =>
+			environment !== null &&
+			resolvedTypeMatches(type, environment, (resolved, matches) => {
+				if (resolved.type === "TSObjectKeyword") return true;
+				if (resolved.type === "TSParenthesizedType") {
+					return matches(resolved.typeAnnotation);
+				}
+				return (
+					resolved.type === "TSUnionType" && resolved.types.some(matches)
+				);
+			});
+
+		const checkParameters = (node: ParameterOwner) => {
+			for (const parameter of node.params) {
+				const annotation = functionParameterTypeAnnotation(parameter);
+				if (annotation === null || annotation === undefined) continue;
+				if (!resolvesToObject(annotation.typeAnnotation)) continue;
+				context.report({
+					node: annotation.typeAnnotation,
+					messageId: "objectParameter",
+					data: { parameter: functionParameterBindingName(parameter, context.sourceCode) },
+				});
+			}
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeAliasEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			ArrowFunctionExpression: checkParameters,
+			FunctionDeclaration: checkParameters,
+			FunctionExpression: checkParameters,
+			TSCallSignatureDeclaration: checkParameters,
+			TSConstructSignatureDeclaration: checkParameters,
+			TSConstructorType: checkParameters,
+			TSDeclareFunction: checkParameters,
+			TSEmptyBodyFunctionExpression: checkParameters,
+			TSFunctionType: checkParameters,
+			TSMethodSignature: checkParameters,
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.",
+    },
+    messages: {
+      reflectApply:
+        "Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "apply")) {
+          context.report({ node, messageId: "reflectApply" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.",
+    },
+    messages: {
+      reflectGet:
+        "Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "get")) {
+          context.report({ node, messageId: "reflectGet" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type RuntimeFunction = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function isRuntimeFunction(node: ESTree.Node): node is RuntimeFunction {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression"
+	);
+}
+
+function isInsideTypeGuard(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isRuntimeFunction(current)) {
+			return current.returnType?.typeAnnotation.type === "TSTypePredicate";
+		}
+		current = current.parent;
+	}
+	return false;
+}
+
+/** Return whether typeof safely probes for the existence of a possibly absent binding. */
+function isExistenceProbe(node: ESTree.UnaryExpression): boolean {
+	const parent = node.parent;
+	if (parent.type !== "BinaryExpression") return false;
+	if (!["===", "!==", "==", "!="].includes(parent.operator)) return false;
+	const other = parent.left === node ? parent.right : parent.left;
+	return other.type === "Literal" && other.value === "undefined";
+}
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.",
+		},
+		messages: {
+			runtimeTypeof:
+				"A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.",
+		},
+		schema: [
+			{
+				type: "object",
+				properties: {
+					allowInTypeGuards: { type: "boolean" },
+				},
+				additionalProperties: false,
+			},
+		],
+		defaultOptions: [{ allowInTypeGuards: false }],
+	},
+	createOnce(context) {
+		return {
+			UnaryExpression(node) {
+				const option = context.options?.[0];
+				const allowInTypeGuards =
+					typeof option === "object" &&
+					option !== null &&
+					!Array.isArray(option) &&
+					option.allowInTypeGuards === true;
+				if (
+					node.operator === "typeof" &&
+					!isExistenceProbe(node) &&
+					(!allowInTypeGuards || !isInsideTypeGuard(node))
+				) {
+					context.report({ node, messageId: "runtimeTypeof" });
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,46 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+const FORBIDDEN_SYMBOL_NAME = "shape";
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Return whether an identifier names a statically accessed member owned by another value. */
+function isBorrowedMemberName(node: ESTree.Node): boolean {
+  const parent = node.parent;
+  if (parent === null || parent.type !== "MemberExpression") return false;
+  return parent.property === node && parent.computed === false;
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+    },
+  },
+  createOnce(context) {
+    const reportForbiddenSymbolName = (node: ESTree.Node & { name: string }) => {
+      if (!containsForbiddenSymbolName(node.name) || isBorrowedMemberName(node)) return;
+      context.report({
+        node,
+        messageId: "forbiddenSymbolName",
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,69 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+  containsUnknownType,
+  functionParameterBindingName,
+  functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): boolean {
+  const predicate = owner.returnType?.typeAnnotation;
+  return (
+    predicate?.type === "TSTypePredicate" &&
+    predicate.parameterName.type === "Identifier" &&
+    predicate.parameterName.name === parameterName
+  );
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow explicitly unknown function parameters except `cause` and type-predicate subjects; decode unknown input at its I/O boundary instead.",
+    },
+    messages: {
+      unknownParameter:
+        "Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.",
+    },
+  },
+  createOnce(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = functionParameterTypeAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!containsUnknownType(annotation.typeAnnotation)) continue;
+        const name = functionParameterBindingName(parameter, context.sourceCode);
+        if (name === "cause" || isTypePredicateSubject(node, name)) continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: "unknownParameter",
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
@@ -1,0 +1,82 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+  createTypeAliasEnvironment,
+  resolvedTypeMatches,
+  type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+
+type FunctionWithReturnType =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow functions whose explicit return contract is unknown or Promise<unknown>.",
+    },
+    messages: {
+      unknownReturn:
+        "This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.",
+    },
+  },
+  createOnce(context) {
+    let environment: TypeAliasEnvironment | null = null;
+
+    const resolvesToUnknown = (type: ESTree.TSType): boolean =>
+      environment !== null &&
+      resolvedTypeMatches(type, environment, (resolved, matches) => {
+        if (resolved.type === "TSUnknownKeyword") return true;
+        if (resolved.type === "TSParenthesizedType") {
+          return matches(resolved.typeAnnotation);
+        }
+        if (resolved.type === "TSUnionType") return resolved.types.some(matches);
+        if (
+          resolved.type !== "TSTypeReference" ||
+          resolved.typeName.type !== "Identifier" ||
+          (resolved.typeName.name !== "Promise" &&
+            resolved.typeName.name !== "PromiseLike")
+        ) {
+          return false;
+        }
+        const value = resolved.typeArguments?.params[0];
+        return value !== undefined && matches(value);
+      });
+
+    const checkReturnType = (node: FunctionWithReturnType) => {
+      const annotation = node.returnType;
+      if (annotation === null || annotation === undefined) return;
+      if (!resolvesToUnknown(annotation.typeAnnotation)) return;
+      context.report({ node: annotation.typeAnnotation, messageId: "unknownReturn" });
+    };
+
+    return {
+      Program(node) {
+        environment = createTypeAliasEnvironment(
+          node,
+          context.sourceCode.visitorKeys,
+        );
+      },
+      ArrowFunctionExpression: checkReturnType,
+      FunctionDeclaration: checkReturnType,
+      FunctionExpression: checkReturnType,
+      TSCallSignatureDeclaration: checkReturnType,
+      TSConstructSignatureDeclaration: checkReturnType,
+      TSConstructorType: checkReturnType,
+      TSDeclareFunction: checkReturnType,
+      TSEmptyBodyFunctionExpression: checkReturnType,
+      TSFunctionType: checkReturnType,
+      TSMethodSignature: checkReturnType,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,54 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	resolvedTypeMatches,
+	type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.",
+		},
+		messages: {
+			unknownAlias:
+				"Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeAliasEnvironment | null = null;
+
+		const resolvesToUnknown = (type: ESTree.TSType): boolean =>
+			environment !== null &&
+			resolvedTypeMatches(type, environment, (resolved, matches) => {
+				if (resolved.type === "TSUnknownKeyword") return true;
+				if (resolved.type === "TSParenthesizedType") {
+					return matches(resolved.typeAnnotation);
+				}
+				return resolved.type === "TSUnionType" && resolved.types.some(matches);
+			});
+
+		return {
+			Program(node) {
+				environment = createTypeAliasEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeAliasDeclaration(node) {
+				if (!resolvesToUnknown(node.typeAnnotation)) return;
+				context.report({
+					node: node.id,
+					messageId: "unknownAlias",
+					data: { alias: node.id.name },
+				});
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,154 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionary,
+	classifyUnsafeDictionaryValue,
+	createTypeEnvironment,
+	type TypeEnvironment,
+} from "../shared/dictionary-types.ts";
+import { visibleTypeAlias } from "../shared/type-alias-resolution.ts";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+	"JSDocNonNullableType",
+	"JSDocNullableType",
+	"JSDocUnknownType",
+	"TSAnyKeyword",
+	"TSArrayType",
+	"TSBigIntKeyword",
+	"TSBooleanKeyword",
+	"TSConditionalType",
+	"TSConstructorType",
+	"TSFunctionType",
+	"TSImportType",
+	"TSIndexedAccessType",
+	"TSInferType",
+	"TSIntersectionType",
+	"TSIntrinsicKeyword",
+	"TSLiteralType",
+	"TSMappedType",
+	"TSNamedTupleMember",
+	"TSNeverKeyword",
+	"TSNullKeyword",
+	"TSNumberKeyword",
+	"TSObjectKeyword",
+	"TSParenthesizedType",
+	"TSStringKeyword",
+	"TSSymbolKeyword",
+	"TSTemplateLiteralType",
+	"TSThisType",
+	"TSTupleType",
+	"TSTypeLiteral",
+	"TSTypeOperator",
+	"TSTypePredicate",
+	"TSTypeQuery",
+	"TSTypeReference",
+	"TSUndefinedKeyword",
+	"TSUnionType",
+	"TSUnknownKeyword",
+	"TSVoidKeyword",
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+	return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (current.type === "TSTypeAliasDeclaration") return true;
+		current = current.parent;
+	}
+	return false;
+}
+
+function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (node.type !== "TSTypeReference" || node.typeArguments?.params.length) return false;
+	const name = typeReferenceName(node);
+	return (
+		name !== null &&
+		visibleTypeAlias(name, node, environment.typeAliases) !== null &&
+		!isInsideTypeAliasDeclaration(node)
+	);
+}
+
+function isInsideTypeParameterConstraint(node: ESTree.TSType): boolean {
+	let child: ESTree.Node = node;
+	let parent: ESTree.Node | null = child.parent;
+	while (parent !== null && parent.type !== "Program") {
+		if (parent.type === "TSTypeParameter" && parent.constraint === child) return true;
+		child = parent;
+		parent = child.parent;
+	}
+	return false;
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (isInsideTypeParameterConstraint(node)) return false;
+	if (isPlainAliasConsumerUse(node, environment)) return false;
+	if (classifyUnsafeDictionary(node, environment) === null) return false;
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+			return false;
+		current = current.parent;
+	}
+	return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
+		},
+		messages: {
+			unsafeDictionary:
+				"This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+		const report = (node: ESTree.Node, value: string) => {
+			context.report({ node, messageId: "unsafeDictionary", data: { value } });
+		};
+		const reportIfUnsafe = (node: ESTree.TSType) => {
+			if (environment === null || !shouldReportType(node, environment)) return;
+			const unsafe = classifyUnsafeDictionary(node, environment);
+			if (unsafe === null) return;
+			report(node, unsafe.unsafeValue);
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeReference: reportIfUnsafe,
+			TSTypeLiteral: reportIfUnsafe,
+			TSMappedType: reportIfUnsafe,
+			TSIndexSignature(node) {
+				if (
+					environment === null ||
+					node.typeAnnotation === null ||
+					node.parent.type === "TSTypeLiteral"
+				)
+					return;
+				const unsafe = classifyUnsafeDictionaryValue(
+					node.typeAnnotation.typeAnnotation,
+					environment,
+				);
+				if (unsafe !== null) report(node, unsafe.unsafeValue);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,366 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Variable } from "@oxlint/plugins";
+
+type BroadTypeKind = "top" | "object" | "record";
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === "TSParenthesizedType") current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === "TSStringKeyword" ||
+    unwrapped.type === "TSNumberKeyword" ||
+    unwrapped.type === "TSSymbolKeyword"
+  ) {
+    return true;
+  }
+  if (unwrapped.type === "TSUnionType") return unwrapped.types.every(isBroadRecordKeyType);
+  return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === "TSTypeReference") {
+    if (typeReferenceName(unwrapped) === "Readonly") {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== "Record") return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+  return (
+    member?.type === "TSIndexSignature" &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
+  if (unwrapped.type === "TSObjectKeyword") return "object";
+  return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case "TSArrayType":
+    case "TSConstructorType":
+    case "TSFunctionType":
+    case "TSMappedType":
+    case "TSObjectKeyword":
+    case "TSTupleType":
+      return true;
+    case "TSTypeLiteral":
+      return unwrapped.members.length > 0;
+    case "TSIntersectionType":
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case "TSTypeOperator":
+      return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+  }
+
+  if (unwrapped.type !== "TSTypeReference") return false;
+  if (typeReferenceName(unwrapped) === "Readonly") {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== "Record") return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === "ArrayExpression" ||
+    unwrapped.type === "ArrowFunctionExpression" ||
+    unwrapped.type === "ClassExpression" ||
+    unwrapped.type === "FunctionExpression" ||
+    unwrapped.type === "NewExpression" ||
+    unwrapped.type === "ObjectExpression"
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== "Identifier") return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.id.type !== "Identifier" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === "top") return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === "object") return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  createOnce(context) {
+    let scopes: Parameters<typeof resolvedVariableForIdentifier>[0] = [];
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== "Identifier") return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "widenThenAssert",
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      Program() {
+        scopes = context.sourceCode.scopeManager.scopes;
+      },
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -1,0 +1,131 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+type TypeAssertion = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+const DEFAULT_SAFETY_MARKERS = ["SAFETY"] as const;
+
+const commentOwnerKinds = new Set([
+  "ExpressionStatement",
+  "PropertyDefinition",
+  "ReturnStatement",
+  "ThrowStatement",
+  "VariableDeclaration",
+]);
+
+function isConstAssertion(node: TypeAssertion): boolean {
+  return (
+    node.typeAnnotation.type === "TSTypeReference" &&
+    node.typeAnnotation.typeName.type === "Identifier" &&
+    node.typeAnnotation.typeName.name === "const"
+  );
+}
+
+function configuredSafetyMarkers(option: unknown): readonly string[] {
+  if (typeof option !== "object" || option === null || !("markers" in option)) {
+    return DEFAULT_SAFETY_MARKERS;
+  }
+  const configured = option.markers;
+  if (!Array.isArray(configured)) return DEFAULT_SAFETY_MARKERS;
+  const markers = configured.flatMap((marker) =>
+    typeof marker === "string" && marker.trim().length > 0 ? [marker.trim()] : [],
+  );
+  return markers.length > 0 ? markers : DEFAULT_SAFETY_MARKERS;
+}
+
+function markerPattern(markers: readonly string[]): RegExp {
+  const alternation = markers
+    .map((marker) => marker.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`))
+    .join("|");
+  return new RegExp(
+    String.raw`(?:^|[^\p{L}\p{N}_])(?:${alternation})\s*:\s*\S`,
+    "u",
+  );
+}
+
+function hasSafetyJustificationBefore(
+  sourceCode: SourceCode,
+  owner: ESTree.Node,
+  assertion: TypeAssertion,
+  pattern: RegExp,
+): boolean {
+  return sourceCode
+    .getCommentsBefore(owner)
+    .some(
+      (comment) => comment.end <= assertion.start && pattern.test(comment.value),
+    );
+}
+
+function hasSafetyComment(
+  sourceCode: SourceCode,
+  node: TypeAssertion,
+  pattern: RegExp,
+): boolean {
+  let current: ESTree.Node = node;
+  while (true) {
+    if (hasSafetyJustificationBefore(sourceCode, current, node, pattern)) return true;
+    if (commentOwnerKinds.has(current.type)) {
+      const exportDeclaration = current.parent;
+      return (
+        exportDeclaration.type === "ExportNamedDeclaration" &&
+        exportDeclaration.declaration === current &&
+        hasSafetyJustificationBefore(sourceCode, exportDeclaration, node, pattern)
+      );
+    }
+    if (current.parent.type === "Program") return false;
+    current = current.parent;
+  }
+}
+
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.",
+    },
+    messages: {
+      missingSafetyComment:
+        "This type assertion has no `{{marker}}:` justification. State the checked invariant immediately before the assertion or its containing statement.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          markers: {
+            type: "array",
+            items: { type: "string", minLength: 1 },
+            minItems: 1,
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{ markers: ["SAFETY"] }],
+  },
+  createOnce(context) {
+    const patterns = new Map<string, RegExp>();
+
+    const checkAssertion = (node: TypeAssertion) => {
+      if (isConstAssertion(node)) return;
+      const markers = configuredSafetyMarkers(context.options?.[0]);
+      const patternKey = markers.join("\u0000");
+      const pattern = patterns.get(patternKey) ?? markerPattern(markers);
+      patterns.set(patternKey, pattern);
+      if (hasSafetyComment(context.sourceCode, node, pattern)) return;
+      context.report({
+        node,
+        messageId: "missingSafetyComment",
+        data: { marker: markers[0] ?? DEFAULT_SAFETY_MARKERS[0] },
+      });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,515 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	hasVisibleTypeBinding,
+	visibleTypeAlias,
+	type TypeAliasEnvironment as LexicalTypeAliasEnvironment,
+} from "./type-alias-resolution.ts";
+
+const BUILT_INS = new Set([
+	"Record",
+	"Readonly",
+	"Partial",
+	"Required",
+	"Pick",
+	"Omit",
+	"PropertyKey",
+	"NonNullable",
+]);
+const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+	readonly type: ESTree.TSType;
+	readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+	readonly kind: "unsafe-dictionary";
+	readonly unsafeValue: "any" | "empty-object" | "object" | "union" | "unknown";
+};
+
+export type WideningTargetKind =
+	| "anonymous object"
+	| "generic container"
+	| "object"
+	| "open dictionary"
+	| "unknown";
+
+export type WideningTarget = {
+	readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+	readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+	readonly typeAliases: LexicalTypeAliasEnvironment;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+	return statement.type === "ExportNamedDeclaration" ||
+		statement.type === "ExportDefaultDeclaration"
+		? (statement.declaration ?? null)
+		: statement;
+}
+
+export function createTypeEnvironment(
+	program: ESTree.Program,
+	visitorKeys: Readonly<Record<string, readonly string[]>>,
+): TypeEnvironment {
+	const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+
+	for (const statement of program.body) {
+		const declaration = declaredStatement(statement);
+		if (declaration?.type !== "TSInterfaceDeclaration") continue;
+		const declarations = interfaces.get(declaration.id.name) ?? [];
+		declarations.push(declaration);
+		interfaces.set(declaration.id.name, declarations);
+	}
+
+	return {
+		interfaces,
+		typeAliases: createTypeAliasEnvironment(program, visitorKeys),
+	};
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isBuiltIn(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeEnvironment,
+): boolean {
+	return (
+		BUILT_INS.has(name) &&
+		!hasVisibleTypeBinding(name, use, environment.typeAliases)
+	);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	return (
+		unwrapped.type === "TSTypeReference" &&
+		typeReferenceName(unwrapped) === name &&
+		(unwrapped.typeArguments === null ||
+			unwrapped.typeArguments === undefined ||
+			unwrapped.typeArguments.params.length === 0)
+	);
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+	let current = type;
+	while (
+		current.type === "TSParenthesizedType" ||
+		(current.type === "TSTypeOperator" && current.operator === "readonly")
+	) {
+		current = current.typeAnnotation;
+	}
+	return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+	return unwrapTransparentType(type).type === "TSNeverKeyword";
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+	return (
+		member.type === "TSPropertySignature" &&
+		member.optional === true &&
+		member.typeAnnotation !== null &&
+		member.typeAnnotation !== undefined &&
+		isNeverType(member.typeAnnotation.typeAnnotation)
+	);
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+	return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(
+	declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+	if (declarations.length !== 1) return false;
+	const [type] = declarations;
+	return (
+		type !== undefined &&
+		type.extends.length === 0 &&
+		(type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+	);
+}
+
+function resolvedSubstitutionArgument(
+	type: ESTree.TSType,
+	base: TypeAliasEnvironment,
+	resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type !== "TSTypeReference") return type;
+	const name = typeReferenceName(unwrapped);
+	if (name === null || resolving.has(name)) return type;
+	const substitution = base.get(name);
+	if (substitution === undefined) return type;
+	const nextResolving = new Set(resolving);
+	nextResolving.add(name);
+	return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+	alias: ESTree.TSTypeAliasDeclaration,
+	type: ESTree.TSTypeReference,
+	base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = type.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const argument = arguments_[index] ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+	}
+	return next;
+}
+
+function unsafeDirectValue(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary["unsafeValue"] | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return "unknown";
+	if (unwrapped.type === "TSAnyKeyword") return "any";
+	if (unwrapped.type === "TSObjectKeyword") return "object";
+	if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
+		return "empty-object";
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some(
+			(member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+		)
+			? "union"
+			: null;
+	}
+	if (unwrapped.type === "TSIntersectionType") {
+		const unsafeMembers = unwrapped.types.map((member) =>
+			unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+		);
+		if (unsafeMembers.includes("any")) return "any";
+		return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+			? (unsafeMembers[0] ?? null)
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+	}
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+	}
+	const interfaceDeclarations = environment.interfaces.get(name);
+	if (interfaceDeclarations !== undefined) {
+		return isEffectivelyEmptyInterface(interfaceDeclarations) ? "empty-object" : null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+function dictionaryValueTypes(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+	const unwrapped = unwrapTransparentType(type);
+
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+			member.type === "TSIndexSignature" && member.typeAnnotation !== null
+				? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+				: [],
+		);
+	}
+
+	if (unwrapped.type === "TSMappedType") {
+		return unwrapped.typeAnnotation === null
+			? []
+			: [{ type: unwrapped.typeAnnotation, substitutions }];
+	}
+
+	if (unwrapped.type !== "TSTypeReference") return [];
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return [];
+
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? []
+			: dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+	}
+
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? []
+			: dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+	}
+
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		const value = unwrapped.typeArguments?.params[1] ?? null;
+		return value === null ? [] : [{ type: value, substitutions }];
+	}
+
+	if (
+		(name === "Pick" || name === "Omit") &&
+		isBuiltIn(name, unwrapped, environment)
+	) {
+		const source = unwrapped.typeArguments?.params[0];
+		return source === undefined
+			? []
+			: dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+	}
+
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return [];
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return [];
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function classifyUnsafeDictionaryValue(
+	valueType: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+	return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+		const unsafeValue = unsafeDirectValue(
+			valueType.type,
+			environment,
+			valueType.substitutions,
+			new Set(),
+		);
+		if (unsafeValue !== null) return { kind: "unsafe-dictionary", unsafeValue };
+	}
+	return null;
+}
+
+export function classifyWideningTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: unwrapped.members.length > 0
+				? { kind: "anonymous object" }
+				: null;
+	}
+	if (unwrapped.type === "TSMappedType") return { kind: "open dictionary" };
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, new Map())
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null) return null;
+	if ((alias.typeParameters?.params.length ?? 0) > 0) {
+		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+		const resolved =
+			substitutions === null
+				? null
+				: classifyAliasBroadTarget(
+						alias.typeAnnotation,
+						environment,
+						substitutions,
+						new Set([name]),
+					);
+		return resolved?.kind === "open dictionary" ? { kind: "generic container" } : null;
+	}
+	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+	if (substitutions === null) return null;
+	const resolved = classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		substitutions,
+		new Set([name]),
+	);
+	return resolved;
+}
+
+function hasBroadRecordKey(
+	type: ESTree.TSTypeReference,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+): boolean {
+	const key = type.typeArguments?.params[0];
+	return key === undefined || isBroadMappedKey(key, environment, substitutions);
+}
+
+function isBroadMappedKey(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	visitedAliases: ReadonlySet<string> = new Set(),
+): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	if (
+		unwrapped.type === "TSStringKeyword" ||
+		unwrapped.type === "TSNumberKeyword" ||
+		unwrapped.type === "TSSymbolKeyword"
+	) {
+		return true;
+	}
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some((member) =>
+			isBroadMappedKey(member, environment, substitutions, visitedAliases),
+		);
+	}
+	if (unwrapped.type !== "TSTypeReference") return false;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return false;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+		return isBroadMappedKey(substitution, environment, substitutions, visitedAliases);
+	}
+	if (name === "PropertyKey" && isBuiltIn(name, unwrapped, environment)) return true;
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (
+		alias === null ||
+		(alias.typeParameters?.params.length ?? 0) > 0 ||
+		visitedAliases.has(name)
+	) {
+		return false;
+	}
+	const nextVisited = new Set(visitedAliases);
+	nextVisited.add(name);
+	return isBroadMappedKey(alias.typeAnnotation, environment, substitutions, nextVisited);
+}
+
+function classifyAliasBroadTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type === "TSMappedType") {
+		return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: classifyAliasBroadTarget(
+					substitution,
+					environment,
+					substitutions,
+					resolvingAliases,
+				);
+	}
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		nextSubstitutions,
+		nextResolving,
+	);
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current.type === "ObjectExpression" && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression" ||
+		current.type === "TSSatisfiesExpression"
+	) {
+		current = current.expression;
+	}
+	if (current.type === "ObjectExpression") return true;
+	return (
+		current.type === "ArrayExpression" ||
+		current.type === "ArrowFunctionExpression" ||
+		current.type === "ClassExpression" ||
+		current.type === "FunctionExpression" ||
+		current.type === "NewExpression" ||
+		current.type === "Literal" ||
+		current.type === "TemplateLiteral" ||
+		current.type === "UnaryExpression"
+	);
+}

--- a/tools/oxlint/anti-slop/shared/function-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/function-parameters.ts
@@ -1,0 +1,49 @@
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+export type FunctionParameter = ESTree.ParamPattern;
+
+/** Return whether a type is or contains TypeScript's absorbing unknown top type. */
+export function containsUnknownType(type: ESTree.TSType): boolean {
+	if (type.type === "TSUnknownKeyword") return true;
+	if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
+	return type.type === "TSUnionType" && type.types.some(containsUnknownType);
+}
+
+/** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
+export function functionParameterTypeAnnotation(
+	parameter: FunctionParameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterTypeAnnotation(parameter.parameter);
+	}
+	if (parameter.type === "RestElement") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.argument);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.left);
+	}
+	return parameter.typeAnnotation;
+}
+
+/** Return only a function parameter's local binding, excluding its annotation and default value. */
+export function functionParameterBindingName(
+	parameter: FunctionParameter,
+	sourceCode: SourceCode,
+): string {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterBindingName(parameter.parameter, sourceCode);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return functionParameterBindingName(parameter.left, sourceCode);
+	}
+	if (parameter.type === "RestElement") {
+		return functionParameterBindingName(parameter.argument, sourceCode);
+	}
+	if (parameter.type === "Identifier") return parameter.name;
+
+	const sourceText = sourceCode.getText(parameter);
+	const annotationStart = parameter.typeAnnotation?.start;
+	return annotationStart === undefined
+		? sourceText
+		: sourceText.slice(0, annotationStart - parameter.start).trimEnd();
+}

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -1,0 +1,61 @@
+import type { ESTree } from "@oxlint/plugins";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function collectInferTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	names: Set<string>,
+): void {
+	if (node.type === "TSInferType") names.add(node.typeParameter.name.name);
+	const record = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = record[key];
+		if (isNode(value)) {
+			collectInferTypeParameterNames(value, visitorKeys, names);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) collectInferTypeParameterNames(child, visitorKeys, names);
+		}
+	}
+}
+
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export function lexicalTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+): ReadonlySet<string> {
+	const names = new Set<string>();
+	let descendant: ESTree.Node = node;
+	let current: ESTree.Node | null = node;
+	while (current !== null && current.type !== "Program") {
+		if ("typeParameters" in current) {
+			for (const parameter of current.typeParameters?.params ?? []) {
+				names.add(parameter.name.name);
+			}
+		}
+		if (
+			current.type === "TSMappedType" &&
+			(descendant === current.nameType || descendant === current.typeAnnotation)
+		) {
+			names.add(current.key.name);
+		}
+		if (current.type === "TSConditionalType" && descendant === current.trueType) {
+			collectInferTypeParameterNames(current.extendsType, visitorKeys, names);
+		}
+		descendant = current;
+		current = current.parent;
+	}
+	return names;
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,35 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+function resolveVariable(
+  sourceCode: SourceCode,
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function isGlobalReflect(sourceCode: SourceCode, expression: ESTree.Expression): boolean {
+  if (expression.type !== "Identifier" || expression.name !== "Reflect") return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === "Literal" && property.value === methodName
+    : property.type === "Identifier" && property.name === methodName;
+}

--- a/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
+++ b/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
@@ -1,0 +1,250 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import { lexicalTypeParameterNames } from "./lexical-type-parameters.ts";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+type TypeScope = ESTree.Node;
+
+type TypeBinding = {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+	readonly scope: TypeScope;
+};
+
+type Substitution = {
+	readonly substitutions: Substitutions;
+	readonly type: ESTree.TSType;
+};
+
+type Substitutions = ReadonlyMap<string, Substitution>;
+
+export type TypeAliasEnvironment = {
+	readonly aliases: readonly ESTree.TSTypeAliasDeclaration[];
+	readonly bindingsByName: ReadonlyMap<string, readonly TypeBinding[]>;
+	readonly visitorKeys: VisitorKeys;
+};
+
+export type ResolvedTypeMatcher = (
+	type: ESTree.TSType,
+	matches: (child: ESTree.TSType) => boolean,
+) => boolean;
+
+const environmentsByProgram = new WeakMap<ESTree.Program, TypeAliasEnvironment>();
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function enclosingTypeScope(node: ESTree.Node): TypeScope {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null) {
+		if (
+			current.type === "Program" ||
+			current.type === "BlockStatement" ||
+			current.type === "TSModuleBlock" ||
+			current.type === "StaticBlock" ||
+			current.type === "SwitchStatement"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return node;
+}
+
+function declaredTypeBinding(node: ESTree.Node): {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+} | null {
+	if (node.type === "TSTypeAliasDeclaration") {
+		return { alias: node, name: node.id.name };
+	}
+	if (
+		node.type === "TSInterfaceDeclaration" ||
+		node.type === "TSEnumDeclaration" ||
+		node.type === "ClassDeclaration" ||
+		node.type === "ClassExpression"
+	) {
+		return node.id === null ? null : { alias: null, name: node.id.name };
+	}
+	if (
+		node.type === "ImportSpecifier" ||
+		node.type === "ImportDefaultSpecifier" ||
+		node.type === "ImportNamespaceSpecifier"
+	) {
+		return { alias: null, name: node.local.name };
+	}
+	return null;
+}
+
+function collectTypeBindings(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	bindingsByName: Map<string, TypeBinding[]>,
+	aliases: ESTree.TSTypeAliasDeclaration[],
+): void {
+	const declared = declaredTypeBinding(node);
+	if (declared !== null) {
+		const bindings = bindingsByName.get(declared.name) ?? [];
+		bindings.push({ ...declared, scope: enclosingTypeScope(node) });
+		bindingsByName.set(declared.name, bindings);
+		if (declared.alias !== null) aliases.push(declared.alias);
+	}
+
+	// SAFETY: Oxlint's visitor keys identify only ESTree child-node properties.
+	const fields = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = fields[key];
+		if (isNode(value)) {
+			collectTypeBindings(value, visitorKeys, bindingsByName, aliases);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) {
+				collectTypeBindings(child, visitorKeys, bindingsByName, aliases);
+			}
+		}
+	}
+}
+
+/** Collect every lexical type alias and competing type binding in a program. */
+export function createTypeAliasEnvironment(
+	program: ESTree.Program,
+	visitorKeys: VisitorKeys,
+): TypeAliasEnvironment {
+	const cached = environmentsByProgram.get(program);
+	if (cached !== undefined) return cached;
+	const bindingsByName = new Map<string, TypeBinding[]>();
+	const aliases: ESTree.TSTypeAliasDeclaration[] = [];
+	collectTypeBindings(program, visitorKeys, bindingsByName, aliases);
+	const environment = { aliases, bindingsByName, visitorKeys };
+	environmentsByProgram.set(program, environment);
+	return environment;
+}
+
+function ancestorDistance(ancestor: ESTree.Node, node: ESTree.Node): number | null {
+	let current: ESTree.Node | null = node;
+	let distance = 0;
+	while (current !== null) {
+		if (current === ancestor) return distance;
+		current = current.parent;
+		distance += 1;
+	}
+	return null;
+}
+
+function nearestTypeBindings(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): readonly TypeBinding[] {
+	const candidates = environment.bindingsByName.get(name) ?? [];
+	let nearestDistance = Number.POSITIVE_INFINITY;
+	let nearest: TypeBinding[] = [];
+	for (const candidate of candidates) {
+		const distance = ancestorDistance(candidate.scope, use);
+		if (distance === null || distance > nearestDistance) continue;
+		if (distance === nearestDistance) {
+			nearest.push(candidate);
+			continue;
+		}
+		nearestDistance = distance;
+		nearest = [candidate];
+	}
+	return nearest;
+}
+
+/** Resolve the nearest visible alias with this name, respecting lexical shadowing. */
+export function visibleTypeAlias(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): ESTree.TSTypeAliasDeclaration | null {
+	if (lexicalTypeParameterNames(use, environment.visitorKeys).has(name)) return null;
+	const bindings = nearestTypeBindings(name, use, environment);
+	return bindings.length === 1 ? (bindings[0]?.alias ?? null) : null;
+}
+
+/** Return whether a local declaration shadows a built-in type at this use. */
+export function hasVisibleTypeBinding(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): boolean {
+	return (
+		lexicalTypeParameterNames(use, environment.visitorKeys).has(name) ||
+		nearestTypeBindings(name, use, environment).length > 0
+	);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function aliasSubstitutions(
+	alias: ESTree.TSTypeAliasDeclaration,
+	reference: ESTree.TSTypeReference,
+	base: Substitutions,
+): Substitutions | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = reference.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const explicitArgument = arguments_[index];
+		const argument = explicitArgument ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		const argumentSubstitutions = explicitArgument === undefined ? next : base;
+		next.set(parameter.name.name, {
+			type: argument,
+			substitutions: new Map(argumentSubstitutions),
+		});
+	}
+	return next;
+}
+
+/** Match a type after resolving visible aliases and substituting their type parameters. */
+export function resolvedTypeMatches(
+	type: ESTree.TSType,
+	environment: TypeAliasEnvironment,
+	matcher: ResolvedTypeMatcher,
+): boolean {
+	const evaluate = (
+		current: ESTree.TSType,
+		substitutions: Substitutions,
+		resolvingAliases: ReadonlySet<ESTree.TSTypeAliasDeclaration>,
+	): boolean => {
+		if (current.type === "TSTypeReference") {
+			const name = typeReferenceName(current);
+			if (name !== null) {
+				const substitution = substitutions.get(name);
+				if (substitution !== undefined && !current.typeArguments?.params.length) {
+					return evaluate(
+						substitution.type,
+						substitution.substitutions,
+						resolvingAliases,
+					);
+				}
+				const alias = visibleTypeAlias(name, current, environment);
+				if (alias !== null && !resolvingAliases.has(alias)) {
+					const nextSubstitutions = aliasSubstitutions(alias, current, substitutions);
+					if (nextSubstitutions !== null) {
+						const nextResolving = new Set(resolvingAliases);
+						nextResolving.add(alias);
+						return evaluate(alias.typeAnnotation, nextSubstitutions, nextResolving);
+					}
+				}
+			}
+		}
+		return matcher(current, (child) =>
+			evaluate(child, substitutions, resolvingAliases),
+		);
+	};
+
+	return evaluate(type, new Map(), new Set());
+}

--- a/tools/oxlint/next/helpers/next-app-router.ts
+++ b/tools/oxlint/next/helpers/next-app-router.ts
@@ -15,7 +15,11 @@ let nextRouteUtilities: ReturnType<typeof loadNextRouteUtilities> | undefined;
 const getNextRouteUtilities = () =>
   (nextRouteUtilities ??= loadNextRouteUtilities());
 
-type RouteUtilityFunction = (value: string) => unknown;
+type RouteUtilityResult =
+  | boolean
+  | string
+  | { readonly interceptedRoute: string };
+type RouteUtilityFunction = (value: string) => RouteUtilityResult;
 
 const routeUtilityFunctionSchema = z.custom<RouteUtilityFunction>(
   (value) => value instanceof Function,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: "server-only",
+        replacement: fileURLToPath(
+          new URL("tests/helpers/server-only.ts", import.meta.url)
+        ),
+      },
+      {
         find: /^@\/(app|auth|components|hooks|lib|trpc)(\/.*)?$/,
         replacement: fileURLToPath(new URL("src/$1$2", import.meta.url)),
       },


### PR DESCRIPTION
## Summary

- vendor the 15 generic anti-slop Oxlint rules and required shared helpers, excluding Effect-specific integration
- enable every vendored rule at error severity and document the upstream license and pinned commit
- refactor existing code to satisfy the stricter rules, including schema-based boundary narrowing, explicit dependency seams, and documented type assertions

## Behavior

No intentional user-facing behavior changes. The production dependency seams delegate to the same implementations, and equivalent branching/type refinements replace the patterns rejected by the new rules. Runtime validation is deliberately stricter for out-of-contract values.

## Verification

- pnpm check
- 218 tests across 43 files
- pnpm build with build-only placeholder values for required environment variables
- git diff --check