### PR TITLE
Fix scheduled run delivery lifecycle

### DIFF
--- a/agent/agent.ts
+++ b/agent/agent.ts
@@ -1,4 +1,6 @@
 import { defineAgent, defineDynamic } from "eve";
+import { scheduledRunIdentity } from "@/agent/lib/schedules/identity";
+import { isScheduledAgentRunLeaseActive } from "@/db/services/scheduled-agent-run-leases";
 import { getGatewayModel } from "@/db/services/settings";
 import { scopeFromPrincipal } from "@/lib/access-scope";
 
@@ -9,6 +11,16 @@ export default defineAgent({
   model: defineDynamic({
     events: {
       "step.started": async (_event, ctx) => {
+        const scheduledRun = scheduledRunIdentity(ctx.session.auth);
+        if (
+          scheduledRun &&
+          !(await isScheduledAgentRunLeaseActive(
+            scheduledRun.runId,
+            scheduledRun.leaseToken
+          ))
+        ) {
+          throw new Error("The scheduled run lease is no longer active.");
+        }
         const caller = ctx.session.auth.current ?? ctx.session.auth.initiator;
         if (!caller) throw new Error("An authenticated user is required.");
         return getGatewayModel(scopeFromPrincipal(caller));

--- a/agent/channels/scheduled-run.ts
+++ b/agent/channels/scheduled-run.ts
@@ -7,13 +7,10 @@ import { dispatchScheduledReport } from "@/agent/lib/schedules/report";
 import {
   claimScheduledAgentRunInput,
   finishScheduledAgentRunInput,
-  getClaimedScheduledAgentRun,
   restoreScheduledAgentRunInput,
-  setScheduledRunSession,
 } from "@/db/services/scheduled-agent-jobs";
 
-const startSchema = z.strictObject({
-  leaseToken: z.uuid(),
+const scheduledRunTargetSchema = z.strictObject({
   restart: z.boolean().optional(),
   runId: z.uuid(),
 });
@@ -26,30 +23,21 @@ const respondSchema = z.strictObject({
 const internalRouteAuth = [vercelOidc(), localDev()];
 
 export default defineChannel({
-  routes: [
-    POST("/internal/scheduled-run/start", async (request, { from }) => {
-      const auth = await routeAuth(request, internalRouteAuth);
-      if (auth instanceof Response) return auth;
-      const input = startSchema.parse(await request.json());
-      const claimed = await getClaimedScheduledAgentRun(
-        input.runId,
-        input.leaseToken
-      );
-      if (!claimed) return new Response(null, { status: 409 });
-      const source = from(`scheduled-run:${input.runId}`);
-      if (input.restart) {
-        await source.reset({
-          reason: "Scheduled worker exceeded its runtime.",
-        });
-      }
-      const session = await source.send(scheduledRunPrompt(claimed), {
-        auth: scheduledWorkerAuth(claimed),
-        outputSchema: scheduledRunOutcomeJsonSchema,
-        title: `Scheduled run ${input.runId}`,
+  async receive(input, { from }) {
+    const target = scheduledRunTargetSchema.parse(input.target);
+    const source = from(`scheduled-run:${target.runId}`);
+    if (target.restart) {
+      await source.reset({
+        reason: "Scheduled worker exceeded its runtime.",
       });
-      await setScheduledRunSession(input.runId, input.leaseToken, session.id);
-      return Response.json({ sessionId: session.id });
-    }),
+    }
+    return source.send(input.message, {
+      auth: input.auth,
+      outputSchema: scheduledRunOutcomeJsonSchema,
+      title: `Scheduled run ${target.runId}`,
+    });
+  },
+  routes: [
     POST(
       "/internal/scheduled-run/report",
       async (request, { attachSession, to, waitUntil }) => {
@@ -131,35 +119,3 @@ export default defineChannel({
     ),
   ],
 });
-
-function scheduledRunPrompt(
-  claim: NonNullable<Awaited<ReturnType<typeof getClaimedScheduledAgentRun>>>
-) {
-  return [
-    "Complete this user-owned scheduled task in an isolated background session.",
-    `Scheduled for: ${claim.run.scheduledFor.toISOString()}`,
-    `Task: ${claim.job.prompt}`,
-    "Return exactly one structured final outcome.",
-  ].join("\n\n");
-}
-
-function scheduledWorkerAuth(
-  claim: NonNullable<Awaited<ReturnType<typeof getClaimedScheduledAgentRun>>>
-) {
-  const leaseToken = claim.run.leaseToken;
-  if (!leaseToken) throw new Error("A scheduled run claim requires a lease.");
-  return {
-    attributes: {
-      conversationChannel: claim.job.conversationChannel,
-      conversationId: claim.job.conversationId,
-      scheduleId: claim.job.id,
-      scheduledRunLeaseToken: leaseToken,
-      scheduledRunId: claim.run.id,
-      workspaceId: claim.job.workspaceId,
-    },
-    authenticator: "scheduled-worker",
-    issuer: "open-instinct",
-    principalId: claim.job.createdByUserId,
-    principalType: "user" as const,
-  };
-}

--- a/agent/hooks/scheduled-run-completion.ts
+++ b/agent/hooks/scheduled-run-completion.ts
@@ -1,39 +1,42 @@
 import { defineHook } from "eve/hooks";
-import type { HookContext } from "eve/hooks";
-import { z } from "zod";
+import { scheduledRunIdentity } from "@/agent/lib/schedules/identity";
 import { scheduledRunOutcomeSchema } from "@/agent/lib/schedules/outcome";
 import { postScheduledReport } from "@/agent/lib/schedules/request";
 import {
   completeScheduledAgentRun,
+  markScheduledAgentRunStarted,
   releaseScheduledAgentRun,
   waitForScheduledAgentRunInput,
 } from "@/db/services/scheduled-agent-jobs";
 
-const scheduledWorker = "scheduled-worker";
-const scheduledRunIdentitySchema = z.object({
-  scheduledRunId: z.uuid(),
-  scheduledRunLeaseToken: z.uuid(),
-});
-
-function scheduledRunIdentity(ctx: HookContext) {
-  const caller =
-    ctx.session.auth.initiator?.authenticator === scheduledWorker
-      ? ctx.session.auth.initiator
-      : ctx.session.auth.current;
-  if (caller?.authenticator !== scheduledWorker) return undefined;
-  const identity = scheduledRunIdentitySchema.safeParse(caller.attributes);
-  return identity.success
-    ? {
-        leaseToken: identity.data.scheduledRunLeaseToken,
-        runId: identity.data.scheduledRunId,
-      }
-    : undefined;
-}
+const workerRuntimeLimitMs = 6 * 60 * 60_000;
 
 export default defineHook({
   events: {
+    async "turn.started"(event, ctx) {
+      const identity = scheduledRunIdentity(ctx.session.auth);
+      if (!identity) return;
+      const started = await markScheduledAgentRunStarted(
+        identity.runId,
+        identity.leaseToken,
+        ctx.session.id,
+        workerRuntimeLimitMs,
+        new Date(event.meta.at)
+      );
+      if (!started) {
+        console.warn("[scheduled-run] worker started with a stale lease", {
+          runId: identity.runId,
+          sessionId: ctx.session.id,
+        });
+        return;
+      }
+      console.info("[scheduled-run] worker turn started", {
+        runId: identity.runId,
+        sessionId: ctx.session.id,
+      });
+    },
     async "input.requested"(event, ctx) {
-      const identity = scheduledRunIdentity(ctx);
+      const identity = scheduledRunIdentity(ctx.session.auth);
       if (!identity) return;
       const waiting = await waitForScheduledAgentRunInput(
         identity.runId,
@@ -41,9 +44,24 @@ export default defineHook({
         event.data.requests,
         new Date(event.meta.at)
       );
-      if (waiting?.reportStatus !== "pending") return;
+      if (waiting?.reportStatus !== "pending") {
+        console.warn("[scheduled-run] input request missed its active lease", {
+          runId: identity.runId,
+          sessionId: ctx.session.id,
+        });
+        return;
+      }
+      console.info("[scheduled-run] worker waiting for input", {
+        requestCount: event.data.requests.length,
+        runId: waiting.id,
+        sessionId: ctx.session.id,
+      });
       try {
         await postScheduledReport(waiting.id);
+        console.info("[scheduled-run] input report callback accepted", {
+          runId: waiting.id,
+          sessionId: ctx.session.id,
+        });
       } catch (error) {
         console.warn("[scheduled-run] input report callback failed", {
           cause: error,
@@ -52,19 +70,42 @@ export default defineHook({
       }
     },
     async "result.completed"(event, ctx) {
-      const identity = scheduledRunIdentity(ctx);
+      const identity = scheduledRunIdentity(ctx.session.auth);
       if (!identity) return;
       const outcome = scheduledRunOutcomeSchema.safeParse(event.data.result);
-      if (!outcome.success) return;
+      if (!outcome.success) {
+        console.warn("[scheduled-run] worker returned an invalid outcome", {
+          runId: identity.runId,
+          sessionId: ctx.session.id,
+        });
+        return;
+      }
       const completed = await completeScheduledAgentRun(
         identity.runId,
         identity.leaseToken,
         outcome.data,
         new Date(event.meta.at)
       );
-      if (completed?.reportStatus !== "pending") return;
+      if (!completed) {
+        console.warn("[scheduled-run] worker completion missed its lease", {
+          runId: identity.runId,
+          sessionId: ctx.session.id,
+        });
+        return;
+      }
+      console.info("[scheduled-run] worker completed", {
+        outcomeKind: outcome.data.kind,
+        reportStatus: completed.reportStatus,
+        runId: completed.id,
+        sessionId: ctx.session.id,
+      });
+      if (completed.reportStatus !== "pending") return;
       try {
         await postScheduledReport(completed.id);
+        console.info("[scheduled-run] completion report callback accepted", {
+          runId: completed.id,
+          sessionId: ctx.session.id,
+        });
       } catch (error) {
         console.warn("[scheduled-run] immediate report callback failed", {
           cause: error,
@@ -73,34 +114,73 @@ export default defineHook({
       }
     },
     async "turn.failed"(event, ctx) {
-      const identity = scheduledRunIdentity(ctx);
+      const identity = scheduledRunIdentity(ctx.session.auth);
       if (!identity) return;
-      await releaseScheduledAgentRun(
+      const status = await releaseScheduledAgentRun(
         identity.runId,
         identity.leaseToken,
         event.data.message,
         new Date(event.meta.at)
       );
+      console.warn("[scheduled-run] worker turn failed", {
+        nextStatus: status,
+        runId: identity.runId,
+        sessionId: ctx.session.id,
+      });
+      await reportDeadLetter(status, identity.runId, ctx.session.id);
     },
     async "turn.cancelled"(event, ctx) {
-      const identity = scheduledRunIdentity(ctx);
+      const identity = scheduledRunIdentity(ctx.session.auth);
       if (!identity) return;
-      await releaseScheduledAgentRun(
+      const status = await releaseScheduledAgentRun(
         identity.runId,
         identity.leaseToken,
         "Scheduled worker was cancelled.",
         new Date(event.meta.at)
       );
+      console.warn("[scheduled-run] worker turn cancelled", {
+        nextStatus: status,
+        runId: identity.runId,
+        sessionId: ctx.session.id,
+      });
+      await reportDeadLetter(status, identity.runId, ctx.session.id);
     },
     async "session.failed"(event, ctx) {
-      const identity = scheduledRunIdentity(ctx);
+      const identity = scheduledRunIdentity(ctx.session.auth);
       if (!identity) return;
-      await releaseScheduledAgentRun(
+      const status = await releaseScheduledAgentRun(
         identity.runId,
         identity.leaseToken,
         event.data.message,
         new Date(event.meta.at)
       );
+      console.warn("[scheduled-run] worker session failed", {
+        nextStatus: status,
+        runId: identity.runId,
+        sessionId: ctx.session.id,
+      });
+      await reportDeadLetter(status, identity.runId, ctx.session.id);
     },
   },
 });
+
+async function reportDeadLetter(
+  status: Awaited<ReturnType<typeof releaseScheduledAgentRun>>,
+  runId: string,
+  sessionId: string
+) {
+  if (status !== "dead_letter") return;
+  try {
+    await postScheduledReport(runId);
+    console.info("[scheduled-run] dead-letter report callback accepted", {
+      runId,
+      sessionId,
+    });
+  } catch (error) {
+    console.warn("[scheduled-run] dead-letter report callback failed", {
+      cause: error,
+      runId,
+      sessionId,
+    });
+  }
+}

--- a/agent/lib/schedules/identity.ts
+++ b/agent/lib/schedules/identity.ts
@@ -7,6 +7,27 @@ const scheduledReportIdentitySchema = z.object({
   scheduledRunId: z.uuid(),
   scheduledRunSessionId: z.string().min(1).optional(),
 });
+const scheduledRunIdentitySchema = z.object({
+  scheduledRunId: z.uuid(),
+  scheduledRunLeaseToken: z.uuid(),
+});
+
+export function scheduledRunIdentity(auth: SessionContext["session"]["auth"]) {
+  const caller =
+    auth.current?.authenticator === "scheduled-worker"
+      ? auth.current
+      : auth.initiator?.authenticator === "scheduled-worker"
+        ? auth.initiator
+        : undefined;
+  if (caller?.authenticator !== "scheduled-worker") return undefined;
+  const identity = scheduledRunIdentitySchema.safeParse(caller.attributes);
+  return identity.success
+    ? {
+        leaseToken: identity.data.scheduledRunLeaseToken,
+        runId: identity.data.scheduledRunId,
+      }
+    : undefined;
+}
 
 export function scheduledReportIdentity(
   auth: SessionContext["session"]["auth"]

--- a/agent/lib/schedules/report-lifecycle.ts
+++ b/agent/lib/schedules/report-lifecycle.ts
@@ -15,7 +15,18 @@ export async function finalizeScheduledReportDelivery(
 ) {
   const report = scheduledReportFromSession(session);
   if (report) {
-    await finalizeScheduledReport(report.runId, report.leaseToken, status);
+    const finalized = await finalizeScheduledReport(
+      report.runId,
+      report.leaseToken,
+      status
+    );
+    if (finalized) {
+      console.info("[scheduled-run] report finalized", {
+        runId: report.runId,
+        sessionId: session.session.id,
+        status,
+      });
+    }
   }
 }
 
@@ -25,6 +36,15 @@ export async function releaseScheduledReportDelivery(
 ) {
   const report = scheduledReportFromSession(session);
   if (report) {
-    await releaseScheduledReport(report.runId, report.leaseToken, errorMessage);
+    const released = await releaseScheduledReport(
+      report.runId,
+      report.leaseToken,
+      errorMessage
+    );
+    console.warn("[scheduled-run] report turn failed", {
+      released,
+      runId: report.runId,
+      sessionId: session.session.id,
+    });
   }
 }

--- a/agent/lib/schedules/report.ts
+++ b/agent/lib/schedules/report.ts
@@ -17,6 +17,12 @@ export async function dispatchScheduledReport(
   const claimed = await claimScheduledReport(runId);
   const leaseToken = claimed?.run.reportLeaseToken;
   if (!claimed || !leaseToken) return;
+  console.info("[scheduled-run] dispatching report", {
+    channel: claimed.job.conversationChannel,
+    reportSequence: claimed.run.reportSequence,
+    runId: claimed.run.id,
+    runStatus: claimed.run.status,
+  });
   const reportAttributes = {
     conversationChannel: claimed.job.conversationChannel,
     conversationId: claimed.job.conversationId,
@@ -45,12 +51,18 @@ export async function dispatchScheduledReport(
   try {
     const prompt = scheduledReportPrompt(claimed);
     if (claimed.job.conversationChannel === "linq") {
-      await delivery
+      const session = await delivery
         .to(linq, {
           adapterName: "linq",
           threadId: claimed.job.conversationId,
         })
         .send(prompt, options);
+      console.info("[scheduled-run] report session accepted", {
+        channel: claimed.job.conversationChannel,
+        reportSequence: claimed.run.reportSequence,
+        runId: claimed.run.id,
+        sessionId: session.id,
+      });
       return;
     }
     const result = await delivery
@@ -59,12 +71,24 @@ export async function dispatchScheduledReport(
     if (result.status === "session_not_active") {
       await finalizeScheduledReport(claimed.run.id, leaseToken, "suppressed");
     }
+    console.info("[scheduled-run] report turn accepted", {
+      channel: claimed.job.conversationChannel,
+      reportSequence: claimed.run.reportSequence,
+      resultStatus: result.status,
+      runId: claimed.run.id,
+    });
   } catch (error) {
-    await releaseScheduledReport(
+    const released = await releaseScheduledReport(
       claimed.run.id,
       leaseToken,
       error instanceof Error ? error.message : String(error)
     );
+    console.warn("[scheduled-run] report dispatch failed", {
+      cause: error,
+      released,
+      reportSequence: claimed.run.reportSequence,
+      runId: claimed.run.id,
+    });
   }
 }
 

--- a/agent/lib/schedules/request.ts
+++ b/agent/lib/schedules/request.ts
@@ -16,11 +16,6 @@ interface ScheduledRunRequestBodies {
     leaseToken: string;
     runId: string;
   };
-  "/internal/scheduled-run/start": {
-    leaseToken: string;
-    restart: boolean;
-    runId: string;
-  };
 }
 
 export async function postScheduledRunRoute<

--- a/agent/lib/schedules/tools.ts
+++ b/agent/lib/schedules/tools.ts
@@ -1,6 +1,9 @@
 import type { ToolContext } from "eve/tools";
 import { z } from "zod";
-import type { listScheduledAgentJobs } from "@/db/services/scheduled-agent-jobs";
+import type {
+  createScheduledAgentJob,
+  listScheduledAgentJobs,
+} from "@/db/services/scheduled-agent-jobs";
 import { scopeFromPrincipal } from "@/lib/access-scope";
 
 export function scheduleOwner(context: ToolContext) {
@@ -22,7 +25,7 @@ export function scheduleOwner(context: ToolContext) {
 }
 
 export function scheduleSummary(
-  job: Awaited<ReturnType<typeof listScheduledAgentJobs>>[number]
+  job: Awaited<ReturnType<typeof createScheduledAgentJob>>
 ) {
   return {
     createdAt: job.createdAt.toISOString(),
@@ -33,5 +36,26 @@ export function scheduleSummary(
     prompt: job.prompt,
     status: job.status,
     timing: job.timing,
+  };
+}
+
+export function scheduleListSummary(
+  job: Awaited<ReturnType<typeof listScheduledAgentJobs>>[number]
+) {
+  const latestRun = job.latestRun;
+  return {
+    ...scheduleSummary(job),
+    latestRun: latestRun
+      ? {
+          completedAt: latestRun.completedAt?.toISOString() ?? null,
+          id: latestRun.id,
+          lastError: latestRun.lastError,
+          reportStatus: latestRun.reportStatus,
+          scheduledFor: latestRun.scheduledFor.toISOString(),
+          sessionId: latestRun.workerSessionId,
+          startedAt: latestRun.startedAt?.toISOString() ?? null,
+          status: latestRun.status,
+        }
+      : null,
   };
 }

--- a/agent/schedules/dynamic.ts
+++ b/agent/schedules/dynamic.ts
@@ -1,65 +1,129 @@
-import { defineSchedule } from "eve/schedules";
-import {
-  postScheduledReport,
-  postScheduledRunRoute,
-} from "@/agent/lib/schedules/request";
+import { defineSchedule, type ScheduleToFn } from "eve/schedules";
+import scheduledRunChannel from "@/agent/channels/scheduled-run";
+import { postScheduledReport } from "@/agent/lib/schedules/request";
 import {
   claimReadyScheduledAgentRuns,
   listRecoverableScheduledReports,
   materializeDueScheduledAgentRuns,
   releaseScheduledAgentRun,
+  setScheduledRunSession,
 } from "@/db/services/scheduled-agent-jobs";
 
-const workerRuntimeLimitMs = 6 * 60 * 60_000;
+const workerStartupLimitMs = 5 * 60_000;
 
 export default defineSchedule({
   cron: "* * * * *",
-  run({ waitUntil }) {
-    waitUntil(dispatchDueWork());
+  run({ to, waitUntil }) {
+    waitUntil(dispatchDueWork(to));
   },
 });
 
-async function dispatchDueWork() {
+async function dispatchDueWork(to: ScheduleToFn) {
   const now = new Date();
-  await materializeDueScheduledAgentRuns({ limit: 25, now });
-  const [runs, reportRunIds] = await Promise.all([
-    claimReadyScheduledAgentRuns({
-      leaseForMs: workerRuntimeLimitMs,
-      limit: 25,
-      now,
-    }),
-    listRecoverableScheduledReports(now, 25),
-  ]);
+  const materializedRunIds = await materializeDueScheduledAgentRuns({
+    limit: 25,
+    now,
+  });
+  const runs = await claimReadyScheduledAgentRuns({
+    leaseForMs: workerStartupLimitMs,
+    limit: 25,
+    now,
+  });
+  const reportRunIds = await listRecoverableScheduledReports(now, 25);
+  if (
+    materializedRunIds.length > 0 ||
+    runs.length > 0 ||
+    reportRunIds.length > 0
+  ) {
+    console.info("[scheduled-run] schedule tick found work", {
+      claimedRunCount: runs.length,
+      materializedRunCount: materializedRunIds.length,
+      recoverableReportCount: reportRunIds.length,
+    });
+  }
   await Promise.all([
-    ...runs.map((claim) => executeScheduledRun(claim)),
+    ...runs.map((claim) => executeScheduledRun(to, claim)),
     ...reportRunIds.map((runId) => postScheduledReport(runId)),
   ]);
 }
 
 async function executeScheduledRun(
+  to: ScheduleToFn,
   claim: Awaited<ReturnType<typeof claimReadyScheduledAgentRuns>>[number]
 ) {
   const leaseToken = claim.run.leaseToken;
   if (!leaseToken) throw new Error("A scheduled run claim requires a lease.");
+  console.info("[scheduled-run] dispatching worker", {
+    attempt: claim.run.attempts,
+    jobId: claim.job.id,
+    runId: claim.run.id,
+    scheduledFor: claim.run.scheduledFor.toISOString(),
+  });
   try {
-    const response = await postScheduledRunRoute(
-      "/internal/scheduled-run/start",
-      {
-        leaseToken,
-        restart: claim.run.workerSessionId !== null,
-        runId: claim.run.id,
-      }
+    const session = await to(scheduledRunChannel, {
+      restart: claim.run.workerSessionId !== null,
+      runId: claim.run.id,
+    }).send(scheduledRunPrompt(claim), {
+      auth: scheduledWorkerAuth(claim),
+    });
+    const persisted = await setScheduledRunSession(
+      claim.run.id,
+      leaseToken,
+      session.id
     );
-    if (!response.ok) {
-      throw new Error(
-        `Scheduled run dispatch failed (${String(response.status)}).`
-      );
+    if (!persisted) {
+      throw new Error("The scheduled run lease expired during dispatch.");
     }
+    console.info("[scheduled-run] worker session accepted", {
+      jobId: claim.job.id,
+      runId: claim.run.id,
+      sessionId: session.id,
+    });
   } catch (error) {
-    await releaseScheduledAgentRun(
+    console.warn("[scheduled-run] worker dispatch failed", {
+      cause: error,
+      jobId: claim.job.id,
+      runId: claim.run.id,
+    });
+    const status = await releaseScheduledAgentRun(
       claim.run.id,
       leaseToken,
       error instanceof Error ? error.message : String(error)
     );
+    if (status === "dead_letter") {
+      await postScheduledReport(claim.run.id);
+    }
   }
+}
+
+function scheduledRunPrompt(
+  claim: Awaited<ReturnType<typeof claimReadyScheduledAgentRuns>>[number]
+) {
+  return [
+    "Complete this user-owned scheduled task in an isolated background session.",
+    `Scheduled for: ${claim.run.scheduledFor.toISOString()}`,
+    `Task: ${claim.job.prompt}`,
+    "Return exactly one structured final outcome.",
+  ].join("\n\n");
+}
+
+function scheduledWorkerAuth(
+  claim: Awaited<ReturnType<typeof claimReadyScheduledAgentRuns>>[number]
+) {
+  const leaseToken = claim.run.leaseToken;
+  if (!leaseToken) throw new Error("A scheduled run claim requires a lease.");
+  return {
+    attributes: {
+      conversationChannel: claim.job.conversationChannel,
+      conversationId: claim.job.conversationId,
+      scheduleId: claim.job.id,
+      scheduledRunLeaseToken: leaseToken,
+      scheduledRunId: claim.run.id,
+      workspaceId: claim.job.workspaceId,
+    },
+    authenticator: "scheduled-worker",
+    issuer: "open-instinct",
+    principalId: claim.job.createdByUserId,
+    principalType: "user" as const,
+  };
 }

--- a/agent/tools/schedules.ts
+++ b/agent/tools/schedules.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 import { resolveModeValue } from "@/agent/lib/mode";
 import { scheduledReportIdentity } from "@/agent/lib/schedules/identity";
 import { postScheduledRunRoute } from "@/agent/lib/schedules/request";
-import { scheduleOwner, scheduleSummary } from "@/agent/lib/schedules/tools";
+import {
+  scheduleListSummary,
+  scheduleOwner,
+  scheduleSummary,
+} from "@/agent/lib/schedules/tools";
 import { scheduleTimingSchema } from "@/agent/lib/schedules/timing";
 import {
   createScheduledAgentJob,
@@ -41,7 +45,7 @@ export const listSchedules = defineTool({
   async execute(_input, context) {
     const owner = scheduleOwner(context);
     return (await listScheduledAgentJobs(owner.scope, owner.conversation)).map(
-      scheduleSummary
+      scheduleListSummary
     );
   },
 });

--- a/db/services/scheduled-agent-jobs.ts
+++ b/db/services/scheduled-agent-jobs.ts
@@ -14,6 +14,12 @@ import {
 } from "@/agent/lib/schedules/outcome";
 import { db, scheduledAgentJobs, scheduledAgentRuns } from "@/db";
 
+const exhaustedRunOutcome = {
+  kind: "blocked",
+  summary: "The scheduled task could not complete after three attempts.",
+  userActionNeeded: "Try the task again or update the schedule.",
+} satisfies ScheduledRunOutcome;
+
 export interface CreateScheduledAgentJob {
   readonly conversationChannel: "eve" | "linq";
   readonly conversationId: string;
@@ -95,9 +101,13 @@ export async function listScheduledAgentJobs(
       },
     },
   });
-  return jobs.map(({ runs, ...job }) =>
-    parseJob({ ...job, lastError: runs[0]?.lastError ?? job.lastError })
-  );
+  return jobs.map(({ runs, ...job }) => {
+    const parsed = parseJob(job);
+    parsed.lastError = runs[0]?.lastError ?? parsed.lastError;
+    return Object.assign(parsed, {
+      latestRun: runs[0] ? parseRun(runs[0]) : null,
+    });
+  });
 }
 
 export async function updateScheduledAgentJob(
@@ -225,6 +235,7 @@ export async function claimReadyScheduledAgentRuns(options: {
             eq(scheduledAgentRuns.status, "queued"),
             and(
               eq(scheduledAgentRuns.status, "running"),
+              isNull(scheduledAgentRuns.workerSessionId),
               lte(scheduledAgentRuns.leaseExpiresAt, options.now)
             )
           ),
@@ -238,28 +249,54 @@ export async function claimReadyScheduledAgentRuns(options: {
       .limit(options.limit)
       .for("update", { of: scheduledAgentRuns, skipLocked: true });
     if (ready.length === 0) return [];
+    const exhausted = ready.filter(({ run }) => run.attempts >= 3);
+    if (exhausted.length > 0) {
+      await transaction
+        .update(scheduledAgentRuns)
+        .set({
+          lastError: "Scheduled worker dispatch did not complete.",
+          leaseExpiresAt: null,
+          leaseToken: null,
+          outcome: exhaustedRunOutcome,
+          reportSequence: sql`${scheduledAgentRuns.reportSequence} + 1`,
+          reportStatus: "pending",
+          retryAt: null,
+          status: "dead_letter",
+          updatedAt: options.now,
+        })
+        .where(
+          inArray(
+            scheduledAgentRuns.id,
+            exhausted.map(({ run }) => run.id)
+          )
+        );
+    }
+    const claimable = ready.filter(({ run }) => run.attempts < 3);
+    if (claimable.length === 0) return [];
     const leaseToken = randomUUID();
     const leaseExpiresAt = new Date(options.now.getTime() + options.leaseForMs);
-    const ids = ready.map(({ run }) => run.id);
+    const ids = claimable.map(({ run }) => run.id);
     await transaction
       .update(scheduledAgentRuns)
       .set({
         attempts: sql`${scheduledAgentRuns.attempts} + 1`,
         leaseExpiresAt,
         leaseToken,
-        startedAt: options.now,
+        retryAt: null,
+        startedAt: null,
         status: "running",
         updatedAt: options.now,
       })
       .where(inArray(scheduledAgentRuns.id, ids));
-    return ready.map(({ job, run }) => ({
+    return claimable.map(({ job, run }) => ({
       job: parseJob(job),
       run: parseRun({
         ...run,
         attempts: run.attempts + 1,
         leaseExpiresAt,
         leaseToken,
-        startedAt: options.now,
+        retryAt: null,
+        startedAt: null,
         status: "running",
       }),
     }));
@@ -271,32 +308,49 @@ export async function setScheduledRunSession(
   leaseToken: string,
   workerSessionId: string
 ) {
-  await db
+  const [run] = await db
     .update(scheduledAgentRuns)
     .set({ workerSessionId, updatedAt: new Date() })
     .where(
       and(
         eq(scheduledAgentRuns.id, runId),
+        eq(scheduledAgentRuns.status, "running"),
         eq(scheduledAgentRuns.leaseToken, leaseToken)
       )
-    );
+    )
+    .returning({ id: scheduledAgentRuns.id });
+  if (run) return true;
+  const current = await db.query.scheduledAgentRuns.findFirst({
+    columns: { workerSessionId: true },
+    where: eq(scheduledAgentRuns.id, runId),
+  });
+  return current?.workerSessionId === workerSessionId;
 }
 
-export async function getClaimedScheduledAgentRun(
+export async function markScheduledAgentRunStarted(
   runId: string,
-  leaseToken: string
+  leaseToken: string,
+  workerSessionId: string,
+  leaseForMs: number,
+  now = new Date()
 ) {
-  const claimed = await db.query.scheduledAgentRuns.findFirst({
-    where: and(
-      eq(scheduledAgentRuns.id, runId),
-      eq(scheduledAgentRuns.status, "running"),
-      eq(scheduledAgentRuns.leaseToken, leaseToken)
-    ),
-    with: { job: true },
-  });
-  if (!claimed) return undefined;
-  const { job, ...run } = claimed;
-  return { job: parseJob(job), run: parseRun(run) };
+  const [run] = await db
+    .update(scheduledAgentRuns)
+    .set({
+      leaseExpiresAt: new Date(now.getTime() + leaseForMs),
+      startedAt: sql`coalesce(${scheduledAgentRuns.startedAt}, ${now})`,
+      updatedAt: now,
+      workerSessionId,
+    })
+    .where(
+      and(
+        eq(scheduledAgentRuns.id, runId),
+        eq(scheduledAgentRuns.status, "running"),
+        eq(scheduledAgentRuns.leaseToken, leaseToken)
+      )
+    )
+    .returning({ id: scheduledAgentRuns.id });
+  return run !== undefined;
 }
 
 export async function waitForScheduledAgentRunInput(
@@ -511,14 +565,19 @@ export async function releaseScheduledAgentRun(
       eq(scheduledAgentRuns.leaseToken, leaseToken)
     ),
   });
-  if (!run) return;
+  if (!run) return undefined;
   const dead = run.attempts >= 3;
-  await db
+  const [released] = await db
     .update(scheduledAgentRuns)
     .set({
       lastError: errorMessage.slice(0, 2_000),
       leaseExpiresAt: null,
       leaseToken: null,
+      outcome: dead ? exhaustedRunOutcome : run.outcome,
+      reportSequence: dead
+        ? sql`${scheduledAgentRuns.reportSequence} + 1`
+        : scheduledAgentRuns.reportSequence,
+      reportStatus: dead ? "pending" : run.reportStatus,
       retryAt: dead ? null : new Date(now.getTime() + 5 * 60_000),
       status: dead ? "dead_letter" : "queued",
       updatedAt: now,
@@ -528,7 +587,9 @@ export async function releaseScheduledAgentRun(
         eq(scheduledAgentRuns.id, run.id),
         eq(scheduledAgentRuns.leaseToken, leaseToken)
       )
-    );
+    )
+    .returning({ status: scheduledAgentRuns.status });
+  return released?.status;
 }
 
 export async function claimScheduledReport(runId: string, now = new Date()) {
@@ -544,7 +605,11 @@ export async function claimScheduledReport(runId: string, now = new Date()) {
     .where(
       and(
         eq(scheduledAgentRuns.id, runId),
-        inArray(scheduledAgentRuns.status, ["completed", "waiting_for_input"]),
+        inArray(scheduledAgentRuns.status, [
+          "completed",
+          "dead_letter",
+          "waiting_for_input",
+        ]),
         eq(scheduledAgentRuns.reportStatus, "pending")
       )
     )
@@ -571,6 +636,7 @@ export async function listRecoverableScheduledReports(
         and(
           inArray(scheduledAgentRuns.status, [
             "completed",
+            "dead_letter",
             "waiting_for_input",
           ]),
           or(
@@ -615,7 +681,7 @@ export async function releaseScheduledReport(
   leaseToken: string,
   errorMessage: string
 ) {
-  await db
+  const [run] = await db
     .update(scheduledAgentRuns)
     .set({
       lastError: errorMessage.slice(0, 2_000),
@@ -629,7 +695,9 @@ export async function releaseScheduledReport(
         eq(scheduledAgentRuns.id, runId),
         eq(scheduledAgentRuns.reportLeaseToken, leaseToken)
       )
-    );
+    )
+    .returning({ id: scheduledAgentRuns.id });
+  return run !== undefined;
 }
 
 export async function finalizeScheduledReport(
@@ -639,9 +707,13 @@ export async function finalizeScheduledReport(
 ) {
   const reportableRunStatus =
     reportStatus === "suppressed"
-      ? eq(scheduledAgentRuns.status, "completed")
-      : inArray(scheduledAgentRuns.status, ["completed", "waiting_for_input"]);
-  await db
+      ? inArray(scheduledAgentRuns.status, ["completed", "dead_letter"])
+      : inArray(scheduledAgentRuns.status, [
+          "completed",
+          "dead_letter",
+          "waiting_for_input",
+        ]);
+  const [run] = await db
     .update(scheduledAgentRuns)
     .set({
       reportLeaseExpiresAt: null,
@@ -656,5 +728,7 @@ export async function finalizeScheduledReport(
         eq(scheduledAgentRuns.reportStatus, "queued"),
         reportableRunStatus
       )
-    );
+    )
+    .returning({ id: scheduledAgentRuns.id });
+  return run !== undefined;
 }

--- a/db/services/scheduled-agent-run-leases.ts
+++ b/db/services/scheduled-agent-run-leases.ts
@@ -1,0 +1,19 @@
+import { and, eq, gt } from "drizzle-orm";
+import { db, scheduledAgentRuns } from "@/db";
+
+export async function isScheduledAgentRunLeaseActive(
+  runId: string,
+  leaseToken: string,
+  now = new Date()
+) {
+  const run = await db.query.scheduledAgentRuns.findFirst({
+    columns: { id: true },
+    where: and(
+      eq(scheduledAgentRuns.id, runId),
+      eq(scheduledAgentRuns.status, "running"),
+      eq(scheduledAgentRuns.leaseToken, leaseToken),
+      gt(scheduledAgentRuns.leaseExpiresAt, now)
+    ),
+  });
+  return run !== undefined;
+}

--- a/db/tests/scheduled-agent-jobs.test.ts
+++ b/db/tests/scheduled-agent-jobs.test.ts
@@ -39,6 +39,7 @@ describe("scheduled agent jobs", () => {
     vi.spyOn(Database, "db", "get").mockReturnValue(pgliteDatabase as never);
     const scope = await import("@/db/services/scope");
     const jobs = await import("@/db/services/scheduled-agent-jobs");
+    const leases = await import("@/db/services/scheduled-agent-run-leases");
     const alice = { userId: "alice", workspaceId: "workspace:alice" };
     const bob = { userId: "bob", workspaceId: "workspace:bob" };
     const aliceConversation = {
@@ -74,7 +75,7 @@ describe("scheduled agent jobs", () => {
       []
     );
     expect(await jobs.listScheduledAgentJobs(alice, aliceConversation)).toEqual(
-      [created]
+      [{ ...created, latestRun: null }]
     );
     await jobs.updateScheduledAgentJob(
       alice,
@@ -105,7 +106,7 @@ describe("scheduled agent jobs", () => {
     if (!claim?.run.leaseToken) throw new Error("Expected one leased run.");
     expect(claim).toMatchObject({
       job: { id: created.id, ...aliceConversation },
-      run: { attempts: 1, scheduledFor: dueAt },
+      run: { attempts: 1, scheduledFor: dueAt, startedAt: null },
     });
     expect(
       await jobs.claimReadyScheduledAgentRuns({
@@ -115,11 +116,58 @@ describe("scheduled agent jobs", () => {
       })
     ).toEqual([]);
 
-    await jobs.setScheduledRunSession(
-      claim.run.id,
-      claim.run.leaseToken,
-      "worker-session"
+    expect(
+      await jobs.setScheduledRunSession(
+        claim.run.id,
+        claim.run.leaseToken,
+        "worker-session"
+      )
+    ).toBe(true);
+    const workerStartedAt = new Date("2026-09-01T13:00:05.000Z");
+    expect(
+      await jobs.markScheduledAgentRunStarted(
+        claim.run.id,
+        claim.run.leaseToken,
+        "worker-session",
+        21_600_000,
+        workerStartedAt
+      )
+    ).toBe(true);
+    expect(
+      await leases.isScheduledAgentRunLeaseActive(
+        claim.run.id,
+        claim.run.leaseToken,
+        new Date("2026-09-01T13:00:06.000Z")
+      )
+    ).toBe(true);
+    expect(
+      await jobs.markScheduledAgentRunStarted(
+        claim.run.id,
+        claim.run.leaseToken,
+        "worker-session",
+        21_600_000,
+        new Date("2026-09-01T13:00:10.000Z")
+      )
+    ).toBe(true);
+    expect(
+      await jobs.markScheduledAgentRunStarted(
+        claim.run.id,
+        "00000000-0000-4000-8000-000000000099",
+        "stale-worker-session",
+        21_600_000,
+        workerStartedAt
+      )
+    ).toBe(false);
+    const [listedJob] = await jobs.listScheduledAgentJobs(
+      alice,
+      aliceConversation
     );
+    expect(listedJob?.latestRun).toMatchObject({
+      id: claim.run.id,
+      startedAt: workerStartedAt,
+      status: "running",
+      workerSessionId: "worker-session",
+    });
     const question = {
       action: {
         callId: "call-question",
@@ -231,19 +279,35 @@ describe("scheduled agent jobs", () => {
       await jobs.claimReadyScheduledAgentRuns({
         leaseForMs: 21_600_000,
         limit: 25,
-        now: new Date("2026-09-01T13:10:00.000Z"),
+        now: new Date("2026-09-01T19:03:00.000Z"),
+      })
+    ).toEqual([]);
+    expect(
+      await jobs.releaseScheduledAgentRun(
+        claim.run.id,
+        claim.run.leaseToken,
+        "Worker failed after resumption.",
+        new Date("2026-09-01T19:03:00.000Z")
+      )
+    ).toBe("queued");
+    expect(
+      await jobs.claimReadyScheduledAgentRuns({
+        leaseForMs: 21_600_000,
+        limit: 25,
+        now: new Date("2026-09-01T19:07:00.000Z"),
       })
     ).toEqual([]);
     const [recoveredWorker] = await jobs.claimReadyScheduledAgentRuns({
       leaseForMs: 21_600_000,
       limit: 25,
-      now: new Date("2026-09-01T19:03:00.000Z"),
+      now: new Date("2026-09-01T19:08:00.000Z"),
     });
     if (!recoveredWorker?.run.leaseToken) {
       throw new Error("Expected the interrupted worker to be reclaimed.");
     }
     expect(recoveredWorker.run).toMatchObject({
       attempts: 2,
+      startedAt: null,
       workerSessionId: "worker-session",
     });
     claim = recoveredWorker;
@@ -387,6 +451,64 @@ describe("scheduled agent jobs", () => {
         conversationId: "linq:another-chat",
       })
     ).toEqual([]);
+
+    const [acceptedRun] = await pgliteDatabase
+      .insert(schema.scheduledAgentRuns)
+      .values({
+        attempts: 1,
+        jobId: created.id,
+        leaseExpiresAt: new Date("2026-09-09T13:05:00.000Z"),
+        leaseToken: "00000000-0000-4000-8000-000000000010",
+        scheduledFor: new Date("2026-09-09T13:00:00.000Z"),
+        startedAt: null,
+        status: "running",
+        workerSessionId: "accepted-worker-session",
+      })
+      .returning();
+    if (!acceptedRun) throw new Error("Expected an accepted worker run.");
+    expect(
+      await jobs.claimReadyScheduledAgentRuns({
+        leaseForMs: 300_000,
+        limit: 25,
+        now: new Date("2026-09-09T13:06:00.000Z"),
+      })
+    ).toEqual([]);
+
+    const [exhaustedRun] = await pgliteDatabase
+      .insert(schema.scheduledAgentRuns)
+      .values({
+        attempts: 3,
+        jobId: created.id,
+        leaseExpiresAt: new Date("2026-09-09T14:05:00.000Z"),
+        leaseToken: "00000000-0000-4000-8000-000000000011",
+        scheduledFor: new Date("2026-09-09T14:00:00.000Z"),
+        status: "running",
+      })
+      .returning();
+    if (!exhaustedRun) throw new Error("Expected an exhausted worker run.");
+    expect(
+      await jobs.claimReadyScheduledAgentRuns({
+        leaseForMs: 300_000,
+        limit: 25,
+        now: new Date("2026-09-09T14:06:00.000Z"),
+      })
+    ).toEqual([]);
+    expect(
+      await jobs.claimScheduledReport(
+        exhaustedRun.id,
+        new Date("2026-09-09T14:06:01.000Z")
+      )
+    ).toMatchObject({
+      run: {
+        outcome: {
+          kind: "blocked",
+          summary:
+            "The scheduled task could not complete after three attempts.",
+        },
+        reportStatus: "queued",
+        status: "dead_letter",
+      },
+    });
   }, 20_000);
 });
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -7,8 +7,11 @@ export default {
     "agent/instructions/**/*.ts",
     "agent/memory/**/*.ts",
     "agent/subagents/**/*.ts",
+    "agent/schedules/**/*.ts",
     "agent/tools/**/*.ts",
     "db/drizzle.config.ts",
+    // Drizzle consumes every table and relation exported by this schema barrel.
+    "db/schema/index.ts",
     "evals/**/*.eval.ts",
     "evals/evals.config.ts",
     "taze.config.ts",

--- a/tests/agent/agent.test.ts
+++ b/tests/agent/agent.test.ts
@@ -1,0 +1,91 @@
+import type { DynamicResolveContext } from "eve";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { isScheduledAgentRunLeaseActive } from "@/db/services/scheduled-agent-run-leases";
+import type { getGatewayModel } from "@/db/services/settings";
+
+const services = vi.hoisted(() => ({
+  getModel: vi.fn<typeof getGatewayModel>(),
+  isActive: vi.fn<typeof isScheduledAgentRunLeaseActive>(),
+}));
+
+vi.mock("@/db/services/scheduled-agent-run-leases", () => ({
+  isScheduledAgentRunLeaseActive: services.isActive,
+}));
+vi.mock("@/db/services/settings", () => ({
+  getGatewayModel: services.getModel,
+}));
+
+import agent from "@/agent/agent";
+
+const runId = "00000000-0000-4000-8000-000000000001";
+const oldLeaseToken = "00000000-0000-4000-8000-000000000002";
+const retryLeaseToken = "00000000-0000-4000-8000-000000000003";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  services.getModel.mockResolvedValue("openai/gpt-5.6-sol-fast");
+});
+
+describe("root agent model resolution", () => {
+  it("accepts a valid retry lease forwarded into an older Eve session", async () => {
+    services.isActive.mockImplementation(async (_runId, leaseToken) => {
+      return leaseToken === retryLeaseToken;
+    });
+
+    const model = await agent.model.events["step.started"]?.(
+      {},
+      scheduledWorkerContext()
+    );
+
+    expect(services.isActive).toHaveBeenCalledExactlyOnceWith(
+      runId,
+      retryLeaseToken
+    );
+    expect(services.getModel).toHaveBeenCalledExactlyOnceWith({
+      userId: "user-1",
+      workspaceId: "workspace-1",
+    });
+    expect(model).toBe("openai/gpt-5.6-sol-fast");
+  });
+
+  it("rejects a scheduled worker after its lease is replaced", async () => {
+    services.isActive.mockResolvedValue(false);
+
+    await expect(
+      agent.model.events["step.started"]?.({}, scheduledWorkerContext())
+    ).rejects.toThrow("The scheduled run lease is no longer active.");
+    expect(services.getModel).not.toHaveBeenCalled();
+  });
+});
+
+function scheduledWorkerContext(): DynamicResolveContext {
+  return {
+    channel: { kind: "http" },
+    messages: [],
+    session: {
+      auth: {
+        current: {
+          attributes: {
+            scheduledRunId: runId,
+            scheduledRunLeaseToken: retryLeaseToken,
+            workspaceId: "workspace-1",
+          },
+          authenticator: "scheduled-worker",
+          principalId: "user-1",
+          principalType: "user",
+        },
+        initiator: {
+          attributes: {
+            scheduledRunId: runId,
+            scheduledRunLeaseToken: oldLeaseToken,
+            workspaceId: "workspace-1",
+          },
+          authenticator: "scheduled-worker",
+          principalId: "user-1",
+          principalType: "user",
+        },
+      },
+      id: "worker-session",
+    },
+  };
+}

--- a/tests/agent/channels/eve-message-delivery.test.ts
+++ b/tests/agent/channels/eve-message-delivery.test.ts
@@ -44,6 +44,8 @@ type ActionParameters = Parameters<typeof handleActionResult>;
 describe("Eve scheduled report delivery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delivery.finalize.mockResolvedValue(true);
+    delivery.release.mockResolvedValue(true);
   });
 
   it("finalizes a report when send_message completes", async () => {

--- a/tests/agent/channels/linq-message-delivery.test.ts
+++ b/tests/agent/channels/linq-message-delivery.test.ts
@@ -167,6 +167,8 @@ interface LinqTestMessage {
 describe("Linq message delivery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    scheduleDeliveryCapture.finalize.mockResolvedValue(true);
+    scheduleDeliveryCapture.release.mockResolvedValue(true);
   });
 
   it("does not register automatic assistant text posting", () => {

--- a/tests/agent/channels/scheduled-run-auth.test.ts
+++ b/tests/agent/channels/scheduled-run-auth.test.ts
@@ -1,11 +1,15 @@
-import type { RouteHandlerArgs } from "eve/channels";
-import { describe, expect, it } from "vitest";
+import type {
+  ChannelResolveSession,
+  ChannelSource,
+  RouteHandlerArgs,
+  Session,
+} from "eve/channels";
+import { describe, expect, it, vi } from "vitest";
 import scheduledRunChannel from "@/agent/channels/scheduled-run";
 
 const scheduledRunPaths = [
   "/internal/scheduled-run/report",
   "/internal/scheduled-run/respond",
-  "/internal/scheduled-run/start",
 ] as const;
 
 describe("scheduled run channel authentication", () => {
@@ -35,6 +39,64 @@ describe("scheduled run channel authentication", () => {
   }
 });
 
+describe("scheduled run channel handoff", () => {
+  it("starts a scheduled worker from the channel's native receive hook", async () => {
+    const send = vi
+      .fn<ChannelSource["send"]>()
+      .mockResolvedValue(workerSession());
+    const reset = vi.fn<ChannelSource["reset"]>();
+    const source: ChannelSource = {
+      cancel: vi.fn<ChannelSource["cancel"]>(),
+      clear: vi.fn<ChannelSource["clear"]>(),
+      compact: vi.fn<ChannelSource["compact"]>(),
+      reset,
+      respond: vi.fn<ChannelSource["respond"]>(),
+      send,
+    };
+    const from = vi.fn<(address: string) => ChannelSource>(() => source);
+    const receive = scheduledRunChannel.receive;
+    if (!receive) throw new Error("The scheduled-run channel cannot receive.");
+    const auth = {
+      attributes: { scheduledRunId: "00000000-0000-4000-8000-000000000001" },
+      authenticator: "scheduled-worker",
+      principalId: "user-1",
+      principalType: "user" as const,
+    };
+
+    const result = await receive(
+      {
+        auth,
+        message: "Run the scheduled task.",
+        target: {
+          restart: true,
+          runId: "00000000-0000-4000-8000-000000000001",
+        },
+      },
+      {
+        from,
+        resolveSession: vi
+          .fn<ChannelResolveSession>()
+          .mockResolvedValue(undefined),
+      }
+    );
+
+    expect(from).toHaveBeenCalledExactlyOnceWith(
+      "scheduled-run:00000000-0000-4000-8000-000000000001"
+    );
+    expect(reset).toHaveBeenCalledExactlyOnceWith({
+      reason: "Scheduled worker exceeded its runtime.",
+    });
+    expect(send).toHaveBeenCalledWith(
+      "Run the scheduled task.",
+      expect.objectContaining({
+        auth,
+        title: "Scheduled run 00000000-0000-4000-8000-000000000001",
+      })
+    );
+    expect(result.id).toBe("worker-session");
+  });
+});
+
 function unexpectedRouteContext() {
   return {
     attachSession: unexpectedRouteRequest,
@@ -49,4 +111,18 @@ function unexpectedRouteContext() {
 
 function unexpectedRouteRequest(): never {
   throw new Error("The request should stop at authentication.");
+}
+
+function workerSession(): Session {
+  return {
+    cancel: vi.fn<Session["cancel"]>(),
+    clear: vi.fn<Session["clear"]>(),
+    compact: vi.fn<Session["compact"]>(),
+    getEventStream: vi.fn<Session["getEventStream"]>(),
+    getStreamTailIndex: vi.fn<Session["getStreamTailIndex"]>(),
+    id: "worker-session",
+    reset: vi.fn<Session["reset"]>(),
+    respond: vi.fn<Session["respond"]>(),
+    send: vi.fn<Session["send"]>(),
+  };
 }

--- a/tests/agent/hooks/scheduled-run-completion.test.ts
+++ b/tests/agent/hooks/scheduled-run-completion.test.ts
@@ -2,18 +2,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HookContext } from "eve/hooks";
 import type {
   completeScheduledAgentRun,
+  markScheduledAgentRunStarted,
   releaseScheduledAgentRun,
   waitForScheduledAgentRunInput,
 } from "@/db/services/scheduled-agent-jobs";
 
 const services = vi.hoisted(() => ({
   complete: vi.fn<typeof completeScheduledAgentRun>(),
+  markStarted: vi.fn<typeof markScheduledAgentRunStarted>(),
   release: vi.fn<typeof releaseScheduledAgentRun>(),
   waitForInput: vi.fn<typeof waitForScheduledAgentRunInput>(),
 }));
 
 vi.mock("@/db/services/scheduled-agent-jobs", () => ({
   completeScheduledAgentRun: services.complete,
+  markScheduledAgentRunStarted: services.markStarted,
   releaseScheduledAgentRun: services.release,
   waitForScheduledAgentRunInput: services.waitForInput,
 }));
@@ -22,6 +25,7 @@ import completionHook from "@/agent/hooks/scheduled-run-completion";
 
 const runId = "00000000-0000-4000-8000-000000000001";
 const leaseToken = "00000000-0000-4000-8000-000000000002";
+const retryLeaseToken = "00000000-0000-4000-8000-000000000005";
 const context = {
   agent: { name: "test-agent" },
   channel: { continuationToken: `scheduled-run:${runId}` },
@@ -65,12 +69,76 @@ const resumedContext = {
   },
 } satisfies HookContext;
 
+const retriedContext = {
+  ...context,
+  session: {
+    ...context.session,
+    auth: {
+      ...context.session.auth,
+      current: {
+        attributes: {
+          scheduledRunId: runId,
+          scheduledRunLeaseToken: retryLeaseToken,
+        },
+        authenticator: "scheduled-worker",
+        principalId: "user-1",
+        principalType: "user" as const,
+      },
+    },
+  },
+} satisfies HookContext;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  services.markStarted.mockResolvedValue(true);
+  services.release.mockResolvedValue("queued");
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null)));
 });
 
 describe("scheduled run completion hook", () => {
+  it("starts the runtime lease only when the worker turn begins", async () => {
+    const handler = completionHook.events?.["turn.started"];
+    await handler?.(
+      {
+        data: {
+          sequence: 0,
+          turnId: "turn-1",
+        },
+        meta: { at: "2026-09-01T13:00:05.000Z", id: "event-start" },
+        type: "turn.started",
+      },
+      context
+    );
+
+    expect(services.markStarted).toHaveBeenCalledExactlyOnceWith(
+      runId,
+      leaseToken,
+      "worker-session",
+      21_600_000,
+      new Date("2026-09-01T13:00:05.000Z")
+    );
+  });
+
+  it("uses a retry turn's current lease over the original session lease", async () => {
+    const handler = completionHook.events?.["turn.started"];
+    await handler?.(
+      {
+        data: { sequence: 1, turnId: "turn-2" },
+        meta: { at: "2026-09-01T13:05:05.000Z", id: "event-retry" },
+        type: "turn.started",
+      },
+      retriedContext
+    );
+
+    expect(services.markStarted).toHaveBeenCalledExactlyOnceWith(
+      runId,
+      retryLeaseToken,
+      "worker-session",
+      21_600_000,
+      new Date("2026-09-01T13:05:05.000Z")
+    );
+  });
+
   it("persists the outcome and immediately wakes report delivery", async () => {
     services.complete.mockResolvedValue({
       attempts: 1,

--- a/tests/agent/schedules/dynamic.test.ts
+++ b/tests/agent/schedules/dynamic.test.ts
@@ -9,6 +9,7 @@ import type {
   materializeDueScheduledAgentRuns,
   releaseScheduledAgentRun,
   releaseScheduledReport,
+  setScheduledRunSession,
 } from "@/db/services/scheduled-agent-jobs";
 
 const services = vi.hoisted(() => ({
@@ -19,16 +20,10 @@ const services = vi.hoisted(() => ({
   materialize: vi.fn<typeof materializeDueScheduledAgentRuns>(),
   releaseReport: vi.fn<typeof releaseScheduledReport>(),
   releaseRun: vi.fn<typeof releaseScheduledAgentRun>(),
+  setSession: vi.fn<typeof setScheduledRunSession>(),
 }));
 const requests = vi.hoisted(() => ({
   report: vi.fn<(runId: string) => Promise<void>>(),
-  route:
-    vi.fn<
-      (
-        route: "/internal/scheduled-run/start",
-        body: { leaseToken: string; restart: boolean; runId: string }
-      ) => Promise<Response>
-    >(),
 }));
 
 vi.mock("@/db/services/scheduled-agent-jobs", () => ({
@@ -39,11 +34,11 @@ vi.mock("@/db/services/scheduled-agent-jobs", () => ({
   materializeDueScheduledAgentRuns: services.materialize,
   releaseScheduledAgentRun: services.releaseRun,
   releaseScheduledReport: services.releaseReport,
+  setScheduledRunSession: services.setSession,
 }));
 vi.mock("@/agent/channels/linq", () => ({ default: { channel: "linq" } }));
 vi.mock("@/agent/lib/schedules/request", () => ({
   postScheduledReport: requests.report,
-  postScheduledRunRoute: requests.route,
 }));
 vi.mock("@/agent/channels/scheduled-run", () => ({
   default: { channel: "scheduled-run" },
@@ -58,47 +53,54 @@ describe("dynamic schedule dispatch", () => {
     services.materialize.mockResolvedValue([]);
     services.listReports.mockResolvedValue([]);
     services.claimRuns.mockResolvedValue([]);
+    services.releaseRun.mockResolvedValue("queued");
+    services.setSession.mockResolvedValue(true);
     requests.report.mockResolvedValue();
-    requests.route.mockResolvedValue(new Response(null));
   });
 
-  it("starts due work separately without waiting for its lifetime", async () => {
+  it("hands due work directly to the scheduled-run channel", async () => {
     const claim = scheduledClaim();
     services.claimRuns.mockResolvedValue([claim]);
-    const linqSend = vi.fn<ReturnType<ScheduleToFn>["send"]>();
-    const to = vi.fn<ScheduleToFn>(() => ({ send: linqSend }));
+    const send = vi
+      .fn<ReturnType<ScheduleToFn>["send"]>()
+      .mockResolvedValue(workerSession());
+    const to = vi.fn<ScheduleToFn>(() => ({ send }));
 
     await runSchedule(to);
 
-    expect(requests.route).toHaveBeenCalledWith(
-      "/internal/scheduled-run/start",
-      {
-        leaseToken: claim.run.leaseToken,
-        restart: false,
-        runId: claim.run.id,
-      }
+    expect(to).toHaveBeenCalledWith(expect.anything(), {
+      restart: false,
+      runId: claim.run.id,
+    });
+    expect(send.mock.calls[0]?.[0]).toContain("Task: Watch the price.");
+    expect(send.mock.calls[0]?.[1].auth?.authenticator).toBe(
+      "scheduled-worker"
     );
-    expect(linqSend).not.toHaveBeenCalled();
+    expect(services.setSession).toHaveBeenCalledExactlyOnceWith(
+      claim.run.id,
+      claim.run.leaseToken,
+      "worker-session"
+    );
+    expect(services.claimRuns).toHaveBeenCalledWith(
+      expect.objectContaining({ leaseForMs: 300_000 })
+    );
   });
 
   it("requests a clean restart for a reclaimed interrupted worker", async () => {
     const claim = scheduledClaim();
     claim.run.workerSessionId = "interrupted-worker-session";
     services.claimRuns.mockResolvedValue([claim]);
-    const to = vi.fn<ScheduleToFn>(() => ({
-      send: vi.fn<ReturnType<ScheduleToFn>["send"]>(),
-    }));
+    const send = vi
+      .fn<ReturnType<ScheduleToFn>["send"]>()
+      .mockResolvedValue(workerSession());
+    const to = vi.fn<ScheduleToFn>(() => ({ send }));
 
     await runSchedule(to);
 
-    expect(requests.route).toHaveBeenCalledWith(
-      "/internal/scheduled-run/start",
-      {
-        leaseToken: claim.run.leaseToken,
-        restart: true,
-        runId: claim.run.id,
-      }
-    );
+    expect(to).toHaveBeenCalledWith(expect.anything(), {
+      restart: true,
+      runId: claim.run.id,
+    });
   });
 
   it("requests recovery through the report callback", async () => {
@@ -112,12 +114,31 @@ describe("dynamic schedule dispatch", () => {
     expect(workerSend).not.toHaveBeenCalled();
     expect(requests.report).toHaveBeenCalledExactlyOnceWith(report.run.id);
   });
+
+  it("reports a worker that exhausts its dispatch attempts", async () => {
+    const claim = scheduledClaim();
+    services.claimRuns.mockResolvedValue([claim]);
+    services.releaseRun.mockResolvedValue("dead_letter");
+    const send = vi
+      .fn<ReturnType<ScheduleToFn>["send"]>()
+      .mockRejectedValue(new Error("Workflow did not accept the candidate."));
+    const to = vi.fn<ScheduleToFn>(() => ({ send }));
+
+    await runSchedule(to);
+
+    expect(services.releaseRun).toHaveBeenCalledWith(
+      claim.run.id,
+      claim.run.leaseToken,
+      "Workflow did not accept the candidate."
+    );
+    expect(requests.report).toHaveBeenCalledExactlyOnceWith(claim.run.id);
+  });
 });
 
 describe("scheduled report delivery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    services.releaseReport.mockResolvedValue();
+    services.releaseReport.mockResolvedValue(true);
   });
 
   it("routes Linq reports to the stored conversation", async () => {
@@ -277,7 +298,7 @@ function scheduledClaim(): Awaited<
       reportLeaseToken: null,
       retryAt: null,
       scheduledFor: new Date("2026-09-02T13:00:00.000Z"),
-      startedAt: new Date("2026-09-02T13:00:00.000Z"),
+      startedAt: null,
       status: "running",
       updatedAt: new Date("2026-09-02T13:00:00.000Z"),
       workerSessionId: null,

--- a/tests/agent/schedules/request.test.ts
+++ b/tests/agent/schedules/request.test.ts
@@ -77,15 +77,15 @@ describe("scheduled run requests", () => {
   });
 
   it("leaves local callbacks to Eve local development authentication", async () => {
-    await postScheduledRunRoute("/internal/scheduled-run/start", {
+    await postScheduledRunRoute("/internal/scheduled-run/respond", {
+      answer: "Logan",
       leaseToken: "lease-1",
-      restart: false,
       runId: "run-1",
     });
 
     expect(mocks.getToken).not.toHaveBeenCalled();
     expect(fetch).toHaveBeenCalledWith(
-      new URL("http://127.0.0.1:51829/internal/scheduled-run/start"),
+      new URL("http://127.0.0.1:51829/internal/scheduled-run/respond"),
       expect.objectContaining({ method: "POST", redirect: "error" })
     );
     expect(sentHeaders().get("authorization")).toBeNull();

--- a/tests/agent/tools/schedules.test.ts
+++ b/tests/agent/tools/schedules.test.ts
@@ -179,7 +179,7 @@ describe("schedule tools", () => {
         conversationId: "linq:dm:chat-1",
       }
     );
-    expect(result).toEqual([scheduleSummary(job)]);
+    expect(result).toEqual([scheduleListSummary(job)]);
   });
 
   it("updates a schedule without carrying an action discriminator", async () => {
@@ -398,6 +398,7 @@ function scheduledJob(
     id: "00000000-0000-4000-8000-000000000001",
     lastError: null,
     lastRunAt: null,
+    latestRun: null,
     ...conversation,
     missedRunPolicy: "run_latest",
     nextRunAt: new Date("2026-09-02T13:00:00.000Z"),
@@ -426,4 +427,8 @@ function scheduleSummary(job: ReturnType<typeof scheduledJob>) {
     status: job.status,
     timing: job.timing,
   };
+}
+
+function scheduleListSummary(job: ReturnType<typeof scheduledJob>) {
+  return { ...scheduleSummary(job), latestRun: null };
 }


### PR DESCRIPTION
## Summary

- dispatch due jobs through Eve's native scheduled-run channel so worker sessions appear in Agent Runs
- separate pre-acceptance and runtime leases, prevent stale workers from executing, and make exhausted attempts reportable
- persist worker session IDs and correlated lifecycle logs from claim through final delivery
- expose the latest run and report status through `schedules-list`

## End-to-end flow

```text
dynamic schedule tick
  -> claim due run
  -> scheduled-run channel creates Eve worker session
  -> worker completes or requests input
  -> persist outcome
  -> reporting turn enters the originating Linq or Eve session
  -> send_message finalizes the report as delivered
```

Accepted worker sessions are left to Eve's durable lifecycle instead of being requeued by an application timer. Before each scheduled-worker model step, the stored lease token is checked so a stale or replaced candidate cannot execute tools.

## Verification

- `pnpm check` — 73 test files and 326 tests passed
- Eve production build passed
- Next.js production build passed
- local end-to-end scheduled run was claimed, executed in a new worker session, completed, and delivered through `send_message` to its originating web-channel session
