### PR TITLE
Fix Vercel Blob profile memory setup

### DIFF
--- a/agent/lib/profile-memory.ts
+++ b/agent/lib/profile-memory.ts
@@ -7,15 +7,25 @@ import { scopeFromPrincipal, type AccessScope } from "@/lib/access-scope";
 export function resolveProfileMemoryBackend(
   environment: Pick<
     typeof env,
-    "BLOB_READ_WRITE_TOKEN" | "NODE_ENV" | "VERCEL_ENV"
+    "BLOB_READ_WRITE_TOKEN" | "BLOB_STORE_ID" | "NODE_ENV" | "VERCEL_ENV"
   >
 ) {
-  return environment.NODE_ENV === "production" &&
-    environment.VERCEL_ENV === undefined &&
+  if (environment.NODE_ENV !== "production") {
+    return { kind: "automatic" as const };
+  }
+
+  if (environment.BLOB_STORE_ID) {
+    return {
+      kind: "vercel-blob" as const,
+      options: { storeId: environment.BLOB_STORE_ID },
+    };
+  }
+
+  return environment.VERCEL_ENV === undefined &&
     environment.BLOB_READ_WRITE_TOKEN
     ? {
         kind: "vercel-blob" as const,
-        token: environment.BLOB_READ_WRITE_TOKEN,
+        options: { token: environment.BLOB_READ_WRITE_TOKEN },
       }
     : { kind: "automatic" as const };
 }

--- a/agent/lib/tests/profile-memory.test.ts
+++ b/agent/lib/tests/profile-memory.test.ts
@@ -7,17 +7,33 @@ import {
 } from "@/agent/lib/profile-memory";
 
 describe("profile memory", () => {
-  it("uses an explicit Blob backend only for token-backed production outside Vercel", () => {
+  it("uses an explicit Blob backend for an attached store in production", () => {
+    expect(
+      resolveProfileMemoryBackend({
+        BLOB_READ_WRITE_TOKEN: undefined,
+        BLOB_STORE_ID: "store-id",
+        NODE_ENV: "production",
+        VERCEL_ENV: "production",
+      })
+    ).toEqual({
+      kind: "vercel-blob",
+      options: { storeId: "store-id" },
+    });
     expect(
       resolveProfileMemoryBackend({
         BLOB_READ_WRITE_TOKEN: "blob-token",
+        BLOB_STORE_ID: undefined,
         NODE_ENV: "production",
         VERCEL_ENV: undefined,
       })
-    ).toEqual({ kind: "vercel-blob", token: "blob-token" });
+    ).toEqual({
+      kind: "vercel-blob",
+      options: { token: "blob-token" },
+    });
     expect(
       resolveProfileMemoryBackend({
         BLOB_READ_WRITE_TOKEN: "blob-token",
+        BLOB_STORE_ID: undefined,
         NODE_ENV: "production",
         VERCEL_ENV: "production",
       })
@@ -25,6 +41,7 @@ describe("profile memory", () => {
     expect(
       resolveProfileMemoryBackend({
         BLOB_READ_WRITE_TOKEN: "blob-token",
+        BLOB_STORE_ID: "store-id",
         NODE_ENV: "development",
         VERCEL_ENV: undefined,
       })

--- a/agent/memory/profile.ts
+++ b/agent/memory/profile.ts
@@ -11,7 +11,7 @@ const backend = resolveProfileMemoryBackend(env);
 const provider =
   backend.kind === "vercel-blob"
     ? fileMemory({
-        backend: vercelBlob({ token: backend.token }),
+        backend: vercelBlob(backend.options),
       })
     : fileMemory();
 


### PR DESCRIPTION
## Summary

- use the attached `BLOB_STORE_ID` to select Eve's explicit Vercel Blob memory backend in production
- let `@vercel/blob` resolve Vercel's request-scoped OIDC credential without requiring a manually managed `BLOB_READ_WRITE_TOKEN`
- preserve automatic local development memory and explicit token-backed memory outside Vercel

## Review notes

The deploy-button configuration is unchanged. Please focus on the environment branches in `resolveProfileMemoryBackend` and their direct handoff to `vercelBlob`.

## Validation

- `pnpm vitest run agent/lib/tests/profile-memory.test.ts` — 4 tests passed
- `pnpm check` — 6 tasks, 60 test files, 254 tests passed
- `pnpm build`
- `pnpm build:eve`
- `git diff --check origin/main...HEAD`

Closes #99
