### PR TITLE
Show browser trace intents as the primary column

### DIFF
--- a/db/services/browser-traces.ts
+++ b/db/services/browser-traces.ts
@@ -1,6 +1,7 @@
 import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { AccessScope } from "@/lib/access-scope";
+import { getWorkerIntent } from "@/lib/worker-events";
 import {
   browserTraceDomains,
   browserTraceEvents,
@@ -87,9 +88,10 @@ export async function listBrowserTraces(scope: AccessScope, cursor?: string) {
   return {
     nextCursor:
       rows.length > page.length && last ? encodeTraceCursor(last) : null,
-    traces: page.map((row) =>
+    traces: page.map(({ task, ...row }) =>
       Object.assign({}, row, {
         domains: domainsByTrace.get(row.sessionId) ?? [],
+        intent: getWorkerIntent(task) ?? "Browser task",
       })
     ),
   };

--- a/db/tests/services.test.ts
+++ b/db/tests/services.test.ts
@@ -228,10 +228,16 @@ describe("database services", () => {
     );
 
     const { serializeLoginVaultPayload } = await import("@/lib/vault");
+    const delegatedTask = `You are the subagent "worker".
+
+Caller message:
+Task: Order the blue mug
+
+Buy the blue mug on example.com.`;
     await browserTraces.beginBrowserTrace(alice, {
       sessionId: "worker-alice",
       startedAt: "2026-08-31T00:00:00.000Z",
-      task: "Order the blue mug",
+      task: delegatedTask,
     });
     await browserTraces.recordBrowserTraceDomains(alice, "worker-alice", [
       "shop.example.com",
@@ -253,7 +259,7 @@ describe("database services", () => {
       durationMs: 12_500,
       resultMessage: "Ordered.",
       status: "success",
-      task: "Order the blue mug",
+      task: delegatedTask,
     });
     const traceDomains = await pgliteDatabase
       .select()
@@ -298,9 +304,9 @@ describe("database services", () => {
     expect(tracePage.traces[0]).toMatchObject({
       domains: ["shop.example.com"],
       durationMs: 12_500,
+      intent: "Order the blue mug",
       sessionId: "worker-alice",
       status: "success",
-      task: "Order the blue mug",
     });
     expect((await browserTraces.listBrowserTraces(bob)).traces).toEqual([]);
 

--- a/src/app/(authenticated)/tasks/(overview)/_components/trace-history.tsx
+++ b/src/app/(authenticated)/tasks/(overview)/_components/trace-history.tsx
@@ -120,11 +120,11 @@ export function TraceHistory({
       <Table className="table-fixed">
         <TableHeader>
           <TableRow>
-            <TableHead className="w-[26%]">Task</TableHead>
+            <TableHead className="w-[31%]">Intent</TableHead>
             <TableHead className="w-[9%]">Status</TableHead>
             <TableHead className="w-[8%]">Duration</TableHead>
             <TableHead className="w-[18%]">Domains</TableHead>
-            <TableHead className="w-[25%]">Result</TableHead>
+            <TableHead className="w-[20%]">Result</TableHead>
             <TableHead className="w-[14%]">Started</TableHead>
           </TableRow>
         </TableHeader>
@@ -142,14 +142,14 @@ export function TraceHistory({
               const status = statusLabel(trace.status);
               return (
                 <TableRow key={trace.sessionId}>
-                  <TableCell className="truncate" title={trace.task}>
+                  <TableCell className="truncate" title={trace.intent}>
                     <Button
                       nativeButton={false}
                       render={<Link href={`/tasks/${trace.sessionId}`} />}
                       size="none"
                       variant="link"
                     >
-                      {trace.task}
+                      {trace.intent}
                     </Button>
                   </TableCell>
                   <TableCell>

--- a/src/app/(authenticated)/tasks/(overview)/page.tsx
+++ b/src/app/(authenticated)/tasks/(overview)/page.tsx
@@ -21,8 +21,8 @@ export default async function TasksPage() {
         <div className="max-w-2xl">
           <h1 className="type-page-title">Browser traces</h1>
           <p className="type-supporting-body mt-2 text-muted-foreground">
-            Every browser assignment the agent has run: the task, its verified
-            outcome, how long it took, and the domains it touched.
+            Every browser assignment the agent has run: its intent, verified
+            outcome, duration, and the domains it touched.
           </p>
         </div>
         <Button

--- a/src/app/_lib/subagent-sessions.test.ts
+++ b/src/app/_lib/subagent-sessions.test.ts
@@ -198,7 +198,15 @@ describe("getSubagentTask", () => {
       {
         type: "message.received",
         data: {
-          message: "Task: First task\n\nFull assignment",
+          message: `You are the subagent "worker".
+Description: Execute browser tasks.
+
+The caller delegated the following task to you.
+
+Caller message:
+Task: First task
+
+Full assignment`,
           sequence: 0,
           turnId: "turn_1",
         },

--- a/src/app/_lib/subagent-sessions.ts
+++ b/src/app/_lib/subagent-sessions.ts
@@ -3,6 +3,7 @@ import type {
   SubagentCalledStreamEvent,
   SubagentCompletedStreamEvent,
 } from "eve/client";
+import { getWorkerIntent } from "@/lib/worker-events";
 
 export type SubagentSession = SubagentCalledStreamEvent["data"] & {
   readonly completion?: SubagentCompletedStreamEvent["data"];
@@ -87,9 +88,5 @@ export function getSubagentStatus(
 export function getSubagentTask(events: readonly MessageStreamEvent[]) {
   const message = events.find((event) => event.type === "message.received")
     ?.data.message;
-  return message
-    ?.split(/\r?\n/u)
-    .map((line) => line.trim())
-    .find(Boolean)
-    ?.replace(/^Task:\s*/iu, "");
+  return message ? getWorkerIntent(message) : undefined;
 }

--- a/src/lib/worker-events.ts
+++ b/src/lib/worker-events.ts
@@ -2,7 +2,9 @@ import type { MessageStreamEvent } from "eve/client";
 import { z } from "zod";
 import { taskCompletionOutputSchema } from "@/lib/worker-completion";
 
+const workerIntentPrefix = "Task:";
 const workerTaskNotificationPrefix = /^Background task (\S+) \(worker\) /u;
+export const workerIntentTemplate = `${workerIntentPrefix} <a concise summary of at most 10 words>`;
 const terminalTaskControlSchema = z.object({
   tasks: z.array(
     z.object({
@@ -17,6 +19,16 @@ interface BackgroundWorkerTaskState {
   status?: "cancelled" | "completed" | "failed";
   taskId: string;
   terminalAt?: string;
+}
+
+export function getWorkerIntent(message: string) {
+  for (const line of message.split("\n")) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine.startsWith(workerIntentPrefix)) continue;
+    const intent = trimmedLine.slice(workerIntentPrefix.length).trim();
+    return intent.length ? intent : undefined;
+  }
+  return undefined;
 }
 
 export function measureWorkerTask(

--- a/tests/worker-input-bubbling.test.ts
+++ b/tests/worker-input-bubbling.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { workerIntentTemplate } from "@/lib/worker-events";
 
 describe("worker input bubbling", () => {
   it("keeps native questions disabled", () => {
@@ -24,6 +25,9 @@ describe("worker input bubbling", () => {
     );
     expect(instructions).toContain(
       "confirm the worker explicitly reported checking compatible vault items"
+    );
+    expect(instructions).toContain(
+      `worker \`message\` with \`${workerIntentTemplate}\``
     );
     expect(workerInstructions).toContain(
       "Before returning `Needs user input:` or `Needs vault setup:`"


### PR DESCRIPTION
## Summary
- replace the repetitive worker prompt with the concise intent available at run start
- make Intent the primary linked column while retaining Result for completed traces
- share the existing `Task: <intent>` worker-message contract with chat activity and tether it to the authored instruction template with a test
- extract the intent with exact prefix checks and plain newline splitting; no regex in the intent path

## Verification
- `pnpm check`
- `DATABASE_URL=... KERNEL_API_KEY=... BETTER_AUTH_URL=... pnpm build`