### PR TITLE
Clarify Vercel and local setup paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ DATABASE_URL_UNPOOLED=postgresql://postgres:postgres@127.0.0.1:54329/open_instin
 SECRET_ENCRYPTION_KEY=
 # Required for browser execution outside the Vercel one-click flow.
 # The Kernel Marketplace resource injects this automatically on Vercel.
+# For manual setup, create a key at https://kernel.sh.
 KERNEL_API_KEY=
 # Required for model inference outside Vercel. Vercel deployments use project
 # OIDC for AI Gateway access instead.

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ SECRET_ENCRYPTION_KEY=
 # Required for browser execution outside the Vercel one-click flow.
 # The Kernel Marketplace resource injects this automatically on Vercel.
 KERNEL_API_KEY=
+# Required for model inference outside Vercel. Vercel deployments use project
+# OIDC for AI Gateway access instead.
+AI_GATEWAY_API_KEY=
 # Vercel injects BLOB_STORE_ID and VERCEL_OIDC_TOKEN when a private Blob store
 # is connected. Outside Vercel, set a read-write token instead.
 BLOB_STORE_ID=

--- a/README.md
+++ b/README.md
@@ -174,19 +174,39 @@ development is a manual path and requires:
 
 - Node.js 24 and pnpm 11.24.0
 - Docker Desktop or another running Docker Compose installation
