### PR TITLE
Enforce strict Oxlint policy

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -482,7 +482,6 @@
         "tailwindcss/no-unknown-classes": "off",
         "typescript/consistent-type-definitions": "off",
         "typescript/no-confusing-void-expression": "off",
-        "typescript/no-deprecated": "off",
         "typescript/no-floating-promises": "off",
         "typescript/no-misused-promises": "off",
         "typescript/no-unnecessary-condition": "off",

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -15,7 +15,7 @@
   "options": {
     "denyWarnings": true,
     "typeAware": true,
-    "reportUnusedDisableDirectives": "off"
+    "reportUnusedDisableDirectives": "error"
   },
   "categories": {
     "correctness": "error",

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -73,7 +73,12 @@
     "hooks/unsupported-syntax": "warn",
     "hooks/use-memo": "error",
     "import/no-cycle": "error",
-    "import/no-unassigned-import": "off",
+    "import/no-unassigned-import": [
+      "error",
+      {
+        "allow": ["**/*.css"]
+      }
+    ],
     "jsx-a11y/alt-text": "error",
     "jsx-a11y/anchor-has-content": "error",
     "jsx-a11y/anchor-is-valid": "error",
@@ -211,7 +216,7 @@
     "nextjs/no-typos": "warn",
     "nextjs/no-unwanted-polyfillio": "warn",
     "no-array-constructor": "error",
-    "no-await-in-loop": "off",
+    "no-await-in-loop": "error",
     "no-case-declarations": "error",
     "no-empty": "error",
     "no-empty-function": "error",
@@ -227,11 +232,11 @@
         "message": "Read environment variables through an env.ts or env/ module validated with @t3-oss/env-nextjs for Next.js or @t3-oss/env-core for other runtimes."
       }
     ],
-    "no-shadow": "off",
+    "no-shadow": "error",
     "no-undef": "off",
     "no-useless-assignment": "error",
     "no-var": "error",
-    "oxc/no-map-spread": "off",
+    "oxc/no-map-spread": "error",
     "prefer-const": "error",
     "prefer-rest-params": "error",
     "prefer-spread": "error",
@@ -242,7 +247,7 @@
     "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-target-blank": "error",
     "react/jsx-no-undef": "error",
-    "react/no-array-index-key": "off",
+    "react/no-array-index-key": "error",
     "react/no-children-prop": "error",
     "react/no-danger-with-children": "error",
     "react/no-direct-mutation-state": "error",
@@ -289,7 +294,7 @@
     "typescript/class-literal-property-style": "error",
     "typescript/consistent-generic-constructors": "error",
     "typescript/consistent-indexed-object-style": "error",
-    "typescript/consistent-return": "off",
+    "typescript/consistent-return": "error",
     "typescript/consistent-type-assertions": "error",
     "typescript/consistent-type-definitions": "error",
     "typescript/consistent-type-exports": "error",
@@ -360,8 +365,8 @@
     "typescript/return-await": ["error", "error-handling-correctness-only"],
     "typescript/unified-signatures": "error",
     "typescript/use-unknown-in-catch-callback-variable": "error",
-    "unicorn/consistent-function-scoping": "off",
-    "unicorn/no-array-sort": "off",
+    "unicorn/consistent-function-scoping": "error",
+    "unicorn/no-array-sort": "error",
     "unicorn/no-instanceof-builtins": [
       "error",
       {
@@ -370,60 +375,6 @@
     ]
   },
   "overrides": [
-    {
-      "files": ["**/*.{js,mjs,cjs}"],
-      "rules": {
-        "typescript/await-thenable": "off",
-        "typescript/consistent-type-exports": "off",
-        "typescript/dot-notation": "off",
-        "typescript/no-array-delete": "off",
-        "typescript/no-base-to-string": "off",
-        "typescript/no-confusing-void-expression": "off",
-        "typescript/no-deprecated": "off",
-        "typescript/no-duplicate-type-constituents": "off",
-        "typescript/no-floating-promises": "off",
-        "typescript/no-for-in-array": "off",
-        "typescript/no-implied-eval": "off",
-        "typescript/no-meaningless-void-operator": "off",
-        "typescript/no-misused-promises": "off",
-        "typescript/no-misused-spread": "off",
-        "typescript/no-mixed-enums": "off",
-        "typescript/no-redundant-type-constituents": "off",
-        "typescript/no-unnecessary-boolean-literal-compare": "off",
-        "typescript/no-unnecessary-condition": "off",
-        "typescript/no-unnecessary-template-expression": "off",
-        "typescript/no-unnecessary-type-arguments": "off",
-        "typescript/no-unnecessary-type-assertion": "off",
-        "typescript/no-unnecessary-type-conversion": "off",
-        "typescript/no-unnecessary-type-parameters": "off",
-        "typescript/no-unsafe-argument": "off",
-        "typescript/no-unsafe-assignment": "off",
-        "typescript/no-unsafe-call": "off",
-        "typescript/no-unsafe-enum-comparison": "off",
-        "typescript/no-unsafe-member-access": "off",
-        "typescript/no-unsafe-return": "off",
-        "typescript/no-unsafe-type-assertion": "off",
-        "typescript/no-unsafe-unary-minus": "off",
-        "typescript/no-useless-default-assignment": "off",
-        "typescript/non-nullable-type-assertion-style": "off",
-        "typescript/only-throw-error": "off",
-        "typescript/prefer-find": "off",
-        "typescript/prefer-includes": "off",
-        "typescript/prefer-nullish-coalescing": "off",
-        "typescript/prefer-optional-chain": "off",
-        "typescript/prefer-promise-reject-errors": "off",
-        "typescript/prefer-reduce-type-parameter": "off",
-        "typescript/prefer-regexp-exec": "off",
-        "typescript/prefer-return-this-type": "off",
-        "typescript/related-getter-setter-pairs": "off",
-        "typescript/require-array-sort-compare": "off",
-        "typescript/restrict-plus-operands": "off",
-        "typescript/restrict-template-expressions": "off",
-        "typescript/return-await": "off",
-        "typescript/unbound-method": "off",
-        "typescript/use-unknown-in-catch-callback-variable": "off"
-      }
-    },
     {
       "files": [
         "**/env.{js,cjs,mjs,ts,cts,mts}",
@@ -462,40 +413,16 @@
       }
     },
     {
-      // Eve owns this generated Web Chat scaffold. Keep it updateable from the
-      // framework.
-      "files": ["src/app/**/*.tsx", "src/components/ai-elements/**/*.tsx"],
+      // AI Elements uses typography and animation utilities supplied through
+      // package styles that the Tailwind linter cannot resolve from the app
+      // entrypoint. Keep this exception limited to the affected components.
+      "files": [
+        "src/components/ai-elements/message.tsx",
+        "src/components/ai-elements/reasoning.tsx",
+        "src/components/ai-elements/tool.tsx"
+      ],
       "rules": {
-        "eslint/no-empty-function": "off",
-        "eslint/no-underscore-dangle": "off",
-        "hooks/refs": "off",
-        "hooks/set-state-in-effect": "off",
-        "hooks/static-components": "off",
-        "jsx-a11y/anchor-has-content": "off",
-        "jsx-a11y/control-has-associated-label": "off",
-        "jsx-a11y/heading-has-content": "off",
-        "nextjs/no-img-element": "off",
-        "promise/always-return": "off",
-        "tailwindcss/enforce-consistent-important-position": "off",
-        "tailwindcss/enforce-shorthand": "off",
-        "tailwindcss/no-deprecated-classes": "off",
-        "tailwindcss/no-unknown-classes": "off",
-        "typescript/consistent-type-definitions": "off",
-        "typescript/no-confusing-void-expression": "off",
-        "typescript/no-floating-promises": "off",
-        "typescript/no-misused-promises": "off",
-        "typescript/no-unnecessary-condition": "off",
-        "typescript/no-unnecessary-type-assertion": "off",
-        "typescript/no-unsafe-argument": "off",
-        "typescript/no-unsafe-assignment": "off",
-        "typescript/no-unsafe-member-access": "off",
-        "typescript/no-unsafe-return": "off",
-        "typescript/no-unsafe-type-assertion": "off",
-        "typescript/prefer-nullish-coalescing": "off",
-        "typescript/restrict-template-expressions": "off",
-        "typescript/return-await": "off",
-        "typescript/use-unknown-in-catch-callback-variable": "off",
-        "unicorn/prefer-add-event-listener": "off"
+        "tailwindcss/no-unknown-classes": "off"
       }
     }
   ]

--- a/agent/channels/eve.ts
+++ b/agent/channels/eve.ts
@@ -34,19 +34,19 @@ export default eveChannel({
 
 function sessionIdFromPath(pathname: string) {
   const match = /^\/eve\/v1\/session\/([^/]+)/.exec(pathname);
-  if (!match?.[1]) return;
+  if (!match?.[1]) return undefined;
   try {
     return decodeURIComponent(match[1]);
   } catch {
-    return;
+    return undefined;
   }
 }
 
 async function requestIdentityFromRequest(request: Request) {
   const session = await getAuthSession(request.headers);
-  if (!session) return;
+  if (!session) return undefined;
   const phoneNumber = z.string().safeParse(session.user.phoneNumber);
-  if (!phoneNumber.success) return;
+  if (!phoneNumber.success) return undefined;
 
   return {
     phoneNumber: phoneNumber.data,
@@ -55,9 +55,11 @@ async function requestIdentityFromRequest(request: Request) {
 }
 
 async function waitForSessionOwnership(scope: AccessScope, sessionId: string) {
+  /* oxlint-disable eslint/no-await-in-loop -- Ownership visibility is checked by a bounded sequential retry loop. */
   for (let attempt = 0; attempt < 5; attempt += 1) {
     if (await isSessionOwned(scope, sessionId)) return true;
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
+  /* oxlint-enable eslint/no-await-in-loop */
   return false;
 }

--- a/agent/channels/linq.ts
+++ b/agent/channels/linq.ts
@@ -65,6 +65,7 @@ async function postLinqReply(
     if (files.length > 0) await thread.post({ files, markdown: "" });
     return;
   }
+  /* oxlint-disable eslint/no-await-in-loop -- Reply bubbles must be posted in conversational order. */
   for (const [index, bubble] of bubbles.entries()) {
     if (index === bubbles.length - 1 && files.length > 0) {
       await thread.post({ files, markdown: bubble });
@@ -72,6 +73,7 @@ async function postLinqReply(
       await thread.post({ markdown: bubble });
     }
   }
+  /* oxlint-enable eslint/no-await-in-loop */
 }
 
 const credentials: LinqChannelCredentials = env.LINQ_CONNECTOR

--- a/agent/lib/google-workspace/calendar.ts
+++ b/agent/lib/google-workspace/calendar.ts
@@ -72,8 +72,8 @@ export function parseCalendarAvailability(
   value: calendar_v3.Schema$FreeBusyResponse
 ) {
   const failures = Object.entries(value.calendars ?? {}).flatMap(
-    ([calendarId, calendar]) =>
-      (calendar.errors ?? []).map(
+    ([calendarId, calendarResult]) =>
+      (calendarResult.errors ?? []).map(
         (error) => `${calendarId}: ${error.reason ?? error.domain ?? "unknown"}`
       )
   );

--- a/agent/lib/google-workspace/gmail.ts
+++ b/agent/lib/google-workspace/gmail.ts
@@ -73,11 +73,12 @@ export async function readGmailThread(ctx: ToolContext, threadId: string) {
     );
     return {
       id: thread.id ?? threadId,
-      messages: (thread.messages ?? []).slice(-20).map((message) => ({
-        ...minimizeMessage(message),
-        attachments: collectAttachments(message.payload),
-        body: redactGoogleText(plainText(message.payload)),
-      })),
+      messages: (thread.messages ?? []).slice(-20).map((message) =>
+        Object.assign({}, minimizeMessage(message), {
+          attachments: collectAttachments(message.payload),
+          body: redactGoogleText(plainText(message.payload)),
+        })
+      ),
     };
   });
 }
@@ -162,6 +163,7 @@ export function gmailUpdateLabels(action: GmailUpdateAction) {
     case "unstar":
       return { addLabelIds: [], removeLabelIds: ["STARRED"] };
   }
+  throw new Error("Unsupported Gmail update action.");
 }
 
 function header(part: GmailPart | undefined, name: string) {

--- a/agent/lib/linq-browser-image-delivery.ts
+++ b/agent/lib/linq-browser-image-delivery.ts
@@ -80,29 +80,31 @@ async function readLinqBrowserImage(
     !artifact.filename ||
     !artifact.mediaType
   )
-    return;
-  if (!env.BLOB_STORE_ID && !env.BLOB_READ_WRITE_TOKEN) return;
+    return undefined;
+  if (!env.BLOB_STORE_ID && !env.BLOB_READ_WRITE_TOKEN) return undefined;
   const result = await get(artifact.storagePathname, {
     access: "private",
     abortSignal: options.signal,
   });
-  if (result?.statusCode !== 200) return;
+  if (result?.statusCode !== 200) return undefined;
   if (
     result.blob.size !== artifact.byteSize ||
     result.blob.contentType !== artifact.mediaType
   )
-    return;
+    return undefined;
   const reader = result.stream.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
   try {
+    /* oxlint-disable eslint/no-await-in-loop -- Blob response chunks form an ordered stream. */
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
       total += value.byteLength;
-      if (total > maximumBrowserImageBytes) return;
+      if (total > maximumBrowserImageBytes) return undefined;
       chunks.push(value);
     }
+    /* oxlint-enable eslint/no-await-in-loop */
   } finally {
     reader.releaseLock();
   }
@@ -113,7 +115,7 @@ async function readLinqBrowserImage(
     offset += chunk.byteLength;
   }
   if (createHash("sha256").update(bytes).digest("hex") !== artifact.contentHash)
-    return;
+    return undefined;
   return {
     bytes,
     filename: artifact.filename,

--- a/agent/subagents/worker/lib/autofill/native.ts
+++ b/agent/subagents/worker/lib/autofill/native.ts
@@ -157,6 +157,7 @@ export async function fillWithKernelNativeAutofill({
       }
 
       let lastError: unknown;
+      /* oxlint-disable eslint/no-await-in-loop -- Autofill tries controls in priority order and stops after the first accepted target. */
       for (const control of controls) {
         try {
           await markNativeAutofilledControls(connection, control);
@@ -175,6 +176,7 @@ export async function fillWithKernelNativeAutofill({
         }
         return { filledClaims: claims.length, origin };
       }
+      /* oxlint-enable eslint/no-await-in-loop */
 
       throw new Error(
         "Chromium could not autofill any visible control. Focus a field in the intended card or address form and retry.",
@@ -208,12 +210,14 @@ async function fillNativeLoginControls(
     );
   }
 
+  /* oxlint-disable eslint/no-await-in-loop -- Login fields must be filled in DOM order so page validation sees coherent intermediate state. */
   for (const { control, value } of fills) {
     const accepted = await fillNativeLoginControl(connection, control, value);
     if (!accepted) {
       throw new Error("The login form rejected secure credential autofill.");
     }
   }
+  /* oxlint-enable eslint/no-await-in-loop */
   return fills.length;
 }
 
@@ -552,6 +556,7 @@ async function withKernelPage<T>(
       const iframeTargets = targetInfos.filter(
         ({ targetId, type }) => type === "iframe" && frameIds.has(targetId)
       );
+      /* oxlint-disable eslint/no-await-in-loop -- CDP target attachment mutates one connection and session IDs are collected in target order. */
       for (const iframeTarget of iframeTargets) {
         const attached = attachedTargetSchema.safeParse(
           await connection
@@ -563,6 +568,7 @@ async function withKernelPage<T>(
         );
         if (attached.success) sessionIds.push(attached.data.sessionId);
       }
+      /* oxlint-enable eslint/no-await-in-loop */
 
       return await operation({
         connection,

--- a/agent/subagents/worker/lib/autofill/tests/vault-autofill.test.ts
+++ b/agent/subagents/worker/lib/autofill/tests/vault-autofill.test.ts
@@ -309,9 +309,9 @@ describe("vault browser autofill", () => {
 
   it("lets a vault-owned adapter supply masked suggestions and claims", async () => {
     const adapter: AutofillVaultAdapter = {
-      async listSuggestions(_scope, origin, surface) {
+      async listSuggestions(_scope, origin, targetSurface) {
         expect(origin).toBe("https://merchant.example");
-        expect(surface.kind).toBe("payment-card");
+        expect(targetSurface.kind).toBe("payment-card");
         return [
           {
             candidateId: "opaque-card",

--- a/agent/subagents/worker/lib/tests/vault-screenshot-mask.test.ts
+++ b/agent/subagents/worker/lib/tests/vault-screenshot-mask.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable vitest/require-mock-type-parameters -- The hoisted Kernel fake records cleanup request options. */
 import { describe, expect, it, vi } from "vitest";
 import { withVaultScreenshotMask } from "../vault-screenshot-mask";
 

--- a/agent/subagents/worker/tools/capture_browser_image.ts
+++ b/agent/subagents/worker/tools/capture_browser_image.ts
@@ -160,6 +160,7 @@ async function captureBrowserImage(
         };
       }
   }
+  throw new Error("Unsupported browser image source.");
 }
 
 async function captureImageResource(
@@ -342,6 +343,7 @@ async function readBoundedResponse(response: Response) {
   const chunks: Uint8Array[] = [];
   let total = 0;
   try {
+    /* oxlint-disable eslint/no-await-in-loop -- A response body is an ordered stream and must be read and cancelled sequentially. */
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -352,6 +354,7 @@ async function readBoundedResponse(response: Response) {
       }
       chunks.push(value);
     }
+    /* oxlint-enable eslint/no-await-in-loop */
   } finally {
     reader.releaseLock();
   }

--- a/agent/subagents/worker/tools/computer_action.ts
+++ b/agent/subagents/worker/tools/computer_action.ts
@@ -126,6 +126,7 @@ export default defineTool({
       );
     };
 
+    /* oxlint-disable eslint/no-await-in-loop -- Computer actions must execute in user-specified order and batching is flushed at observation boundaries. */
     for (const action of input.actions) {
       const batchAction = toBatchAction(action);
       if (batchAction) {
@@ -184,6 +185,7 @@ export default defineTool({
           throw new Error(`Computer action ${action.type} was not batched.`);
       }
     }
+    /* oxlint-enable eslint/no-await-in-loop */
     await flushPendingActions();
 
     return outputSchema.parse({
@@ -266,4 +268,5 @@ function toBatchAction(
     case "write_clipboard":
       return null;
   }
+  throw new Error("Unsupported computer action.");
 }

--- a/agent/subagents/worker/tools/manage_browsers.ts
+++ b/agent/subagents/worker/tools/manage_browsers.ts
@@ -183,6 +183,7 @@ const manageBrowsers = defineTool({
         return "Browser session deleted successfully";
       }
     }
+    throw new Error("Unsupported browser management action.");
   },
 });
 

--- a/agent/tools/google_workspace_read.ts
+++ b/agent/tools/google_workspace_read.ts
@@ -73,5 +73,6 @@ export default defineTool({
           ...(await searchGoogleContacts(ctx, input.query, input.pageSize)),
         };
     }
+    throw new Error("Unsupported Google Workspace read action.");
   },
 });

--- a/agent/tools/google_workspace_write.ts
+++ b/agent/tools/google_workspace_write.ts
@@ -60,5 +60,6 @@ export default defineTool({
           event: await createCalendarEvent(ctx, input),
         };
     }
+    throw new Error("Unsupported Google Workspace write action.");
   },
 });

--- a/db/services/browser-traces.ts
+++ b/db/services/browser-traces.ts
@@ -87,10 +87,11 @@ export async function listBrowserTraces(scope: AccessScope, cursor?: string) {
   return {
     nextCursor:
       rows.length > page.length && last ? encodeTraceCursor(last) : null,
-    traces: page.map((row) => ({
-      ...row,
-      domains: domainsByTrace.get(row.sessionId) ?? [],
-    })),
+    traces: page.map((row) =>
+      Object.assign({}, row, {
+        domains: domainsByTrace.get(row.sessionId) ?? [],
+      })
+    ),
   };
 }
 

--- a/db/services/vault.ts
+++ b/db/services/vault.ts
@@ -67,10 +67,11 @@ export async function readVaultItems(scope: AccessScope) {
   await ensureScope(scope);
   const records = await listVaultItems(scope);
   return Promise.all(
-    records.map(async (record) => ({
-      ...record,
-      hasSecret: await hasVaultSecret(scope, record.id),
-    }))
+    records.map(async (record) =>
+      Object.assign({}, record, {
+        hasSecret: await hasVaultSecret(scope, record.id),
+      })
+    )
   );
 }
 
@@ -160,6 +161,7 @@ function vaultAccountHint(input: VaultCreateItem) {
     case "contact":
       return "";
   }
+  throw new Error("Unsupported vault item kind.");
 }
 
 function encryptVaultSecret(

--- a/db/tests/database-migration.test.ts
+++ b/db/tests/database-migration.test.ts
@@ -267,9 +267,11 @@ async function applyMigration(database: PGlite, name: string) {
     new URL(`../migrations/${name}`, import.meta.url),
     "utf8"
   );
+  /* oxlint-disable eslint/no-await-in-loop -- SQL migration statements must execute in file order. */
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await database.exec(statement);
   }
+  /* oxlint-enable eslint/no-await-in-loop */
 }
 
 async function pendingConstraintCount(database: PGlite) {

--- a/db/tests/services.test.ts
+++ b/db/tests/services.test.ts
@@ -137,8 +137,8 @@ describe("database services", () => {
     expect(await sessions.isSessionOwned(bob, "session-alice")).toBe(false);
 
     await sessions.claimSession(alice, "session-imessage");
-    const unindexedChats = (await chats.listChats(alice)).sort((left, right) =>
-      left.sessionId.localeCompare(right.sessionId)
+    const unindexedChats = (await chats.listChats(alice)).toSorted(
+      (left, right) => left.sessionId.localeCompare(right.sessionId)
     );
     expect(
       unindexedChats.map(({ sessionId, title, usage }) => ({
@@ -355,9 +355,11 @@ async function applyInitialMigration(database: PGlite) {
     new URL("../migrations/0000_fluffy_the_spike.sql", import.meta.url),
     "utf8"
   );
+  /* oxlint-disable eslint/no-await-in-loop -- SQL migration statements must execute in file order. */
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await database.exec(statement);
   }
+  /* oxlint-enable eslint/no-await-in-loop */
 }
 
 async function applyBrowserImageMigration(database: PGlite) {
@@ -365,9 +367,11 @@ async function applyBrowserImageMigration(database: PGlite) {
     new URL("../migrations/0003_unusual_fabian_cortez.sql", import.meta.url),
     "utf8"
   );
+  /* oxlint-disable eslint/no-await-in-loop -- SQL migration statements must execute in file order. */
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await database.exec(statement);
   }
+  /* oxlint-enable eslint/no-await-in-loop */
 }
 
 async function applyBrowserTraceMigration(database: PGlite) {
@@ -375,9 +379,11 @@ async function applyBrowserTraceMigration(database: PGlite) {
     new URL("../migrations/0004_kind_manta.sql", import.meta.url),
     "utf8"
   );
+  /* oxlint-disable eslint/no-await-in-loop -- SQL migration statements must execute in file order. */
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await database.exec(statement);
   }
+  /* oxlint-enable eslint/no-await-in-loop */
 }
 
 async function applyBrowserTraceEventMigration(database: PGlite) {
@@ -385,7 +391,9 @@ async function applyBrowserTraceEventMigration(database: PGlite) {
     new URL("../migrations/0005_brave_kang.sql", import.meta.url),
     "utf8"
   );
+  /* oxlint-disable eslint/no-await-in-loop -- SQL migration statements must execute in file order. */
   for (const statement of migration.split("--> statement-breakpoint")) {
     if (statement.trim()) await database.exec(statement);
   }
+  /* oxlint-enable eslint/no-await-in-loop */
 }

--- a/evals/browser/browser.eval.ts
+++ b/evals/browser/browser.eval.ts
@@ -23,6 +23,7 @@ export default browserBenchmarkTasks.flatMap((task) =>
         let session: EveEvalSession | typeof t = t;
         let completed: EveEvalTurn | null = null;
         const workerEvents = [...started.events];
+        /* oxlint-disable eslint/no-await-in-loop -- Each watch resumes from the stream index produced by the previous turn. */
         for (let attempt = 0; attempt < 8 && completed === null; attempt += 1) {
           const live = t.target.watchTurn(started.sessionId, {
             startIndex: requireStreamIndex(session),
@@ -33,6 +34,7 @@ export default browserBenchmarkTasks.flatMap((task) =>
           if (didFinishWorker(workerEvents)) completed = turn;
           session = live.session;
         }
+        /* oxlint-enable eslint/no-await-in-loop */
 
         await t.require(
           completed,

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "deps:check": "taze --no-github-actions --no-node-version --fail-on-outdated",
     "deploy": "turbo run deploy:app",
     "deploy:app": "eve deploy",
-    "dev": "node scripts/dev.mjs",
+    "dev": "node scripts/dev.ts",
     "dev:app": "next dev",
     "eval": "eve eval",
     "format": "oxfmt .",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,6 +1,5 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
-import { once } from "node:events";
 import { fileURLToPath } from "node:url";
 
 const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
@@ -8,7 +7,7 @@ const composeProject = `open-instinct-${createHash("sha256")
   .update(repositoryRoot)
   .digest("hex")
   .slice(0, 12)}`;
-const composeArguments = (...args) => [
+const composeArguments = (...args: string[]) => [
   "compose",
   "--project-name",
   composeProject,
@@ -18,7 +17,7 @@ const composeArguments = (...args) => [
 // oxlint-disable-next-line eslint/no-restricted-properties -- the development supervisor must forward the caller's environment to its child processes
 const inheritedEnvironment = { ...process.env };
 
-function developmentEnvironment(port) {
+function developmentEnvironment(port: string) {
   const localDatabaseUrl = `postgresql://postgres:postgres@127.0.0.1:${port}/open_instinct`;
   return {
     ...inheritedEnvironment,
@@ -32,35 +31,47 @@ async function resolvePostgresPort() {
     "docker",
     composeArguments("port", "postgres", "5432")
   );
-  if (output === undefined) return;
-  const port = output.trim().match(/:(\d+)$/)?.[1];
+  if (output === undefined) return undefined;
+  const port = /:(\d+)$/.exec(output.trim())?.[1];
   if (!port) {
     throw new Error("Could not resolve the local PostgreSQL port.");
   }
   return port;
 }
 
-let activeChild;
+let activeChild: ChildProcess | undefined;
 let composeAttempted = false;
-let shutdownSignal;
+let shutdownSignal: NodeJS.Signals | undefined;
 
-function interrupt(child, signal) {
+function interrupt(child: ChildProcess, signal: NodeJS.Signals) {
+  const childPid = child.pid;
   try {
     if (process.platform === "win32") {
       child.kill(signal);
       return;
     }
 
-    process.kill(-child.pid, signal);
+    if (childPid === undefined) {
+      throw new Error(
+        "Cannot forward a signal before the child process starts."
+      );
+    }
+    process.kill(-childPid, signal);
   } catch (error) {
-    if (error?.code !== "ESRCH") {
-      console.error(`Failed to forward ${signal} to ${child.pid}:`, error);
+    if (
+      !(error instanceof Error && "code" in error && error.code === "ESRCH")
+    ) {
+      console.error(
+        `Failed to forward ${signal} to ${String(childPid)}:`,
+        error
+      );
       process.exitCode = 1;
     }
   }
 }
 
-for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+const shutdownSignals: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
+for (const signal of shutdownSignals) {
   process.on(signal, () => {
     if (shutdownSignal === undefined) {
       shutdownSignal = signal;
@@ -72,9 +83,15 @@ for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
 }
 
 async function run(
-  command,
-  args,
-  { allowInterruption = false, env = inheritedEnvironment } = {}
+  command: string,
+  args: string[],
+  {
+    allowInterruption = false,
+    env = inheritedEnvironment,
+  }: {
+    allowInterruption?: boolean;
+    env?: NodeJS.ProcessEnv;
+  } = {}
 ) {
   const child = spawn(command, args, {
     cwd: repositoryRoot,
@@ -85,10 +102,12 @@ async function run(
   activeChild = child;
 
   try {
-    const [code] = await once(child, "exit");
+    const code = await childExitCode(child);
 
     if (code !== 0 && !(allowInterruption && shutdownSignal !== undefined)) {
-      throw new Error(`${command} ${args.join(" ")} exited with ${code}`);
+      throw new Error(
+        `${command} ${args.join(" ")} exited with ${String(code)}`
+      );
     }
 
     return code === 0 && shutdownSignal === undefined;
@@ -99,7 +118,7 @@ async function run(
   }
 }
 
-async function runForOutput(command, args) {
+async function runForOutput(command: string, args: string[]) {
   const child = spawn(command, args, {
     cwd: repositoryRoot,
     detached: process.platform !== "win32",
@@ -109,14 +128,16 @@ async function runForOutput(command, args) {
   activeChild = child;
   child.stdout.setEncoding("utf8");
   let output = "";
-  child.stdout.on("data", (chunk) => {
+  child.stdout.on("data", (chunk: string) => {
     output += chunk;
   });
 
   try {
-    const [code] = await once(child, "exit");
+    const code = await childExitCode(child);
     if (code !== 0 && shutdownSignal === undefined) {
-      throw new Error(`${command} ${args.join(" ")} exited with ${code}`);
+      throw new Error(
+        `${command} ${args.join(" ")} exited with ${String(code)}`
+      );
     }
     return shutdownSignal === undefined ? output : undefined;
   } finally {
@@ -124,6 +145,13 @@ async function runForOutput(command, args) {
       activeChild = undefined;
     }
   }
+}
+
+function childExitCode(child: ChildProcess) {
+  return new Promise<number | null>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", resolve);
+  });
 }
 
 try {
@@ -136,9 +164,7 @@ try {
 
   if (shouldContinue) {
     const port = await resolvePostgresPort();
-    shouldContinue = port !== undefined;
-
-    if (shouldContinue) {
+    if (port !== undefined) {
       const environment = developmentEnvironment(port);
       shouldContinue = await run("pnpm", ["db:migrate"], {
         allowInterruption: true,

--- a/src/app/(authenticated)/(manager)/_components/google-workspace-action.tsx
+++ b/src/app/(authenticated)/(manager)/_components/google-workspace-action.tsx
@@ -9,8 +9,12 @@ export function GoogleWorkspaceAction({
   readonly state?: "connected" | "disconnected" | "unavailable";
 }) {
   const update = api.googleWorkspace.update.useMutation({
-    onError: () => window.location.assign("/?google=unavailable"),
-    onSuccess: ({ redirectTo }) => window.location.assign(redirectTo),
+    onError: () => {
+      window.location.assign("/?google=unavailable");
+    },
+    onSuccess: ({ redirectTo }) => {
+      window.location.assign(redirectTo);
+    },
   });
 
   if (!state) {
@@ -26,7 +30,9 @@ export function GoogleWorkspaceAction({
   return (
     <Button
       disabled={update.isPending}
-      onClick={() => update.mutate(action)}
+      onClick={() => {
+        update.mutate(action);
+      }}
       size="sm"
       type="button"
       variant="outline"

--- a/src/app/(authenticated)/(manager)/_components/model-selector.tsx
+++ b/src/app/(authenticated)/(manager)/_components/model-selector.tsx
@@ -48,13 +48,14 @@ export function ModelSelector({ modelId }: { readonly modelId: string }) {
       providerModels.push(model);
       groups.set(model.ownedBy, providerModels);
     }
-    return [...groups.entries()].sort(([left], [right]) =>
+    return [...groups.entries()].toSorted(([left], [right]) =>
       left.localeCompare(right)
     );
   }, [catalog.data]);
 
-  const select = (selectedModelId: string) =>
+  const select = (selectedModelId: string) => {
     selectModel.mutate({ modelId: selectedModelId });
+  };
 
   const catalogError =
     catalog.error instanceof Error
@@ -99,7 +100,9 @@ export function ModelSelector({ modelId }: { readonly modelId: string }) {
                 <ModelSelectorItem
                   data-checked={model.id === modelId}
                   key={model.id}
-                  onSelect={() => select(model.id)}
+                  onSelect={() => {
+                    select(model.id);
+                  }}
                   value={`${model.name} ${model.id} ${model.ownedBy}`}
                 >
                   <ModelSelectorLogo provider={providerLogo(model.ownedBy)} />
@@ -133,6 +136,6 @@ function providerLogo(provider: string) {
 
 function formatPricing(model: ModelCatalogItem) {
   if (model.pricing?.input === undefined || model.pricing.output === undefined)
-    return;
+    return undefined;
   return `${priceFormatter.format(model.pricing.input)} / ${priceFormatter.format(model.pricing.output)} per M`;
 }

--- a/src/app/(authenticated)/(manager)/chat/_components/agent-chat.tsx
+++ b/src/app/(authenticated)/(manager)/chat/_components/agent-chat.tsx
@@ -181,17 +181,18 @@ export function AgentChat({
 
   useEffect(() => {
     if (activeSessionId === undefined || latestTerminalTurnId === undefined) {
-      return;
+      return undefined;
     }
 
     const terminalTurn = `${activeSessionId}:${latestTerminalTurnId}`;
-    if (persistedUsageTurn.current === terminalTurn) return;
+    if (persistedUsageTurn.current === terminalTurn) return undefined;
     persistedUsageTurn.current = terminalTurn;
     saveChat({ sessionId: activeSessionId, usage });
+    return undefined;
   }, [activeSessionId, latestTerminalTurnId, saveChat, usage]);
 
   useEffect(() => {
-    if (activeSessionId === undefined || !hasPendingWorker) return;
+    if (activeSessionId === undefined || !hasPendingWorker) return undefined;
 
     const interval = window.setInterval(() => {
       if (agent.status !== "ready" || backgroundCatchUp.current !== undefined) {
@@ -207,7 +208,9 @@ export function AgentChat({
       });
     }, 750);
 
-    return () => window.clearInterval(interval);
+    return () => {
+      window.clearInterval(interval);
+    };
   }, [activeSessionId, agent, hasPendingWorker]);
 
   const handleSubmit = async (message: PromptInputMessage) => {
@@ -325,7 +328,7 @@ export function AgentChat({
           className={cn(
             "mx-auto w-full px-4 sm:px-6",
             showConversationLayout
-              ? "absolute bottom-0 left-1/2 z-20 max-w-3xl -translate-x-1/2 bg-gradient-to-t from-background via-background to-transparent pt-4 pb-6"
+              ? "absolute bottom-0 left-1/2 z-20 max-w-3xl -translate-x-1/2 bg-linear-to-t from-background via-background to-transparent pt-4 pb-6"
               : "flex max-w-xl flex-1 flex-col items-center justify-center gap-8 pb-[10vh]"
           )}
         >

--- a/src/app/(authenticated)/(manager)/chat/_components/agent-message.tsx
+++ b/src/app/(authenticated)/(manager)/chat/_components/agent-message.tsx
@@ -47,11 +47,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-export type AgentInputResponse = {
+export interface AgentInputResponse {
   readonly optionId?: string;
   readonly requestId: string;
   readonly text?: string;
-};
+}
 
 type EveFilePart = Extract<EveMessagePart, { type: "file" }>;
 
@@ -263,6 +263,7 @@ function AgentMessagePart({
       return tool;
     }
   }
+  throw new Error("Unsupported agent message part.");
 }
 
 function QuestionRequest({
@@ -355,6 +356,8 @@ function AttachmentPart({ part }: { readonly part: EveFilePart }) {
   const body = (
     <span className="flex max-w-sm items-center gap-3 rounded-md border bg-background/60 p-2 text-sm">
       {isImage ? (
+        // Browser artifacts use runtime URLs that cannot be declared in Next Image configuration.
+        // oxlint-disable-next-line nextjs/no-img-element -- runtime browser artifact URL
         <img
           alt={label}
           className="size-12 shrink-0 rounded-sm object-cover"
@@ -447,6 +450,7 @@ function AuthorizationPrompt({
             <Button
               render={
                 <a
+                  aria-label={`Sign in with ${part.displayName}`}
                   href={part.authorization.url}
                   rel="noreferrer"
                   target="_blank"
@@ -498,6 +502,7 @@ function formatAuthorizationOutcome(
     case "timed-out":
       return "timed out";
   }
+  throw new Error("Unsupported authorization outcome.");
 }
 
 function formatBytes(size: number | undefined): string | undefined {
@@ -505,7 +510,7 @@ function formatBytes(size: number | undefined): string | undefined {
     return undefined;
   }
   if (size < 1024) {
-    return `${size} B`;
+    return `${String(size)} B`;
   }
   if (size < 1024 * 1024) {
     return `${(size / 1024).toFixed(1)} KB`;
@@ -529,7 +534,7 @@ function InputRequestActions({
     return null;
   }
 
-  const inputResponse = part.toolMetadata?.eve?.inputResponse;
+  const inputResponse = part.toolMetadata.eve.inputResponse;
   const selectedOption = inputRequest.options?.find(
     (option) => option.id === inputResponse?.optionId
   );
@@ -574,10 +579,10 @@ function InputRequestActions({
 function partKey(part: EveMessagePart, index: number): string {
   switch (part.type) {
     case "authorization":
-      return `authorization:${part.turnId}:${part.stepIndex}:${part.name}`;
+      return `authorization:${part.turnId}:${String(part.stepIndex)}:${part.name}`;
     case "dynamic-tool":
       return part.toolCallId;
     default:
-      return `${part.type}:${index}`;
+      return `${part.type}:${String(index)}`;
   }
 }

--- a/src/app/(authenticated)/(manager)/chat/_components/subagent-panel.tsx
+++ b/src/app/(authenticated)/(manager)/chat/_components/subagent-panel.tsx
@@ -57,7 +57,7 @@ export function SubagentPanel({
   const subscriptionKey = getSubagentSubscriptionKey(sessions);
 
   useEffect(() => {
-    if (!subscriptionKey) return;
+    if (!subscriptionKey) return undefined;
     const controllers = subscriptionKey.split("\n").map((subscription) => {
       const [encodedSessionId] = subscription.split(":");
       const childSessionId = decodeURIComponent(encodedSessionId ?? "");
@@ -124,10 +124,10 @@ export function SubagentPanel({
   }, [subscriptionKey]);
 
   useEffect(() => {
-    if (!window.matchMedia("(min-width: 48rem)").matches) return;
+    if (!window.matchMedia("(min-width: 48rem)").matches) return undefined;
     if (!selectedId) {
       const taskId = restoreFocusId.current;
-      if (!taskId) return;
+      if (!taskId) return undefined;
       const frame = requestAnimationFrame(() => {
         document
           .querySelector<HTMLButtonElement>(
@@ -136,7 +136,9 @@ export function SubagentPanel({
           ?.focus();
         restoreFocusId.current = undefined;
       });
-      return () => cancelAnimationFrame(frame);
+      return () => {
+        cancelAnimationFrame(frame);
+      };
     }
 
     const frame = requestAnimationFrame(() =>
@@ -176,7 +178,9 @@ export function SubagentPanel({
     restoreFocusId.current = sessionId;
     setSelectedId(sessionId);
   };
-  const closeTask = () => setSelectedId(undefined);
+  const closeTask = () => {
+    setSelectedId(undefined);
+  };
   const activity = (
     <ActivityCard
       doneCount={doneCount}
@@ -215,7 +219,9 @@ export function SubagentPanel({
       <Button
         aria-label="Open activity panel"
         className="absolute top-2 right-3 z-30 md:hidden"
-        onClick={() => setMobileOpen(true)}
+        onClick={() => {
+          setMobileOpen(true);
+        }}
         size="icon-sm"
         type="button"
         variant="ghost"
@@ -315,7 +321,7 @@ function ActivityCard({
       <CardContent className="min-h-0 overflow-y-auto pr-6">
         <p className="type-section-title text-muted-foreground">Activity</p>
         <label
-          className="mt-4 flex cursor-pointer items-center gap-3 rounded-lg px-2 py-2 hover:bg-muted"
+          className="mt-4 flex cursor-pointer items-center gap-3 rounded-lg p-2 hover:bg-muted"
           htmlFor="show-full-trace"
         >
           <span className="type-supporting-body min-w-0 flex-1">
@@ -324,12 +330,12 @@ function ActivityCard({
           <Switch
             checked={traceView === "trace"}
             id="show-full-trace"
-            onCheckedChange={(checked) =>
-              onTraceViewChange(checked ? "trace" : "imessage")
-            }
+            onCheckedChange={(checked) => {
+              onTraceViewChange(checked ? "trace" : "imessage");
+            }}
           />
         </label>
-        <div className="type-supporting-body flex items-center px-2 py-2 text-muted-foreground">
+        <div className="type-supporting-body flex items-center p-2 text-muted-foreground">
           <span>Usage</span>
           <span className="ml-auto">{formatChatUsage(usage)}</span>
         </div>
@@ -359,10 +365,12 @@ function ActivityCard({
                   return (
                     <button
                       aria-label={`${agentLabel(session.name)} task, ${status}`}
-                      className="group flex w-full items-center gap-3 rounded-md py-3 pr-2 pl-2 text-left"
+                      className="group flex w-full items-center gap-3 rounded-md px-2 py-3 text-left"
                       data-task-session={session.childSessionId}
                       key={session.childSessionId}
-                      onClick={() => onSelect(session.childSessionId)}
+                      onClick={() => {
+                        onSelect(session.childSessionId);
+                      }}
                       type="button"
                     >
                       <span className="min-w-0 flex-1">

--- a/src/app/(authenticated)/(manager)/page.tsx
+++ b/src/app/(authenticated)/(manager)/page.tsx
@@ -60,7 +60,7 @@ export default async function Page({ searchParams }: PageProps<"/">) {
           <ConnectorRow
             action={
               <span className="type-caption text-muted-foreground">
-                {browserReady ? "Connected" : "Unavailable"}
+                Connected
               </span>
             }
             description="Run isolated browsers in your Kernel account."
@@ -120,10 +120,10 @@ function GoogleWorkspaceSection({
   );
 }
 
-type GoogleWorkspaceConnection = {
+interface GoogleWorkspaceConnection {
   readonly accountLabel: string | null;
   readonly state: "connected" | "disconnected" | "unavailable";
-};
+}
 
 async function readGoogleWorkspaceConnection(
   userId: string
@@ -185,7 +185,9 @@ export function ChannelsSection({
           <Button
             className="h-11 justify-start"
             nativeButton={false}
-            render={<a href={`sms:${linqPhoneNumber}`} />}
+            render={
+              <a aria-label="Open iMessage" href={`sms:${linqPhoneNumber}`} />
+            }
             variant="outline"
           >
             <MailIcon />

--- a/src/app/(authenticated)/(manager)/vault/_components/addresses/form.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/addresses/form.tsx
@@ -67,8 +67,9 @@ export function AddressForm({
     });
   };
 
-  const update = (field: keyof typeof form, value: string) =>
+  const update = (field: keyof typeof form, value: string) => {
     setForm((current) => ({ ...current, [field]: value }));
+  };
 
   return (
     <form noValidate onSubmit={submit}>
@@ -78,7 +79,9 @@ export function AddressForm({
             error={errors.nickname?.[0]}
             id="vault-address-label"
             label="Name"
-            onChange={(value) => update("nickname", value)}
+            onChange={(value) => {
+              update("nickname", value);
+            }}
             placeholder="Home"
             value={form.nickname}
           />
@@ -87,7 +90,9 @@ export function AddressForm({
             error={errors.recipientName?.[0]}
             id="vault-address-recipient"
             label="Recipient name"
-            onChange={(value) => update("recipientName", value)}
+            onChange={(value) => {
+              update("recipientName", value);
+            }}
             value={form.recipientName}
           />
         </div>
@@ -96,7 +101,9 @@ export function AddressForm({
           error={errors.line1?.[0]}
           id="vault-address-line1"
           label="Address line 1"
-          onChange={(value) => update("line1", value)}
+          onChange={(value) => {
+            update("line1", value);
+          }}
           value={form.line1}
         />
         <FormField
@@ -104,7 +111,9 @@ export function AddressForm({
           error={errors.line2?.[0]}
           id="vault-address-line2"
           label="Address line 2 (optional)"
-          onChange={(value) => update("line2", value)}
+          onChange={(value) => {
+            update("line2", value);
+          }}
           value={form.line2}
         />
         <div className="grid gap-3 sm:grid-cols-2">
@@ -113,7 +122,9 @@ export function AddressForm({
             error={errors.city?.[0]}
             id="vault-address-city"
             label="City"
-            onChange={(value) => update("city", value)}
+            onChange={(value) => {
+              update("city", value);
+            }}
             value={form.city}
           />
           <FormField
@@ -121,7 +132,9 @@ export function AddressForm({
             error={errors.region?.[0]}
             id="vault-address-region"
             label="State / province / region"
-            onChange={(value) => update("region", value)}
+            onChange={(value) => {
+              update("region", value);
+            }}
             value={form.region}
           />
         </div>
@@ -131,7 +144,9 @@ export function AddressForm({
             error={errors.postalCode?.[0]}
             id="vault-address-postal"
             label="ZIP / postal code"
-            onChange={(value) => update("postalCode", value)}
+            onChange={(value) => {
+              update("postalCode", value);
+            }}
             value={form.postalCode}
           />
           <FormField
@@ -140,7 +155,9 @@ export function AddressForm({
             id="vault-address-country"
             label="Country"
             maxLength={2}
-            onChange={(value) => update("countryCode", value.toUpperCase())}
+            onChange={(value) => {
+              update("countryCode", value.toUpperCase());
+            }}
             value={form.countryCode}
           />
         </div>

--- a/src/app/(authenticated)/(manager)/vault/_components/addresses/form.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/addresses/form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type FormEvent, useState } from "react";
+import { type SubmitEvent, useState } from "react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
@@ -47,9 +47,11 @@ export function AddressForm({
   });
   const result = addressFormSchema.safeParse(form);
   const errors =
-    attempted && !result.success ? result.error.flatten().fieldErrors : {};
+    attempted && !result.success
+      ? z.flattenError(result.error).fieldErrors
+      : {};
 
-  const submit = (event: FormEvent) => {
+  const submit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     setAttempted(true);
     if (!result.success) return;

--- a/src/app/(authenticated)/(manager)/vault/_components/addresses/index.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/addresses/index.tsx
@@ -52,7 +52,12 @@ export function VaultAddresses({
               title="Addresses"
             />
             <div className="flex justify-end gap-2">
-              <Button onClick={() => section.setView("add")} type="button">
+              <Button
+                onClick={() => {
+                  section.setView("add");
+                }}
+                type="button"
+              >
                 <PlusIcon />
                 Add address
               </Button>
@@ -61,7 +66,9 @@ export function VaultAddresses({
         ) : (
           <>
             <VaultSectionBackButton
-              onClick={() => section.setView("list")}
+              onClick={() => {
+                section.setView("list");
+              }}
               title="Addresses"
             />
             <DialogHeader className="pr-10 sm:pr-6">
@@ -73,7 +80,9 @@ export function VaultAddresses({
             </DialogHeader>
             <AddressForm
               initialLabel={initialAdd ? setup.label : undefined}
-              onSaved={() => section.setView("list")}
+              onSaved={() => {
+                section.setView("list");
+              }}
             />
           </>
         )}

--- a/src/app/(authenticated)/(manager)/vault/_components/cards/form.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/cards/form.tsx
@@ -105,9 +105,9 @@ export function CardForm({
             id="vault-payment-cardholder"
             label="Name on card"
             name="cc-name"
-            onChange={(cardholderName) =>
-              setForm((current) => ({ ...current, cardholderName }))
-            }
+            onChange={(cardholderName) => {
+              setForm((current) => ({ ...current, cardholderName }));
+            }}
             value={form.cardholderName}
           />
           <CardField
@@ -116,9 +116,9 @@ export function CardForm({
             id="vault-payment-nickname"
             label="Nickname (optional)"
             name="card-nickname"
-            onChange={(nickname) =>
-              setForm((current) => ({ ...current, nickname }))
-            }
+            onChange={(nickname) => {
+              setForm((current) => ({ ...current, nickname }));
+            }}
             placeholder="Personal"
             value={form.nickname}
           />
@@ -132,12 +132,12 @@ export function CardForm({
           label="Card number"
           maxLength={23}
           name="cc-number"
-          onChange={(value) =>
+          onChange={(value) => {
             setForm((current) => ({
               ...current,
               cardNumber: formatCardNumber(value),
-            }))
-          }
+            }));
+          }}
           placeholder="1234 5678 9012 3456"
           trailingLabel={cardType?.niceType}
           value={form.cardNumber}
@@ -152,12 +152,12 @@ export function CardForm({
             label="Expiration"
             maxLength={7}
             name="cc-exp"
-            onChange={(value) =>
+            onChange={(value) => {
               setForm((current) => ({
                 ...current,
                 expiration: formatExpiration(value),
-              }))
-            }
+              }));
+            }}
             placeholder="MM / YY"
             value={form.expiration}
           />
@@ -169,12 +169,12 @@ export function CardForm({
             label="CVC"
             maxLength={4}
             name="cc-csc"
-            onChange={(value) =>
+            onChange={(value) => {
               setForm((current) => ({
                 ...current,
                 cvc: value.replaceAll(/\D/gu, "").slice(0, 4),
-              }))
-            }
+              }));
+            }}
             placeholder="123"
             value={form.cvc}
           />
@@ -186,9 +186,9 @@ export function CardForm({
             label="Billing ZIP / postal"
             maxLength={20}
             name="postal-code"
-            onChange={(billingPostalCode) =>
-              setForm((current) => ({ ...current, billingPostalCode }))
-            }
+            onChange={(billingPostalCode) => {
+              setForm((current) => ({ ...current, billingPostalCode }));
+            }}
             value={form.billingPostalCode}
           />
         </div>
@@ -231,7 +231,9 @@ function CardField({
         {...inputProps}
         aria-invalid={error ? true : undefined}
         id={id}
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
       />
       <FieldError errors={error ? [{ message: error }] : undefined} />
     </Field>

--- a/src/app/(authenticated)/(manager)/vault/_components/cards/form.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/cards/form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type FormEvent, useState } from "react";
+import { type SubmitEvent, useState } from "react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
 import { Badge } from "@/components/ui/badge";
@@ -64,9 +64,11 @@ export function CardForm({
   const cardType = paymentCardType(form.cardNumber);
   const result = paymentCardFormSchema.safeParse(form);
   const errors =
-    attempted && !result.success ? result.error.flatten().fieldErrors : {};
+    attempted && !result.success
+      ? z.flattenError(result.error).fieldErrors
+      : {};
 
-  const submit = (event: FormEvent) => {
+  const submit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     setAttempted(true);
     if (!result.success) return;

--- a/src/app/(authenticated)/(manager)/vault/_components/cards/index.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/cards/index.tsx
@@ -52,7 +52,12 @@ export function VaultCards({
               title="Cards"
             />
             <div className="flex justify-end gap-2">
-              <Button onClick={() => section.setView("add")} type="button">
+              <Button
+                onClick={() => {
+                  section.setView("add");
+                }}
+                type="button"
+              >
                 <PlusIcon />
                 Add card
               </Button>
@@ -61,7 +66,9 @@ export function VaultCards({
         ) : (
           <>
             <VaultSectionBackButton
-              onClick={() => section.setView("list")}
+              onClick={() => {
+                section.setView("list");
+              }}
               title="Cards"
             />
             <DialogHeader className="pr-10 sm:pr-6">
@@ -73,7 +80,9 @@ export function VaultCards({
             </DialogHeader>
             <CardForm
               initialLabel={initialAdd ? setup.label : undefined}
-              onSaved={() => section.setView("list")}
+              onSaved={() => {
+                section.setView("list");
+              }}
             />
           </>
         )}

--- a/src/app/(authenticated)/(manager)/vault/_components/contacts/form.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/contacts/form.tsx
@@ -81,8 +81,9 @@ export function ContactForm({
     });
   };
 
-  const update = (field: keyof typeof form, value: string) =>
+  const update = (field: keyof typeof form, value: string) => {
     setForm((current) => ({ ...current, [field]: value }));
+  };
 
   return (
     <form noValidate onSubmit={submit}>
@@ -91,7 +92,9 @@ export function ContactForm({
           error={errors.nickname?.[0]}
           id="vault-contact-label"
           label="Name"
-          onChange={(value) => update("nickname", value)}
+          onChange={(value) => {
+            update("nickname", value);
+          }}
           placeholder="Checkout"
           value={form.nickname}
         />
@@ -100,7 +103,9 @@ export function ContactForm({
           error={errors.fullName?.[0]}
           id="vault-contact-name"
           label="Full name (optional)"
-          onChange={(value) => update("fullName", value)}
+          onChange={(value) => {
+            update("fullName", value);
+          }}
           value={form.fullName}
         />
         <FormField
@@ -108,7 +113,9 @@ export function ContactForm({
           error={errors.email?.[0]}
           id="vault-contact-email"
           label="Email (optional)"
-          onChange={(value) => update("email", value)}
+          onChange={(value) => {
+            update("email", value);
+          }}
           type="email"
           value={form.email}
         />
@@ -117,7 +124,9 @@ export function ContactForm({
           error={errors.phone?.[0]}
           id="vault-contact-phone"
           label="Phone (optional)"
-          onChange={(value) => update("phone", value)}
+          onChange={(value) => {
+            update("phone", value);
+          }}
           type="tel"
           value={form.phone}
         />

--- a/src/app/(authenticated)/(manager)/vault/_components/contacts/form.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/contacts/form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type FormEvent, useState } from "react";
+import { type SubmitEvent, useState } from "react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
@@ -57,9 +57,11 @@ export function ContactForm({
   });
   const result = contactFormSchema.safeParse(form);
   const errors =
-    attempted && !result.success ? result.error.flatten().fieldErrors : {};
+    attempted && !result.success
+      ? z.flattenError(result.error).fieldErrors
+      : {};
 
-  const submit = (event: FormEvent) => {
+  const submit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     setAttempted(true);
     if (!result.success) return;

--- a/src/app/(authenticated)/(manager)/vault/_components/contacts/index.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/contacts/index.tsx
@@ -52,7 +52,12 @@ export function VaultContacts({
               title="Contact info"
             />
             <div className="flex justify-end gap-2">
-              <Button onClick={() => section.setView("add")} type="button">
+              <Button
+                onClick={() => {
+                  section.setView("add");
+                }}
+                type="button"
+              >
                 <PlusIcon />
                 Add contact
               </Button>
@@ -61,7 +66,9 @@ export function VaultContacts({
         ) : (
           <>
             <VaultSectionBackButton
-              onClick={() => section.setView("list")}
+              onClick={() => {
+                section.setView("list");
+              }}
               title="Contact info"
             />
             <DialogHeader className="pr-10 sm:pr-6">
@@ -73,7 +80,9 @@ export function VaultContacts({
             </DialogHeader>
             <ContactForm
               initialLabel={initialAdd ? setup.label : undefined}
-              onSaved={() => section.setView("list")}
+              onSaved={() => {
+                section.setView("list");
+              }}
             />
           </>
         )}

--- a/src/app/(authenticated)/(manager)/vault/_components/field.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/field.tsx
@@ -21,7 +21,9 @@ export function FormField({
         {...inputProps}
         aria-invalid={error ? true : undefined}
         id={id}
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => {
+          onChange(event.target.value);
+        }}
       />
       <FieldError errors={error ? [{ message: error }] : undefined} />
     </Field>

--- a/src/app/(authenticated)/(manager)/vault/_components/logins/form.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/logins/form.tsx
@@ -121,9 +121,9 @@ export function LoginForm({
             error={errors.nickname?.[0]}
             id="vault-login-label"
             label="Name"
-            onChange={(nickname) =>
-              setForm((current) => ({ ...current, nickname }))
-            }
+            onChange={(nickname) => {
+              setForm((current) => ({ ...current, nickname }));
+            }}
             placeholder="GitHub"
             value={form.nickname}
           />
@@ -134,7 +134,9 @@ export function LoginForm({
           id="vault-login-origin"
           inputMode="url"
           label="Website"
-          onChange={(origin) => setForm((current) => ({ ...current, origin }))}
+          onChange={(origin) => {
+            setForm((current) => ({ ...current, origin }));
+          }}
           placeholder="https://www.ubereats.com"
           type="url"
           value={form.origin}
@@ -180,9 +182,9 @@ export function LoginForm({
             error={errors.identifier?.[0]}
             id="vault-login-identifier"
             label={identifierLabel(form.identifierType)}
-            onChange={(identifier) =>
-              setForm((current) => ({ ...current, identifier }))
-            }
+            onChange={(identifier) => {
+              setForm((current) => ({ ...current, identifier }));
+            }}
             placeholder={identifierPlaceholder(form.identifierType)}
             value={form.identifier}
           />
@@ -195,9 +197,9 @@ export function LoginForm({
           error={errors.password?.[0]}
           id="vault-login-password"
           label={passwordOptional ? "Password (optional)" : "Password"}
-          onChange={(password) =>
-            setForm((current) => ({ ...current, password }))
-          }
+          onChange={(password) => {
+            setForm((current) => ({ ...current, password }));
+          }}
           type="password"
           value={form.password}
         />

--- a/src/app/(authenticated)/(manager)/vault/_components/logins/form.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/logins/form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type FormEvent, useState } from "react";
+import { type SubmitEvent, useState } from "react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
@@ -84,9 +84,11 @@ export function LoginForm({
   });
   const result = loginFormSchema.safeParse(form);
   const errors =
-    attempted && !result.success ? result.error.flatten().fieldErrors : {};
+    attempted && !result.success
+      ? z.flattenError(result.error).fieldErrors
+      : {};
 
-  const submit = (event: FormEvent) => {
+  const submit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     setAttempted(true);
     if (!result.success) return;

--- a/src/app/(authenticated)/(manager)/vault/_components/logins/import.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/logins/import.tsx
@@ -113,6 +113,7 @@ export function ChromeImportPanel({ onDone }: { readonly onDone: () => void }) {
               nativeButton={false}
               render={
                 <a
+                  aria-label="Open Google Password Manager"
                   href={GOOGLE_PASSWORD_MANAGER_URL}
                   rel="noreferrer"
                   target="_blank"

--- a/src/app/(authenticated)/(manager)/vault/_components/logins/index.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/logins/index.tsx
@@ -59,13 +59,20 @@ export function VaultLogins({
             />
             <div className="flex justify-end gap-2">
               <Button
-                onClick={() => section.setView("import")}
+                onClick={() => {
+                  section.setView("import");
+                }}
                 type="button"
                 variant="outline"
               >
                 Bulk import
               </Button>
-              <Button onClick={() => section.setView("add")} type="button">
+              <Button
+                onClick={() => {
+                  section.setView("add");
+                }}
+                type="button"
+              >
                 <PlusIcon />
                 Add login
               </Button>
@@ -74,11 +81,17 @@ export function VaultLogins({
         ) : (
           <>
             <VaultSectionBackButton
-              onClick={() => section.setView("list")}
+              onClick={() => {
+                section.setView("list");
+              }}
               title="Logins"
             />
             {section.view === "import" ? (
-              <ChromeImportPanel onDone={() => section.setView("list")} />
+              <ChromeImportPanel
+                onDone={() => {
+                  section.setView("list");
+                }}
+              />
             ) : (
               <>
                 <DialogHeader className="pr-10 sm:pr-6">
@@ -93,7 +106,9 @@ export function VaultLogins({
                   initialIdentifierType={initialSetup?.identifierType}
                   initialLabel={initialSetup?.label}
                   initialOrigin={initialSetup?.origin}
-                  onSaved={() => section.setView("list")}
+                  onSaved={() => {
+                    section.setView("list");
+                  }}
                 />
               </>
             )}

--- a/src/app/(authenticated)/(manager)/vault/_components/section.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/section.tsx
@@ -218,7 +218,9 @@ export function VaultItemList({
 function VaultItemRow({ item }: { readonly item: VaultItem }) {
   const router = useRouter();
   const remove = api.vault.remove.useMutation({
-    onSuccess: () => router.refresh(),
+    onSuccess: () => {
+      router.refresh();
+    },
   });
 
   return (
@@ -235,7 +237,9 @@ function VaultItemRow({ item }: { readonly item: VaultItem }) {
       <Button
         aria-label={`Remove ${item.label}`}
         disabled={remove.isPending}
-        onClick={() => remove.mutate({ id: item.id })}
+        onClick={() => {
+          remove.mutate({ id: item.id });
+        }}
         size="icon-sm"
         type="button"
         variant="quiet"
@@ -253,10 +257,13 @@ function VaultItemIcon({ item }: { readonly item: VaultItem }) {
       <Globe2Icon className="size-4" />
       {faviconUrl ? (
         // Imported domains cannot be declared in Next Image configuration.
+        // oxlint-disable-next-line nextjs/no-img-element -- user-imported favicon URL
         <img
           alt=""
           className="absolute inset-0 size-full bg-background object-contain p-1"
-          onError={(event) => event.currentTarget.remove()}
+          onError={(event) => {
+            event.currentTarget.remove();
+          }}
           referrerPolicy="no-referrer"
           src={faviconUrl}
         />

--- a/src/app/(authenticated)/(manager)/vault/_components/section.tsx
+++ b/src/app/(authenticated)/(manager)/vault/_components/section.tsx
@@ -253,7 +253,6 @@ function VaultItemIcon({ item }: { readonly item: VaultItem }) {
       <Globe2Icon className="size-4" />
       {faviconUrl ? (
         // Imported domains cannot be declared in Next Image configuration.
-        // oxlint-disable-next-line nextjs/no-img-element
         <img
           alt=""
           className="absolute inset-0 size-full bg-background object-contain p-1"

--- a/src/app/(authenticated)/(tasks)/tasks/(overview)/_components/trace-history.tsx
+++ b/src/app/(authenticated)/(tasks)/tasks/(overview)/_components/trace-history.tsx
@@ -57,17 +57,17 @@ export function TraceHistory({
   readonly initialPage?: BrowserTracePage;
 }) {
   const router = useRouter();
-  const history = api.traces.list.useInfiniteQuery(
-    {},
-    {
-      getNextPageParam: (page) => page.nextCursor ?? undefined,
-      initialData: initialPage
-        ? { pageParams: [null], pages: [initialPage] }
-        : undefined,
-      initialCursor: null,
-      staleTime: 30 * 1000,
-    }
-  );
+  const queryOptions = {
+    getNextPageParam: (page: BrowserTracePage) => page.nextCursor ?? undefined,
+    initialCursor: null,
+    staleTime: 30 * 1000,
+  };
+  if (initialPage) {
+    Object.assign(queryOptions, {
+      initialData: { pageParams: [null], pages: [initialPage] },
+    });
+  }
+  const history = api.traces.list.useInfiniteQuery({}, queryOptions);
   const pages = history.data?.pages;
   const traces = useMemo(
     () => [

--- a/src/app/(authenticated)/(tasks)/tasks/(overview)/page.tsx
+++ b/src/app/(authenticated)/(tasks)/tasks/(overview)/page.tsx
@@ -16,7 +16,7 @@ export default async function TasksPage() {
     initialError = "Unable to read the browser trace history.";
   }
   return (
-    <div className="flex w-full flex-col gap-6 px-4 py-6 sm:px-8 sm:py-8">
+    <div className="flex w-full flex-col gap-6 px-4 py-6 sm:p-8">
       <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="max-w-2xl">
           <h1 className="type-page-title">Browser traces</h1>

--- a/src/app/(authenticated)/(tasks)/tasks/[sessionId]/page.tsx
+++ b/src/app/(authenticated)/(tasks)/tasks/[sessionId]/page.tsx
@@ -44,7 +44,7 @@ export default async function TraceDetailPage({
   const events = await listBrowserTraceEvents(scope, trace.sessionId);
 
   return (
-    <div className="flex w-full flex-col gap-6 px-4 py-6 sm:px-8 sm:py-8">
+    <div className="flex w-full flex-col gap-6 px-4 py-6 sm:p-8">
       <header className="flex flex-col gap-4">
         <div>
           <Button

--- a/src/app/(authenticated)/_components/account-control.tsx
+++ b/src/app/(authenticated)/_components/account-control.tsx
@@ -9,7 +9,7 @@ export function AuthenticatedAccountControl() {
   if (!session?.user) return null;
 
   return (
-    <div className="flex items-center gap-2 border-t border-sidebar-border px-3 py-3">
+    <div className="flex items-center gap-2 border-t border-sidebar-border p-3">
       <UserIcon className="size-4 shrink-0 text-muted-foreground" />
       <span className="min-w-0 flex-1 truncate type-label text-muted-foreground">
         {session.user.phoneNumber ?? "Signed in"}

--- a/src/app/(authenticated)/_components/authenticated-navigation.tsx
+++ b/src/app/(authenticated)/_components/authenticated-navigation.tsx
@@ -70,4 +70,5 @@ function activeRoute(pathname: string) {
   if (pathname.startsWith("/chats")) return "chats";
   if (pathname.startsWith("/chat")) return "chat";
   if (pathname.startsWith("/tasks")) return "tasks";
+  return undefined;
 }

--- a/src/app/(authenticated)/layout.tsx
+++ b/src/app/(authenticated)/layout.tsx
@@ -30,7 +30,7 @@ export default async function AuthenticatedLayout({
     <TRPCProvider>
       <SidebarProvider style={sidebarStyle}>
         <Sidebar>
-          <SidebarHeader className="border-b border-sidebar-border px-4 py-4">
+          <SidebarHeader className="border-b border-sidebar-border p-4">
             <Link aria-label="Workspace" className="w-fit" href="/">
               <Logo className="size-7" />
             </Link>

--- a/src/app/artifacts/[artifactId]/route.ts
+++ b/src/app/artifacts/[artifactId]/route.ts
@@ -46,19 +46,19 @@ async function openArtifact(
   const byteSize = artifact?.byteSize;
   const filename = artifact?.filename;
   const mediaType = artifact?.mediaType;
-  if (!artifact || !byteSize || !filename || !mediaType) return;
-  if (!env.BLOB_STORE_ID && !env.BLOB_READ_WRITE_TOKEN) return;
+  if (!artifact || !byteSize || !filename || !mediaType) return undefined;
+  if (!env.BLOB_STORE_ID && !env.BLOB_READ_WRITE_TOKEN) return undefined;
   const result = await get(artifact.storagePathname, {
     access: "private",
     abortSignal: options.signal,
     ifNoneMatch: options.ifNoneMatch,
   });
-  if (!result) return;
+  if (!result) return undefined;
   if (
     result.statusCode === 200 &&
     (result.blob.size !== byteSize || result.blob.contentType !== mediaType)
   )
-    return;
+    return undefined;
   return { artifact: { ...artifact, byteSize, filename, mediaType }, result };
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: LayoutProps<"/">) {
   const session = await getAuthSession(await headers());
-  const workspaceId = session?.user?.id
+  const workspaceId = session
     ? accessScopeForUser(`better-auth:${session.user.id}`).workspaceId
     : undefined;
 

--- a/src/app/sign-in/phone-auth-form.tsx
+++ b/src/app/sign-in/phone-auth-form.tsx
@@ -105,7 +105,12 @@ export function PhoneAuthForm({
 
   if (step === "verification-code") {
     return (
-      <form className="mt-6 space-y-4" onSubmit={submitCode}>
+      <form
+        className="mt-6 space-y-4"
+        onSubmit={(event) => {
+          void submitCode(event);
+        }}
+      >
         <div className="space-y-2">
           <Label htmlFor="code">Verification code</Label>
           <Input
@@ -114,7 +119,9 @@ export function PhoneAuthForm({
             inputMode="numeric"
             maxLength={6}
             name="code"
-            onChange={(event) => setVerificationCode(event.target.value)}
+            onChange={(event) => {
+              setVerificationCode(event.target.value);
+            }}
             pattern="[0-9]{6}"
             required
             value={verificationCode}
@@ -144,13 +151,20 @@ export function PhoneAuthForm({
   }
 
   return (
-    <form className="mt-6 space-y-4" onSubmit={submitDetails}>
+    <form
+      className="mt-6 space-y-4"
+      onSubmit={(event) => {
+        void submitDetails(event);
+      }}
+    >
       <div className="space-y-2">
         <Label htmlFor="phone-number">Phone number</Label>
         <Input
           autoComplete="tel"
           id="phone-number"
-          onChange={(event) => setPhoneNumber(event.target.value.trim())}
+          onChange={(event) => {
+            setPhoneNumber(event.target.value.trim());
+          }}
           placeholder="(202) 555-0123"
           required
           type="tel"

--- a/src/app/sign-in/phone-auth-form.tsx
+++ b/src/app/sign-in/phone-auth-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useState, type SubmitEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -24,7 +24,7 @@ export function PhoneAuthForm({
   const [step, setStep] = useState<AuthStep>("phone-number");
   const [verificationCode, setVerificationCode] = useState("");
 
-  async function submitDetails(event: FormEvent<HTMLFormElement>) {
+  async function submitDetails(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(undefined);
     const normalizedPhoneNumber = normalizeAuthPhoneNumber(phoneNumber);
@@ -58,7 +58,7 @@ export function PhoneAuthForm({
     }
   }
 
-  async function submitCode(event: FormEvent<HTMLFormElement>) {
+  async function submitCode(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(undefined);
     const code = verificationCode.trim();

--- a/src/auth/phone-number.ts
+++ b/src/auth/phone-number.ts
@@ -7,7 +7,7 @@ export function isE164PhoneNumber(value: string) {
 
 export function normalizeAuthPhoneNumber(value: string) {
   const trimmedValue = value.trim();
-  if (!PHONE_NUMBER_INPUT.test(trimmedValue)) return;
+  if (!PHONE_NUMBER_INPUT.test(trimmedValue)) return undefined;
 
   const digits = trimmedValue.replace(/\D/g, "");
   const normalizedValue = trimmedValue.startsWith("+")

--- a/src/components/ai-elements/conversation.tsx
+++ b/src/components/ai-elements/conversation.tsx
@@ -34,11 +34,12 @@ export const Conversation = ({
   scrollRestorationKey,
   ...props
 }: ConversationProps) => {
-  const parsedRenderer = z.function().safeParse(children);
-  // SAFETY: z.function established that this branch contains the render-child member of the children union.
-  const renderChild = parsedRenderer.success
-    ? (parsedRenderer.data as ConversationRenderChild)
-    : undefined;
+  const parsedRenderer = z
+    .custom<ConversationRenderChild>(
+      (value) => z.function().safeParse(value).success
+    )
+    .safeParse(children);
+  const renderChild = parsedRenderer.success ? parsedRenderer.data : undefined;
   return (
     <StickToBottom
       className={cn("relative flex-1 overflow-y-hidden", className)}
@@ -82,7 +83,7 @@ function ConversationScrollRestoration({
 
   useLayoutEffect(() => {
     const scrollElement = scrollRef.current;
-    if (scrollElement === null) return;
+    if (scrollElement === null) return undefined;
 
     if (restoredKeyRef.current !== storageKey) {
       const saved = readScrollPosition(sessionStorage.getItem(storageKey));
@@ -93,7 +94,7 @@ function ConversationScrollRestoration({
         });
       } else {
         scrollElement.scrollTop = scrollElement.scrollHeight;
-        scrollToBottom({ animation: "instant", ignoreEscapes: true });
+        void scrollToBottom({ animation: "instant", ignoreEscapes: true });
       }
       restoredKeyRef.current = storageKey;
     }
@@ -194,7 +195,8 @@ export const ConversationEmptyState = ({
 
 export type ConversationScrollButtonProps = ComponentProps<typeof Button>;
 
-const subscribeToHydration = () => () => {};
+const unsubscribeFromHydration = () => undefined;
+const subscribeToHydration = () => unsubscribeFromHydration;
 
 export const ConversationScrollButton = ({
   className,
@@ -208,7 +210,7 @@ export const ConversationScrollButton = ({
   );
 
   const handleScrollToBottom = useCallback(() => {
-    scrollToBottom();
+    void scrollToBottom();
   }, [scrollToBottom]);
 
   return (

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -336,16 +336,17 @@ export function ArtifactMessageImage({
   if (!parsedSource.success || !isBrowserImageArtifactUrl(parsedSource.data)) {
     return (
       <span className="text-muted-foreground">
-        Image not displayed: {alt || "external image"}
+        Image not displayed: {alt ?? "external image"}
       </span>
     );
   }
 
   return (
     <a href={parsedSource.data} rel="noreferrer" target="_blank">
+      {/* oxlint-disable-next-line nextjs/no-img-element -- validated runtime browser image URL */}
       <img
         {...props}
-        alt={alt || "Browser image"}
+        alt={alt ?? "Browser image"}
         className={cn(
           "my-3 max-h-[32rem] w-auto max-w-full rounded-lg border bg-muted object-contain",
           className

--- a/src/components/ai-elements/model-selector.tsx
+++ b/src/components/ai-elements/model-selector.tsx
@@ -86,7 +86,6 @@ export function ModelSelectorLogo({
 }) {
   return (
     // The official AI Elements selector uses the models.dev provider artwork.
-    // eslint-disable-next-line @next/next/no-img-element
     <img
       {...props}
       alt=""

--- a/src/components/ai-elements/model-selector.tsx
+++ b/src/components/ai-elements/model-selector.tsx
@@ -86,6 +86,7 @@ export function ModelSelectorLogo({
 }) {
   return (
     // The official AI Elements selector uses the models.dev provider artwork.
+    // oxlint-disable-next-line nextjs/no-img-element -- external provider artwork
     <img
       {...props}
       alt=""

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-/* oxlint-disable eslint/no-empty-function, eslint/no-underscore-dangle, jsx-a11y/heading-has-content, typescript/no-confusing-void-expression, typescript/no-misused-promises, typescript/no-unnecessary-condition, typescript/no-unnecessary-type-assertion, typescript/no-unsafe-type-assertion, typescript/return-await, unicorn/prefer-add-event-listener -- Preserve the public AI Elements browser and form API for source-compatible consumer migration. */
-
 import {
   Command,
   CommandEmpty,

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-/* oxlint-disable eslint/no-empty-function, eslint/no-underscore-dangle, jsx-a11y/heading-has-content, typescript/no-confusing-void-expression, typescript/no-deprecated, typescript/no-misused-promises, typescript/no-unnecessary-condition, typescript/no-unnecessary-type-assertion, typescript/no-unsafe-type-assertion, typescript/return-await, unicorn/prefer-add-event-listener -- Preserve the public AI Elements browser and form API for source-compatible consumer migration. */
+/* oxlint-disable eslint/no-empty-function, eslint/no-underscore-dangle, jsx-a11y/heading-has-content, typescript/no-confusing-void-expression, typescript/no-misused-promises, typescript/no-unnecessary-condition, typescript/no-unnecessary-type-assertion, typescript/no-unsafe-type-assertion, typescript/return-await, unicorn/prefer-add-event-listener -- Preserve the public AI Elements browser and form API for source-compatible consumer migration. */
 
 import {
   Command,
@@ -58,13 +58,13 @@ import type {
   ChangeEventHandler,
   ClipboardEventHandler,
   ComponentProps,
-  FormEvent,
-  FormEventHandler,
   HTMLAttributes,
   KeyboardEventHandler,
   PropsWithChildren,
   ReactNode,
   RefObject,
+  SubmitEvent,
+  SubmitEventHandler,
 } from "react";
 import {
   Children,
@@ -511,7 +511,7 @@ export type PromptInputProps = Omit<
   }) => void;
   onSubmit: (
     message: PromptInputMessage,
-    event: FormEvent<HTMLFormElement>
+    event: SubmitEvent<HTMLFormElement>
   ) => void | Promise<void>;
 };
 
@@ -844,7 +844,7 @@ export const PromptInput = ({
     [referencedSources, clearReferencedSources]
   );
 
-  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
+  const handleSubmit: SubmitEventHandler<HTMLFormElement> = useCallback(
     async (event) => {
       event.preventDefault();
 

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -62,7 +62,6 @@ import type {
   ReactNode,
   RefObject,
   SubmitEvent,
-  SubmitEventHandler,
 } from "react";
 import {
   Children,
@@ -84,12 +83,23 @@ const convertBlobUrlToDataUrl = async (url: string): Promise<string | null> => {
   try {
     const response = await fetch(url);
     const blob = await response.blob();
-    // FileReader uses callback-based API, wrapping in Promise is necessary
-    return new Promise((resolve) => {
+    return await new Promise((resolve) => {
       const reader = new FileReader();
-      // SAFETY: FileReader.result is a string because readAsDataURL is the only read operation used here.
-      reader.onloadend = () => resolve(reader.result as string);
-      reader.onerror = () => resolve(null);
+      reader.addEventListener(
+        "loadend",
+        () => {
+          const result = reader.result;
+          resolve(result instanceof ArrayBuffer ? null : result);
+        },
+        { once: true }
+      );
+      reader.addEventListener(
+        "error",
+        () => {
+          resolve(null);
+        },
+        { once: true }
+      );
       reader.readAsDataURL(blob);
     });
   } catch {
@@ -98,12 +108,16 @@ const convertBlobUrlToDataUrl = async (url: string): Promise<string | null> => {
 };
 
 const captureScreenshot = async (): Promise<File | null> => {
-  if (
-    typeof navigator === "undefined" ||
-    !navigator.mediaDevices?.getDisplayMedia
-  ) {
+  if (typeof navigator === "undefined") {
     return null;
   }
+  const mediaDevices = z
+    .custom<MediaDevices>(
+      (value) =>
+        z.object({ getDisplayMedia: z.function() }).safeParse(value).success
+    )
+    .safeParse(navigator.mediaDevices);
+  if (!mediaDevices.success) return null;
 
   let stream: MediaStream | null = null;
   const video = document.createElement("video");
@@ -111,17 +125,28 @@ const captureScreenshot = async (): Promise<File | null> => {
   video.playsInline = true;
 
   try {
-    stream = await navigator.mediaDevices.getDisplayMedia({
+    stream = await mediaDevices.data.getDisplayMedia({
       audio: false,
       video: true,
     });
 
     video.srcObject = stream;
 
-    // Video element uses callback-based API, wrapping in Promise is necessary
     await new Promise<void>((resolve, reject) => {
-      video.onloadedmetadata = () => resolve();
-      video.onerror = () => reject(new Error("Failed to load screen stream"));
+      video.addEventListener(
+        "loadedmetadata",
+        () => {
+          resolve();
+        },
+        { once: true }
+      );
+      video.addEventListener(
+        "error",
+        () => {
+          reject(new Error("Failed to load screen stream"));
+        },
+        { once: true }
+      );
     });
 
     await video.play();
@@ -170,6 +195,10 @@ const captureScreenshot = async (): Promise<File | null> => {
   }
 };
 
+const dragDataTransferSchema = z.custom<DataTransfer>(
+  (value) => value !== null && value !== undefined
+);
+
 // ============================================================================
 // Provider Context & Types
 // ============================================================================
@@ -193,7 +222,7 @@ export interface PromptInputControllerProps {
   textInput: TextInputContext;
   attachments: AttachmentsContext;
   /** INTERNAL: Allows PromptInput to register its file textInput + "open" callback */
-  __registerFileInput: (
+  registerFileInput: (
     ref: RefObject<HTMLInputElement | null>,
     open: () => void
   ) => void;
@@ -247,14 +276,16 @@ export const PromptInputProvider = ({
 }: PromptInputProviderProps) => {
   // ----- textInput state
   const [textInput, setTextInput] = useState(initialTextInput);
-  const clearInput = useCallback(() => setTextInput(""), []);
+  const clearInput = useCallback(() => {
+    setTextInput("");
+  }, []);
 
   // ----- attachments state (global when wrapped)
   const [attachmentFiles, setAttachmentFiles] = useState<
     (FileUIPart & { id: string })[]
   >([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const openRef = useRef<() => void>(() => {});
+  const openRef = useRef<(() => void) | undefined>(undefined);
 
   const add = useCallback((files: File[] | FileList) => {
     const incoming = [...files];
@@ -330,7 +361,7 @@ export const PromptInputProvider = ({
     [attachmentFiles, add, remove, clear, openFileDialog]
   );
 
-  const __registerFileInput = useCallback(
+  const registerFileInput = useCallback(
     (ref: RefObject<HTMLInputElement | null>, open: () => void) => {
       fileInputRef.current = ref.current;
       openRef.current = open;
@@ -340,7 +371,7 @@ export const PromptInputProvider = ({
 
   const controller = useMemo<PromptInputControllerProps>(
     () => ({
-      __registerFileInput,
+      registerFileInput,
       attachments,
       textInput: {
         clear: clearInput,
@@ -348,7 +379,7 @@ export const PromptInputProvider = ({
         value: textInput,
       },
     }),
-    [textInput, clearInput, attachments, __registerFileInput]
+    [textInput, clearInput, attachments, registerFileInput]
   );
 
   return (
@@ -628,17 +659,15 @@ export const PromptInput = ({
     [matchesAccept, maxFiles, maxFileSize, onError]
   );
 
-  const removeLocal = useCallback(
-    (id: string) =>
-      setItems((prev) => {
-        const found = prev.find((file) => file.id === id);
-        if (found?.url) {
-          URL.revokeObjectURL(found.url);
-        }
-        return prev.filter((file) => file.id !== id);
-      }),
-    []
-  );
+  const removeLocal = useCallback((id: string) => {
+    setItems((prev) => {
+      const found = prev.find((file) => file.id === id);
+      if (found?.url) {
+        URL.revokeObjectURL(found.url);
+      }
+      return prev.filter((file) => file.id !== id);
+    });
+  }, []);
 
   // Wrapper that validates files before calling provider's add
   const addWithProviderValidation = useCallback(
@@ -683,25 +712,24 @@ export const PromptInput = ({
     [matchesAccept, maxFileSize, maxFiles, onError, files.length, controller]
   );
 
-  const clearAttachments = useCallback(
-    () =>
-      usingProvider
-        ? controller?.attachments.clear()
-        : setItems((prev) => {
-            for (const file of prev) {
-              if (file.url) {
-                URL.revokeObjectURL(file.url);
-              }
-            }
-            return [];
-          }),
-    [usingProvider, controller]
-  );
+  const clearAttachments = useCallback(() => {
+    if (usingProvider) {
+      controller.attachments.clear();
+      return;
+    }
+    setItems((previousItems) => {
+      for (const file of previousItems) {
+        if (file.url) {
+          URL.revokeObjectURL(file.url);
+        }
+      }
+      return [];
+    });
+  }, [usingProvider, controller]);
 
-  const clearReferencedSources = useCallback(
-    () => setReferencedSources([]),
-    []
-  );
+  const clearReferencedSources = useCallback(() => {
+    setReferencedSources([]);
+  }, []);
 
   const add = usingProvider ? addWithProviderValidation : addLocal;
   const remove = usingProvider ? controller.attachments.remove : removeLocal;
@@ -719,7 +747,9 @@ export const PromptInput = ({
     if (!usingProvider) {
       return;
     }
-    controller.__registerFileInput(inputRef, () => inputRef.current?.click());
+    controller.registerFileInput(inputRef, () => {
+      inputRef.current?.click();
+    });
   }, [usingProvider, controller]);
 
   // Note: File input cannot be programmatically set for security reasons
@@ -734,24 +764,28 @@ export const PromptInput = ({
   useEffect(() => {
     const form = formRef.current;
     if (!form) {
-      return;
+      return undefined;
     }
     if (globalDrop) {
       // when global drop is on, let the document-level handler own drops
-      return;
+      return undefined;
     }
 
     const onDragOver = (e: DragEvent) => {
-      if (e.dataTransfer?.types?.includes("Files")) {
+      const dataTransfer = dragDataTransferSchema.safeParse(e.dataTransfer);
+      if (!dataTransfer.success) return;
+      if (dataTransfer.data.types.includes("Files")) {
         e.preventDefault();
       }
     };
     const onDrop = (e: DragEvent) => {
-      if (e.dataTransfer?.types?.includes("Files")) {
+      const dataTransfer = dragDataTransferSchema.safeParse(e.dataTransfer);
+      if (!dataTransfer.success) return;
+      if (dataTransfer.data.types.includes("Files")) {
         e.preventDefault();
       }
-      if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
-        add(e.dataTransfer.files);
+      if (dataTransfer.data.files.length > 0) {
+        add(dataTransfer.data.files);
       }
     };
     form.addEventListener("dragover", onDragOver);
@@ -764,20 +798,24 @@ export const PromptInput = ({
 
   useEffect(() => {
     if (!globalDrop) {
-      return;
+      return undefined;
     }
 
     const onDragOver = (e: DragEvent) => {
-      if (e.dataTransfer?.types?.includes("Files")) {
+      const dataTransfer = dragDataTransferSchema.safeParse(e.dataTransfer);
+      if (!dataTransfer.success) return;
+      if (dataTransfer.data.types.includes("Files")) {
         e.preventDefault();
       }
     };
     const onDrop = (e: DragEvent) => {
-      if (e.dataTransfer?.types?.includes("Files")) {
+      const dataTransfer = dragDataTransferSchema.safeParse(e.dataTransfer);
+      if (!dataTransfer.success) return;
+      if (dataTransfer.data.types.includes("Files")) {
         e.preventDefault();
       }
-      if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
-        add(e.dataTransfer.files);
+      if (dataTransfer.data.files.length > 0) {
+        add(dataTransfer.data.files);
       }
     };
     document.addEventListener("dragover", onDragOver);
@@ -817,7 +855,7 @@ export const PromptInput = ({
       add,
       clear: clearAttachments,
       fileInputRef: inputRef,
-      files: files.map((item) => ({ ...item, id: item.id })),
+      files,
       openFileDialog,
       remove,
     }),
@@ -830,7 +868,7 @@ export const PromptInput = ({
         const array = Array.isArray(incoming) ? incoming : [incoming];
         setReferencedSources((prev) => [
           ...prev,
-          ...array.map((s) => ({ ...s, id: nanoid() })),
+          ...array.map((source) => Object.assign({}, source, { id: nanoid() })),
         ]);
       },
       clear: clearReferencedSources,
@@ -842,8 +880,8 @@ export const PromptInput = ({
     [referencedSources, clearReferencedSources]
   );
 
-  const handleSubmit: SubmitEventHandler<HTMLFormElement> = useCallback(
-    async (event) => {
+  const handleSubmit = useCallback(
+    async (event: SubmitEvent<HTMLFormElement>) => {
       event.preventDefault();
 
       const form = event.currentTarget;
@@ -864,7 +902,7 @@ export const PromptInput = ({
         // Convert blob URLs to data URLs asynchronously
         const convertedFiles: FileUIPart[] = await Promise.all(
           files.map(async ({ id: _id, ...item }) => {
-            if (item.url?.startsWith("blob:")) {
+            if (item.url.startsWith("blob:")) {
               const dataUrl = await convertBlobUrlToDataUrl(item.url);
               // If conversion failed, keep the original blob URL
               return {
@@ -918,7 +956,9 @@ export const PromptInput = ({
       />
       <form
         className={cn("w-full", className)}
-        onSubmit={handleSubmit}
+        onSubmit={(event) => {
+          void handleSubmit(event);
+        }}
         ref={formRef}
         {...props}
       >
@@ -1014,11 +1054,7 @@ export const PromptInputTextarea = ({
 
   const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = useCallback(
     (event) => {
-      const items = event.clipboardData?.items;
-
-      if (!items) {
-        return;
-      }
+      const items = event.clipboardData.items;
 
       const files: File[] = [];
 
@@ -1039,8 +1075,12 @@ export const PromptInputTextarea = ({
     [attachments]
   );
 
-  const handleCompositionEnd = useCallback(() => setIsComposing(false), []);
-  const handleCompositionStart = useCallback(() => setIsComposing(true), []);
+  const handleCompositionEnd = useCallback(() => {
+    setIsComposing(false);
+  }, []);
+  const handleCompositionStart = useCallback(() => {
+    setIsComposing(true);
+  }, []);
 
   const controlledProps = controller
     ? {
@@ -1121,6 +1161,12 @@ export type PromptInputButtonTooltip =
       side?: ComponentProps<typeof TooltipContent>["side"];
     };
 
+const promptInputButtonTooltipOptionsSchema = z.object({
+  content: z.custom<ReactNode>(),
+  shortcut: z.string().optional(),
+  side: z.enum(["bottom", "left", "right", "top"]).optional(),
+});
+
 export type PromptInputButtonProps = ComponentProps<typeof InputGroupButton> & {
   tooltip?: PromptInputButtonTooltip;
 };
@@ -1150,10 +1196,9 @@ export const PromptInputButton = ({
   }
 
   const tooltipText = z.string().safeParse(tooltip);
-  // SAFETY: A failed string parse leaves only the object member of the declared tooltip union.
   const tooltipOptions = tooltipText.success
     ? undefined
-    : (tooltip as Exclude<PromptInputButtonTooltip, string>);
+    : promptInputButtonTooltipOptionsSchema.parse(tooltip);
   const tooltipContent = tooltipText.success
     ? tooltipText.data
     : tooltipOptions?.content;
@@ -1244,15 +1289,16 @@ export const PromptInputSubmit = ({
     Icon = <XIcon className="size-4" />;
   }
 
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleClick = useCallback<
+    NonNullable<PromptInputSubmitProps["onClick"]>
+  >(
+    (e) => {
       if (isGenerating && onStop) {
         e.preventDefault();
         onStop();
         return;
       }
-      // SAFETY: InputGroupButton exposes the same button click event contract used by this wrapper.
-      (onClick as React.MouseEventHandler<HTMLButtonElement> | undefined)?.(e);
+      onClick?.(e);
     },
     [isGenerating, onStop, onClick]
   );
@@ -1377,14 +1423,16 @@ export const PromptInputTab = ({
 export type PromptInputTabLabelProps = HTMLAttributes<HTMLHeadingElement>;
 
 export const PromptInputTabLabel = ({
+  children,
   className,
   ...props
 }: PromptInputTabLabelProps) => (
-  // Content provided via children in props
   <h3
     className={cn("mb-2 px-3 type-card-title text-muted-foreground", className)}
     {...props}
-  />
+  >
+    {children}
+  </h3>
 );
 
 export type PromptInputTabBodyProps = HTMLAttributes<HTMLDivElement>;

--- a/src/components/ai-elements/question.tsx
+++ b/src/components/ai-elements/question.tsx
@@ -3,9 +3,9 @@
 import type {
   ChangeEvent,
   ComponentProps,
-  FormEvent,
   HTMLAttributes,
   ReactNode,
+  SubmitEvent,
 } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -60,7 +60,7 @@ export type QuestionProps = Omit<
   disabled?: boolean;
   onSubmit?: (
     response: QuestionResponse,
-    event: FormEvent<HTMLFormElement>
+    event: SubmitEvent<HTMLFormElement>
   ) => void | Promise<void>;
   onValueChange?: (value: QuestionValue) => void;
   selectionMode?: SelectionMode;
@@ -143,7 +143,7 @@ export const Question = ({
   );
 
   const handleSubmit = useCallback(
-    async (event: FormEvent<HTMLFormElement>) => {
+    async (event: SubmitEvent<HTMLFormElement>) => {
       event.preventDefault();
       if (disabled) {
         return;

--- a/src/components/ai-elements/question.tsx
+++ b/src/components/ai-elements/question.tsx
@@ -172,7 +172,9 @@ export const Question = ({
           "space-y-4 rounded-lg border bg-background p-4",
           className
         )}
-        onSubmit={handleSubmit}
+        onSubmit={(event) => {
+          void handleSubmit(event);
+        }}
         {...props}
       >
         {children}
@@ -317,7 +319,7 @@ export const QuestionSubmit = ({
 
   return (
     <Button
-      disabled={question.disabled || disabled || !hasResponse}
+      disabled={question.disabled || disabled === true || !hasResponse}
       type="submit"
       {...props}
     >

--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -138,8 +138,11 @@ export const Reasoning = memo(
           hasAutoClosedRef.current = true;
         }, AUTO_CLOSE_DELAY);
 
-        return () => clearTimeout(timer);
+        return () => {
+          clearTimeout(timer);
+        };
       }
+      return undefined;
     }, [isStreaming, isOpen, setIsOpen]);
 
     const handleOpenChange = useCallback(

--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-/* oxlint-disable typescript/no-confusing-void-expression -- Preserve the AI Elements controlled and uncontrolled disclosure API. */
 import {
   Collapsible,
   CollapsibleContent,

--- a/src/components/ai-elements/shimmer.tsx
+++ b/src/components/ai-elements/shimmer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-/* oxlint-disable hooks/static-components, typescript/no-unnecessary-condition, typescript/no-unsafe-type-assertion, typescript/restrict-template-expressions -- AI Elements supports a caller-selected intrinsic motion element. */
+/* oxlint-disable hooks/static-components -- AI Elements supports a caller-selected intrinsic motion element. */
 
 import { cn } from "@/lib/utils";
 import { LazyMotion, domAnimation, m } from "motion/react";

--- a/src/components/ai-elements/shimmer.tsx
+++ b/src/components/ai-elements/shimmer.tsx
@@ -4,13 +4,7 @@
 
 import { cn } from "@/lib/utils";
 import { LazyMotion, domAnimation, m } from "motion/react";
-import {
-  type CSSProperties,
-  type ElementType,
-  type JSX,
-  memo,
-  useMemo,
-} from "react";
+import { type ElementType, memo, useMemo } from "react";
 
 interface TextShimmerProps {
   children: string;
@@ -27,11 +21,10 @@ const ShimmerComponent = ({
   duration = 2,
   spread = 2,
 }: TextShimmerProps) => {
-  // SAFETY: The public `as` prop is constrained to React element types accepted by motion.create.
-  const MotionComponent = m.create(Component as keyof JSX.IntrinsicElements);
+  const MotionComponent = m.create(Component);
 
   const dynamicSpread = useMemo(
-    () => (children?.length ?? 0) * spread,
+    () => children.length * spread,
     [children, spread]
   );
 
@@ -45,14 +38,11 @@ const ShimmerComponent = ({
           className
         )}
         initial={{ backgroundPosition: "100% center" }}
-        style={
-          // SAFETY: CSSProperties omits repository-owned custom properties even though React passes them through.
-          {
-            "--spread": `${dynamicSpread}px`,
-            backgroundImage:
-              "var(--bg), linear-gradient(color-mix(in oklab, var(--color-muted-foreground) 60%, transparent), color-mix(in oklab, var(--color-muted-foreground) 60%, transparent))",
-          } as CSSProperties
-        }
+        style={{
+          "--spread": `${String(dynamicSpread)}px`,
+          backgroundImage:
+            "var(--bg), linear-gradient(color-mix(in oklab, var(--color-muted-foreground) 60%, transparent), color-mix(in oklab, var(--color-muted-foreground) 60%, transparent))",
+        }}
         transition={{
           repeat: Number.POSITIVE_INFINITY,
           duration,

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -197,8 +197,8 @@ function FieldError({
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
         {uniqueErrors.map(
-          (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>
+          (error) =>
+            error?.message && <li key={error.message}>{error.message}</li>
         )}
       </ul>
     );

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -100,7 +100,9 @@ function SidebarProvider({
 
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {
-    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+    return isMobile
+      ? setOpenMobile((currentOpen) => !currentOpen)
+      : setOpen((currentOpen) => !currentOpen);
   }, [isMobile, setOpen, setOpenMobile]);
 
   // Adds a keyboard shortcut to toggle the sidebar.

--- a/src/lib/installation-secrets.ts
+++ b/src/lib/installation-secrets.ts
@@ -66,7 +66,7 @@ async function resolveInstallationSecrets() {
 function configuredInstallationSecrets() {
   const betterAuthSecret = env.BETTER_AUTH_SECRET;
   const secretEncryptionKey = env.SECRET_ENCRYPTION_KEY;
-  if (!betterAuthSecret && !secretEncryptionKey) return;
+  if (!betterAuthSecret && !secretEncryptionKey) return undefined;
   if (!betterAuthSecret || !secretEncryptionKey) {
     throw new Error(
       "Set both BETTER_AUTH_SECRET and SECRET_ENCRYPTION_KEY, or leave both unset for automatic private Blob provisioning."
@@ -84,7 +84,7 @@ async function readInstallationSecrets(pathname: string) {
     access: "private",
     useCache: false,
   });
-  if (!result) return;
+  if (!result) return undefined;
   if (result.statusCode !== 200) {
     throw new Error("The installation secrets Blob returned no content.");
   }

--- a/src/lib/tests/installation-secrets.test.ts
+++ b/src/lib/tests/installation-secrets.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable vitest/require-mock-type-parameters -- The Blob mock implements only the persistence operations exercised here. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { get, put } from "@vercel/blob";
 import { z } from "zod";

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -323,6 +323,7 @@ export function loginAccountHint(
       case "username":
         return `Username · ${identifier.value.slice(0, 2)}•••`;
     }
+    throw new Error("Unsupported login identifier type.");
   })();
   return origin
     ? `${new URL(origin).hostname} · ${identifierHint}`

--- a/src/trpc/router.ts
+++ b/src/trpc/router.ts
@@ -63,7 +63,9 @@ export const appRouter = createTRPCRouter({
     import: protectedProcedure
       .input(vaultImportItemsSchema)
       .mutation(async ({ ctx, input }) => {
+        /* oxlint-disable eslint/no-await-in-loop -- Import preserves source order and avoids concurrent writes to the same vault scope. */
         for (const item of input) await saveVaultItem(ctx.scope, item);
+        /* oxlint-enable eslint/no-await-in-loop */
       }),
     remove: protectedProcedure
       .input(z.object({ id: z.string().min(1) }))

--- a/tests/agent/channels/eve-channel-auth.test.ts
+++ b/tests/agent/channels/eve-channel-auth.test.ts
@@ -55,17 +55,17 @@ describe("Eve channel authentication", () => {
 });
 
 function unexpectedRouteContext() {
-  const unexpected = () => {
-    throw new Error("The request should stop at authorization.");
-  };
-
   return {
-    attachSession: unexpected,
-    from: unexpected,
+    attachSession: unexpectedRouteRequest,
+    from: unexpectedRouteRequest,
     params: { sessionId: "session/one" },
     requestIp: null,
-    resolveSession: unexpected,
-    to: unexpected,
-    waitUntil: unexpected,
+    resolveSession: unexpectedRouteRequest,
+    to: unexpectedRouteRequest,
+    waitUntil: unexpectedRouteRequest,
   } satisfies RouteHandlerArgs;
+}
+
+function unexpectedRouteRequest(): never {
+  throw new Error("The request should stop at authorization.");
 }

--- a/tests/agent/channels/linq-message-delivery.test.ts
+++ b/tests/agent/channels/linq-message-delivery.test.ts
@@ -1,4 +1,4 @@
-/* oxlint-disable typescript/no-unsafe-type-assertion, vitest/require-mock-type-parameters -- The handler fixture supplies only the Chat SDK fields exercised here. */
+/* oxlint-disable typescript/no-unsafe-type-assertion -- The handler fixture supplies only the Chat SDK fields exercised here. */
 import type { HookContext } from "eve/hooks";
 import { describe, expect, it, vi } from "vitest";
 import type * as Blob from "@vercel/blob";

--- a/tests/agent/subagents/worker/tools/worker-browser-images.test.ts
+++ b/tests/agent/subagents/worker/tools/worker-browser-images.test.ts
@@ -1,4 +1,4 @@
-/* oxlint-disable typescript/no-unsafe-type-assertion, vitest/require-mock-type-parameters -- The test fixtures implement only the external API surface exercised by the tool. */
+/* oxlint-disable vitest/require-mock-type-parameters -- The test fixtures implement only the external API surface exercised by the tool. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toolContextFor } from "@/tests/helpers/tool-context";
 

--- a/tests/agent/subagents/worker/tools/worker-browser-tools.test.ts
+++ b/tests/agent/subagents/worker/tools/worker-browser-tools.test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable typescript/no-unsafe-type-assertion -- Eve tool contexts are runtime-owned; these fixtures exercise only mocked authorization and abort-signal boundaries. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import * as WorkerAccess from "@/agent/subagents/worker/lib/access";

--- a/tests/local-development.test.ts
+++ b/tests/local-development.test.ts
@@ -20,14 +20,14 @@ describe("local development", () => {
     const [compose, developmentScript, packageManifestSource] =
       await Promise.all([
         readFile(new URL("../compose.yaml", import.meta.url), "utf8"),
-        readFile(new URL("../scripts/dev.mjs", import.meta.url), "utf8"),
+        readFile(new URL("../scripts/dev.ts", import.meta.url), "utf8"),
         readFile(new URL("../package.json", import.meta.url), "utf8"),
       ]);
     const packageManifest = z
       .object({ scripts: z.object({ dev: z.string() }) })
       .parse(JSON.parse(packageManifestSource));
 
-    expect(packageManifest.scripts.dev).toBe("node scripts/dev.mjs");
+    expect(packageManifest.scripts.dev).toBe("node scripts/dev.ts");
     expect(compose).toContain("image: postgres:17-alpine");
     expect(compose).toContain('"127.0.0.1::5432"');
     expect(compose).toContain("postgres-data:/var/lib/postgresql/data");
@@ -160,7 +160,7 @@ printf 'pnpm %s\\n' "$*" >> "$DEV_SUPERVISOR_LOG"
 
   const supervisor = spawn(
     process.execPath,
-    [new URL("../scripts/dev.mjs", import.meta.url).pathname],
+    [new URL("../scripts/dev.ts", import.meta.url).pathname],
     {
       env: {
         DEV_SUPERVISOR_LOG: logPath,
@@ -217,7 +217,7 @@ printf 'pnpm %s %s\n' "$*" "$DATABASE_URL" >> "$DEV_SUPERVISOR_LOG"
 
   const supervisor = spawn(
     process.execPath,
-    [new URL("../scripts/dev.mjs", import.meta.url).pathname],
+    [new URL("../scripts/dev.ts", import.meta.url).pathname],
     {
       env: {
         DEV_SUPERVISOR_LOG: logPath,
@@ -239,6 +239,7 @@ printf 'pnpm %s %s\n' "$*" "$DATABASE_URL" >> "$DEV_SUPERVISOR_LOG"
 }
 
 async function waitForLogEntry(path: string, expected: string) {
+  /* oxlint-disable eslint/no-await-in-loop -- This bounded poll must observe each read before scheduling the next retry. */
   for (let attempt = 0; attempt < 250; attempt += 1) {
     const contents = await readFile(path, "utf8").catch(() => "");
     if (contents.includes(expected)) {
@@ -246,6 +247,7 @@ async function waitForLogEntry(path: string, expected: string) {
     }
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
+  /* oxlint-enable eslint/no-await-in-loop */
 
   throw new Error(`Timed out waiting for ${expected}`);
 }

--- a/tools/oxlint/next/helpers/next-app-router.ts
+++ b/tools/oxlint/next/helpers/next-app-router.ts
@@ -101,6 +101,7 @@ export const findAppDirectory = (filename: string): string | undefined => {
     if (path.basename(directory) === "app") return directory;
     directory = path.dirname(directory);
   }
+  return undefined;
 };
 
 export const getAppRoute = (filename: string, appDirectory: string) => {
@@ -132,6 +133,7 @@ export const resolveLocalImport = (
   if (source.startsWith(".")) {
     return normalizePath(path.resolve(path.dirname(filename), source));
   }
+  return undefined;
 };
 
 const resolveImportFile = (target: string): string | undefined => {
@@ -259,7 +261,7 @@ export const getCommonDirectory = (
   const [first, ...rest] = directories.map((directory) =>
     normalizePath(directory).split(path.sep)
   );
-  if (!first) return;
+  if (!first) return undefined;
 
   let length = first.length;
   for (const segments of rest) {

--- a/tools/oxlint/next/rules/require-generated-route-props.ts
+++ b/tools/oxlint/next/rules/require-generated-route-props.ts
@@ -60,13 +60,14 @@ const getFunction = (
     case "FunctionExpression":
       return expression;
   }
+  return undefined;
 };
 
 const getIdentifierName = (node: ESTree.Node | null | undefined) =>
   node?.type === "Identifier" ? node.name : undefined;
 
 const getRouteLiteral = (node: ESTree.TSType | undefined) => {
-  if (node?.type !== "TSLiteralType") return;
+  if (node?.type !== "TSLiteralType") return undefined;
   return isStringLiteral(node.literal) ? node.literal.value : undefined;
 };
 
@@ -214,6 +215,7 @@ export const requireGeneratedRoutePropsRule = defineRule({
         kind = match[1] ?? "";
         route = getAppRoute(filename, appDirectory);
         reportedParameters = new Set();
+        return undefined;
       },
       Program(program) {
         const functions = getDeclaredFunctions(program.body);

--- a/tools/oxlint/next/tests/oxlint-next-plugin.test.ts
+++ b/tools/oxlint/next/tests/oxlint-next-plugin.test.ts
@@ -13,7 +13,7 @@ import { requirePageRouteGroupRule } from "@/tools/oxlint/next/rules/require-pag
 const tester = new RuleTester();
 
 test("exports the repository-owned Next architecture rules", () => {
-  assert.deepEqual(Object.keys(plugin.rules).sort(), [
+  assert.deepEqual(Object.keys(plugin.rules).toSorted(), [
     "no-route-private-imports",
     "prefer-nearest-route-private-owner",
     "require-generated-route-props",


### PR DESCRIPTION
## Summary
- enable `typescript/no-deprecated` and fail on stale lint suppressions
- remove the blanket JavaScript and application/AI Elements lint exemptions
- enable unassigned-import, await-in-loop, shadowing, map-spread, array-index-key, consistent-return, function-scoping, and immutable-sort checks
- fix the resulting type-safety, async, accessibility, React, Tailwind, and control-flow violations
- convert the development supervisor to TypeScript so it receives the full type-aware lint policy
- retain only narrow, documented exceptions for sequential loops, runtime images, generated shadcn code, and package-provided AI Elements Tailwind utilities

## Verification
- `pnpm check` (0 lint warnings/errors; 214 tests passed; typecheck, formatting, Knip, and boundaries passed)
- `pnpm build` (with documented local database URL and auth origin placeholders)