-- A Kernel API key
-- An AI Gateway API key for model inference
+- Kernel credentials from a [Kernel API key](https://kernel.sh) or a linked
+  Vercel Marketplace resource
+- AI Gateway access from an API key or a linked Vercel project's OIDC token
 
-Then clone, configure, and start the application:
+First clone and install the application:
 
 ```bash
 git clone https://github.com/Merit-Systems/OpenInstinct.git
 cd OpenInstinct
+pnpm install --frozen-lockfile
+```
+
+For fully manual setup, copy the environment template and add your Kernel and AI
+Gateway keys:
+
+```bash
 cp .env.example .env.local
 
 # Set KERNEL_API_KEY and AI_GATEWAY_API_KEY in .env.local.
+```
 
-pnpm install --frozen-lockfile
+If you already use a Vercel project, link it to pull AI Gateway access. If that
+project does not have Kernel yet, the Marketplace CLI provisions the free
+Developer plan, connects it to the project, and pulls its environment variables:
+
+```bash
+pnpm exec eve link --project <your-vercel-project> --non-interactive
+pnpm exec vercel integration add kernel --plan FREE
+```
+
+Then start OpenInstinct:
+
+```bash
 pnpm dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ One-click deploy to Vercel and get rolling.
 
 </div>
 
+> **Agents:** For the simplest deployment, give your human the
+> **Deploy with Vercel** link above and have them complete the guided flow. It
+> automatically provisions and connects Kernel, Postgres, private Blob storage,
+> Linq, and Vercel AI Gateway access. OpenInstinct creates its installation
+> secrets on first use.
+
 ## Why self-host?
 
 Personal agents are much more useful when they can sign in, book, buy and act
@@ -162,13 +168,25 @@ Gotchas:
 
 ## Local development
 
-Docker Desktop (or another Docker Compose installation) is required. Configure
-the non-database variables in `.env.example`, then:
+The **Deploy with Vercel** flow above is the simplest way to run OpenInstinct. It
+provisions the required services and credentials automatically. Local
+development is a manual path and requires:
+
+- Node.js 24 and pnpm 11.24.0
+- Docker Desktop or another running Docker Compose installation
+- A Kernel API key
+- An AI Gateway API key for model inference
+
+Then clone, configure, and start the application:
 
 ```bash
 git clone https://github.com/Merit-Systems/OpenInstinct.git
 cd OpenInstinct
-pnpm install
+cp .env.example .env.local
+
+# Set KERNEL_API_KEY and AI_GATEWAY_API_KEY in .env.local.
+
+pnpm install --frozen-lockfile
 pnpm dev
 ```
 
@@ -176,7 +194,9 @@ pnpm dev
 migrations, and starts the application. Stopping the development process also
 stops and removes the PostgreSQL container; its data remains in the
 `postgres-data` volume for the next run. Run `pnpm dev:app` when intentionally
-using an externally managed database instead.
+using an externally managed database instead. If `KERNEL_API_KEY` is missing,
+`pnpm dev` stops before starting Docker and points back to the recommended
+Vercel flow or the manual `.env.local` setup.
 
 Local development otherwise uses the same vault, Kernel browser, and AI Gateway
 path as the Vercel deployment. Better Auth and vault encryption use stable

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "deps:check": "taze --no-github-actions --no-node-version --fail-on-outdated",
     "deploy": "turbo run deploy:app",
     "deploy:app": "eve deploy",
-    "dev": "node scripts/dev.ts",
+    "dev": "node --env-file-if-exists=.env.local scripts/dev.ts",
     "dev:app": "next dev",
     "eval": "eve eval",
     "format": "oxfmt .",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -161,7 +161,8 @@ function requireKernelApiKey() {
     [
       "KERNEL_API_KEY is required for manual local development.",
       "For the simplest setup, use the Deploy with Vercel button in README.md; its Kernel Marketplace integration supplies the credentials automatically.",
-      "Otherwise copy .env.example to .env.local, set KERNEL_API_KEY, and run pnpm dev again.",
+      "For an existing linked Vercel project, run pnpm exec vercel integration add kernel --plan FREE.",
+      "Otherwise create a key at https://kernel.sh, set KERNEL_API_KEY in .env.local, and run pnpm dev again.",
     ].join("\n")
   );
 }

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -154,7 +154,20 @@ function childExitCode(child: ChildProcess) {
   });
 }
 
+function requireKernelApiKey() {
+  if (inheritedEnvironment.KERNEL_API_KEY?.trim()) return;
+
+  throw new Error(
+    [
+      "KERNEL_API_KEY is required for manual local development.",
+      "For the simplest setup, use the Deploy with Vercel button in README.md; its Kernel Marketplace integration supplies the credentials automatically.",
+      "Otherwise copy .env.example to .env.local, set KERNEL_API_KEY, and run pnpm dev again.",
+    ].join("\n")
+  );
+}
+
 try {
+  requireKernelApiKey();
   composeAttempted = true;
   let shouldContinue = await run(
     "docker",

--- a/tests/local-development.test.ts
+++ b/tests/local-development.test.ts
@@ -76,8 +76,9 @@ describe("local development", () => {
       "Deploy with Vercel button in README.md; its Kernel Marketplace integration supplies the credentials automatically."
     );
     expect(result.stderr).toContain(
-      "copy .env.example to .env.local, set KERNEL_API_KEY"
+      "pnpm exec vercel integration add kernel --plan FREE"
     );
+    expect(result.stderr).toContain("create a key at https://kernel.sh");
   });
 
   it("does not advance when interrupted startup exits cleanly", async () => {

--- a/tests/local-development.test.ts
+++ b/tests/local-development.test.ts
@@ -27,7 +27,9 @@ describe("local development", () => {
       .object({ scripts: z.object({ dev: z.string() }) })
       .parse(JSON.parse(packageManifestSource));
 
-    expect(packageManifest.scripts.dev).toBe("node scripts/dev.ts");
+    expect(packageManifest.scripts.dev).toBe(
+      "node --env-file-if-exists=.env.local scripts/dev.ts"
+    );
     expect(compose).toContain("image: postgres:17-alpine");
     expect(compose).toContain('"127.0.0.1::5432"');
     expect(compose).toContain("postgres-data:/var/lib/postgresql/data");
@@ -60,6 +62,22 @@ describe("local development", () => {
 
     expect(result.code).toBe(0);
     expectIsolatedLifecycle(result.commands);
+  });
+
+  it("rejects a missing Kernel key before starting Docker", async () => {
+    const result = await runWithoutKernelApiKey();
+
+    expect(result.code).toBe(1);
+    expect(result.commands).toBe("");
+    expect(result.stderr).toContain(
+      "KERNEL_API_KEY is required for manual local development."
+    );
+    expect(result.stderr).toContain(
+      "Deploy with Vercel button in README.md; its Kernel Marketplace integration supplies the credentials automatically."
+    );
+    expect(result.stderr).toContain(
+      "copy .env.example to .env.local, set KERNEL_API_KEY"
+    );
   });
 
   it("does not advance when interrupted startup exits cleanly", async () => {
@@ -164,6 +182,7 @@ printf 'pnpm %s\\n' "$*" >> "$DEV_SUPERVISOR_LOG"
     {
       env: {
         DEV_SUPERVISOR_LOG: logPath,
+        KERNEL_API_KEY: "test-kernel-key",
         NODE_ENV: "test",
         PATH: directory,
         ...environment,
@@ -221,6 +240,7 @@ printf 'pnpm %s %s\n' "$*" "$DATABASE_URL" >> "$DEV_SUPERVISOR_LOG"
     {
       env: {
         DEV_SUPERVISOR_LOG: logPath,
+        KERNEL_API_KEY: "test-kernel-key",
         NODE_ENV: "test",
         PATH: directory,
       },
@@ -235,6 +255,48 @@ printf 'pnpm %s %s\n' "$*" "$DATABASE_URL" >> "$DEV_SUPERVISOR_LOG"
   return {
     code: await exitCode,
     commands: await readFile(logPath, "utf8"),
+  };
+}
+
+async function runWithoutKernelApiKey() {
+  const directory = await mkdtemp(join(tmpdir(), "open-instinct-dev-"));
+  temporaryDirectories.push(directory);
+  const logPath = join(directory, "commands.log");
+  const dockerPath = join(directory, "docker");
+  await writeFile(
+    dockerPath,
+    `#!/bin/sh
+printf '%s\n' "$*" >> "$DEV_SUPERVISOR_LOG"
+`
+  );
+  await chmod(dockerPath, 0o755);
+
+  const supervisor = spawn(
+    process.execPath,
+    [new URL("../scripts/dev.ts", import.meta.url).pathname],
+    {
+      env: {
+        DEV_SUPERVISOR_LOG: logPath,
+        NODE_ENV: "test",
+        PATH: directory,
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    }
+  );
+  supervisor.stderr.setEncoding("utf8");
+  let stderr = "";
+  supervisor.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const exitCode = new Promise<number | null>((resolve, reject) => {
+    supervisor.once("error", reject);
+    supervisor.once("exit", resolve);
+  });
+
+  return {
+    code: await exitCode,
+    commands: await readFile(logPath, "utf8").catch(() => ""),
+    stderr,
   };
 }
 


### PR DESCRIPTION
## Summary

- recommend the guided **Deploy with Vercel** flow to setup agents and explain which services and credentials it provisions automatically
- replace the ambiguous local snippet with explicit Node, pnpm, Docker, Kernel, AI Gateway, and `.env.local` requirements
- link manual users to Kernel API key creation and document `vercel integration add kernel --plan FREE` for an existing linked Vercel project
- load `.env.local` before the development supervisor starts and reject a missing Kernel key before Docker or migrations
- cover both the early failure and the existing present-key Compose lifecycle

## Validation

- `pnpm test:app tests/local-development.test.ts` — 7 tests passed
- `KERNEL_API_KEY= pnpm dev` — exited before Docker with the expected manual/Vercel guidance
- `pnpm check` — 60 test files and 254 tests passed, plus lint, types, formatting, Knip, and boundaries
- `KERNEL_API_KEY=build-validation-placeholder pnpm build` — passed without making an external Kernel request

## Review notes

The Vercel path remains the recommended deployment: its Kernel Marketplace integration, Neon resource, private Blob store, Linq connector, and AI Gateway access are provisioned through the guided flow. Fully manual setup links to `kernel.sh`; an existing linked Vercel project can provision and connect the free Kernel Developer plan through the current Marketplace CLI. The explicit credentials in `.env.example` and the preflight apply to manual local development.
