### PR TITLE
Fix scheduled result delivery after background work

### DIFF
--- a/agent/channels/scheduled-run.ts
+++ b/agent/channels/scheduled-run.ts
@@ -2,7 +2,6 @@ import { defineChannel, POST } from "eve/channels";
 import { localDev, routeAuth, vercelOidc } from "eve/channels/auth";
 import { parseInputResponses, resolveTextToResponses } from "eve/client";
 import { z } from "zod";
-import { scheduledRunOutcomeJsonSchema } from "@/agent/lib/schedules/outcome";
 import { dispatchScheduledReport } from "@/agent/lib/schedules/report";
 import {
   claimScheduledAgentRunInput,
@@ -33,7 +32,6 @@ export default defineChannel({
     }
     return source.send(input.message, {
       auth: input.auth,
-      outputSchema: scheduledRunOutcomeJsonSchema,
       title: `Scheduled run ${target.runId}`,
     });
   },

--- a/agent/hooks/scheduled-run-completion.ts
+++ b/agent/hooks/scheduled-run-completion.ts
@@ -1,9 +1,9 @@
 import { defineHook } from "eve/hooks";
 import { scheduledRunIdentity } from "@/agent/lib/schedules/identity";
 import { scheduledRunOutcomeSchema } from "@/agent/lib/schedules/outcome";
-import { postScheduledReport } from "@/agent/lib/schedules/request";
 import {
   completeScheduledAgentRun,
+  deferScheduledAgentRunCompletion,
   markScheduledAgentRunStarted,
   releaseScheduledAgentRun,
   waitForScheduledAgentRunInput,
@@ -56,36 +56,80 @@ export default defineHook({
         runId: waiting.id,
         sessionId: ctx.session.id,
       });
-      try {
-        await postScheduledReport(waiting.id);
-        console.info("[scheduled-run] input report callback accepted", {
-          runId: waiting.id,
-          sessionId: ctx.session.id,
-        });
-      } catch (error) {
-        console.warn("[scheduled-run] input report callback failed", {
-          cause: error,
-          runId: waiting.id,
-        });
-      }
+      console.info("[scheduled-run] input report queued", {
+        runId: waiting.id,
+        sessionId: ctx.session.id,
+      });
     },
-    async "result.completed"(event, ctx) {
+    async "subagent.completed"(event, ctx) {
+      if (!event.data.backgroundTask) return;
       const identity = scheduledRunIdentity(ctx.session.auth);
       if (!identity) return;
-      const outcome = scheduledRunOutcomeSchema.safeParse(event.data.result);
-      if (!outcome.success) {
-        console.warn("[scheduled-run] worker returned an invalid outcome", {
+      const deferred = await deferScheduledAgentRunCompletion(
+        identity.runId,
+        identity.leaseToken,
+        ctx.session.turn.id,
+        new Date(event.meta.at)
+      );
+      console.info("[scheduled-run] worker delegated background work", {
+        deferred,
+        runId: identity.runId,
+        sessionId: ctx.session.id,
+        taskId: event.data.backgroundTask.taskId,
+        turnId: ctx.session.turn.id,
+      });
+    },
+    async "message.completed"(event, ctx) {
+      const identity = scheduledRunIdentity(ctx.session.auth);
+      if (!identity) return;
+      if (event.data.finishReason === "tool-calls") return;
+      if (event.data.finishReason !== "stop") {
+        const status = await releaseScheduledAgentRun(
+          identity.runId,
+          identity.leaseToken,
+          `Scheduled worker stopped with finish reason: ${event.data.finishReason}.`,
+          new Date(event.meta.at)
+        );
+        console.warn("[scheduled-run] worker stopped without a final result", {
+          finishReason: event.data.finishReason,
+          nextStatus: status,
           runId: identity.runId,
           sessionId: ctx.session.id,
         });
+        logDeadLetterReportQueued(status, identity.runId, ctx.session.id);
         return;
       }
+      const message = event.data.message?.trim().slice(0, 4_000);
+      const outcome = scheduledRunOutcomeSchema.parse(
+        message
+          ? {
+              kind: "result",
+              summary: message,
+              urgency: "normal",
+            }
+          : {
+              kind: "nothing_to_report",
+              reason: "The scheduled task produced no useful update.",
+            }
+      );
       const completed = await completeScheduledAgentRun(
         identity.runId,
         identity.leaseToken,
-        outcome.data,
+        event.data.turnId,
+        outcome,
         new Date(event.meta.at)
       );
+      if (completed?.status === "deferred") {
+        console.info(
+          "[scheduled-run] worker completion deferred for background work",
+          {
+            runId: identity.runId,
+            sessionId: ctx.session.id,
+            turnId: event.data.turnId,
+          }
+        );
+        return;
+      }
       if (!completed) {
         console.warn("[scheduled-run] worker completion missed its lease", {
           runId: identity.runId,
@@ -94,22 +138,15 @@ export default defineHook({
         return;
       }
       console.info("[scheduled-run] worker completed", {
-        outcomeKind: outcome.data.kind,
-        reportStatus: completed.reportStatus,
-        runId: completed.id,
+        outcomeKind: outcome.kind,
+        reportStatus: completed.run.reportStatus,
+        runId: completed.run.id,
         sessionId: ctx.session.id,
       });
-      if (completed.reportStatus !== "pending") return;
-      try {
-        await postScheduledReport(completed.id);
-        console.info("[scheduled-run] completion report callback accepted", {
-          runId: completed.id,
+      if (completed.run.reportStatus === "pending") {
+        console.info("[scheduled-run] completion report queued", {
+          runId: completed.run.id,
           sessionId: ctx.session.id,
-        });
-      } catch (error) {
-        console.warn("[scheduled-run] immediate report callback failed", {
-          cause: error,
-          runId: completed.id,
         });
       }
     },
@@ -127,7 +164,7 @@ export default defineHook({
         runId: identity.runId,
         sessionId: ctx.session.id,
       });
-      await reportDeadLetter(status, identity.runId, ctx.session.id);
+      logDeadLetterReportQueued(status, identity.runId, ctx.session.id);
     },
     async "turn.cancelled"(event, ctx) {
       const identity = scheduledRunIdentity(ctx.session.auth);
@@ -143,7 +180,7 @@ export default defineHook({
         runId: identity.runId,
         sessionId: ctx.session.id,
       });
-      await reportDeadLetter(status, identity.runId, ctx.session.id);
+      logDeadLetterReportQueued(status, identity.runId, ctx.session.id);
     },
     async "session.failed"(event, ctx) {
       const identity = scheduledRunIdentity(ctx.session.auth);
@@ -159,28 +196,19 @@ export default defineHook({
         runId: identity.runId,
         sessionId: ctx.session.id,
       });
-      await reportDeadLetter(status, identity.runId, ctx.session.id);
+      logDeadLetterReportQueued(status, identity.runId, ctx.session.id);
     },
   },
 });
 
-async function reportDeadLetter(
+function logDeadLetterReportQueued(
   status: Awaited<ReturnType<typeof releaseScheduledAgentRun>>,
   runId: string,
   sessionId: string
 ) {
   if (status !== "dead_letter") return;
-  try {
-    await postScheduledReport(runId);
-    console.info("[scheduled-run] dead-letter report callback accepted", {
-      runId,
-      sessionId,
-    });
-  } catch (error) {
-    console.warn("[scheduled-run] dead-letter report callback failed", {
-      cause: error,
-      runId,
-      sessionId,
-    });
-  }
+  console.info("[scheduled-run] dead-letter report queued", {
+    runId,
+    sessionId,
+  });
 }

--- a/agent/instructions/content/role/scheduled-worker.md
+++ b/agent/instructions/content/role/scheduled-worker.md
@@ -1,17 +1,17 @@
 # Role
 
-You are OpenInstinct executing a user-owned scheduled task in an isolated background session. Complete the supplied task autonomously and return one structured outcome for the main conversation to evaluate.
+You are OpenInstinct executing a user-owned scheduled task in an isolated background session. Complete the supplied task autonomously. Your final response is an internal handoff to the main conversation, not a message sent directly to the user.
 
 # Boundaries
 
 - Delegate browser interaction to the declared `worker` subagent. Use read-only connections and public search directly when they are sufficient.
 - Never change connected accounts, schedules, profile data, or vault state.
 
-# Outcome
+# Handoff
 
-- Return exactly one outcome matching the required schema.
-- Use `result` only for a useful, verified finding or completed outcome.
-- Use `nothing_to_report` when there is genuinely no useful change.
+- Return one concise final handoff only when there is a useful, verified finding, completed outcome, or terminal blocker. Include the concrete result, relevant evidence, and exact blocker when applicable.
+- Preserve exact `![label](/artifacts/id)` references for any useful worker images in the handoff.
+- When there is genuinely no useful change, return a brief handoff saying so; the reporting turn decides whether the user should be notified.
 - When information, a choice, approval, or a user action would let the task continue, use `ask_question` and resume the same run after they answer. For a missing supported vault item, include only its safe setup metadata and ask the user to add it and reply when finished; never request the value itself.
-- Use `blocked` only when the run cannot usefully continue after a user response, such as an unsupported capability or terminal external condition.
-- Include the concrete result, relevant evidence, and exact blocker when applicable. Do not write as though you are speaking directly to the user.
+- Report a terminal blocker only when the run cannot usefully continue after a user response, such as an unsupported capability or terminal external condition.
+- Do not write as though you are speaking directly to the user.

--- a/agent/lib/schedules/outcome.ts
+++ b/agent/lib/schedules/outcome.ts
@@ -26,7 +26,3 @@ export const scheduledRunOutcomeSchema = z.discriminatedUnion("kind", [
 ]);
 
 export type ScheduledRunOutcome = z.infer<typeof scheduledRunOutcomeSchema>;
-
-export const scheduledRunOutcomeJsonSchema = z
-  .record(z.string(), z.json())
-  .parse(z.toJSONSchema(scheduledRunOutcomeSchema));

--- a/agent/lib/schedules/report.ts
+++ b/agent/lib/schedules/report.ts
@@ -9,7 +9,7 @@ import linq from "../../channels/linq";
 
 export async function dispatchScheduledReport(
   delivery: {
-    readonly attachSession: AttachSessionFn;
+    readonly attachSession?: AttachSessionFn;
     readonly to: ScheduleToFn;
   },
   runId: string
@@ -64,6 +64,9 @@ export async function dispatchScheduledReport(
         sessionId: session.id,
       });
       return;
+    }
+    if (!delivery.attachSession) {
+      throw new Error("Eve debug reports require an active session handle.");
     }
     const result = await delivery
       .attachSession(claimed.job.conversationId)

--- a/agent/schedules/dynamic.ts
+++ b/agent/schedules/dynamic.ts
@@ -1,5 +1,6 @@
 import { defineSchedule, type ScheduleToFn } from "eve/schedules";
 import scheduledRunChannel from "@/agent/channels/scheduled-run";
+import { dispatchScheduledReport } from "@/agent/lib/schedules/report";
 import { postScheduledReport } from "@/agent/lib/schedules/request";
 import {
   claimReadyScheduledAgentRuns,
@@ -29,21 +30,17 @@ async function dispatchDueWork(to: ScheduleToFn) {
     limit: 25,
     now,
   });
-  const reportRunIds = await listRecoverableScheduledReports(now, 25);
-  if (
-    materializedRunIds.length > 0 ||
-    runs.length > 0 ||
-    reportRunIds.length > 0
-  ) {
+  const reports = await listRecoverableScheduledReports(now, 25);
+  if (materializedRunIds.length > 0 || runs.length > 0 || reports.length > 0) {
     console.info("[scheduled-run] schedule tick found work", {
       claimedRunCount: runs.length,
       materializedRunCount: materializedRunIds.length,
-      recoverableReportCount: reportRunIds.length,
+      recoverableReportCount: reports.length,
     });
   }
   await Promise.all([
     ...runs.map((claim) => executeScheduledRun(to, claim)),
-    ...reportRunIds.map((runId) => postScheduledReport(runId)),
+    ...reports.map((report) => dispatchRecoverableReport(to, report)),
   ]);
 }
 
@@ -91,9 +88,21 @@ async function executeScheduledRun(
       error instanceof Error ? error.message : String(error)
     );
     if (status === "dead_letter") {
-      await postScheduledReport(claim.run.id);
+      await dispatchRecoverableReport(to, {
+        conversationChannel: claim.job.conversationChannel,
+        runId: claim.run.id,
+      });
     }
   }
+}
+
+function dispatchRecoverableReport(
+  to: ScheduleToFn,
+  report: Awaited<ReturnType<typeof listRecoverableScheduledReports>>[number]
+) {
+  return report.conversationChannel === "linq"
+    ? dispatchScheduledReport({ to }, report.runId)
+    : postScheduledReport(report.runId);
 }
 
 function scheduledRunPrompt(
@@ -103,7 +112,6 @@ function scheduledRunPrompt(
     "Complete this user-owned scheduled task in an isolated background session.",
     `Scheduled for: ${claim.run.scheduledFor.toISOString()}`,
     `Task: ${claim.job.prompt}`,
-    "Return exactly one structured final outcome.",
   ].join("\n\n");
 }
 

--- a/db/migrations/0010_rapid_cerise.sql
+++ b/db/migrations/0010_rapid_cerise.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "scheduled_agent_runs" ADD COLUMN "deferred_completion_turn_id" text;

--- a/db/migrations/meta/0010_snapshot.json
+++ b/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1937 @@
+{
+  "id": "6a5f5899-87c7-4f9b-8c6b-d33aef5f9198",
+  "prevId": "6623372f-18f4-44f3-82fb-76f70af98d12",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "phoneNumber": {
+          "name": "phoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phoneNumberVerified": {
+          "name": "phoneNumberVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_phoneNumber_unique": {
+          "name": "user_phoneNumber_unique",
+          "nullsNotDistinct": false,
+          "columns": ["phoneNumber"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_image_artifacts": {
+      "name": "browser_image_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_session_id": {
+          "name": "worker_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_pathname": {
+          "name": "storage_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "browser_image_artifacts_workspace_idempotency_uidx": {
+          "name": "browser_image_artifacts_workspace_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "browser_image_artifacts_workspace_created_idx": {
+          "name": "browser_image_artifacts_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_image_artifacts_membership_fkey": {
+          "name": "browser_image_artifacts_membership_fkey",
+          "tableFrom": "browser_image_artifacts",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "browser_image_artifacts_status_check": {
+          "name": "browser_image_artifacts_status_check",
+          "value": "\"browser_image_artifacts\".\"status\" IN ('pending', 'ready')"
+        },
+        "browser_image_artifacts_source_kind_check": {
+          "name": "browser_image_artifacts_source_kind_check",
+          "value": "\"browser_image_artifacts\".\"source_kind\" IN ('element', 'full_page', 'image_resource', 'viewport')"
+        },
+        "browser_image_artifacts_ready_fields_check": {
+          "name": "browser_image_artifacts_ready_fields_check",
+          "value": "\"browser_image_artifacts\".\"status\" = 'pending' OR (\"browser_image_artifacts\".\"filename\" IS NOT NULL AND \"browser_image_artifacts\".\"media_type\" IS NOT NULL AND \"browser_image_artifacts\".\"byte_size\" > 0 AND \"browser_image_artifacts\".\"content_hash\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.browser_sessions": {
+      "name": "browser_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "worker_session_id": {
+          "name": "worker_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "browser_sessions_workspace_idx": {
+          "name": "browser_sessions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "browser_sessions_worker_idx": {
+          "name": "browser_sessions_worker_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "worker_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_sessions_membership_fkey": {
+          "name": "browser_sessions_membership_fkey",
+          "tableFrom": "browser_sessions",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_trace_domains": {
+      "name": "browser_trace_domains",
+      "schema": "",
+      "columns": {
+        "trace_session_id": {
+          "name": "trace_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "browser_trace_domains_domain_idx": {
+          "name": "browser_trace_domains_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_trace_domains_trace_fkey": {
+          "name": "browser_trace_domains_trace_fkey",
+          "tableFrom": "browser_trace_domains",
+          "tableTo": "browser_traces",
+          "columnsFrom": ["trace_session_id"],
+          "columnsTo": ["session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "browser_trace_domains_pkey": {
+          "name": "browser_trace_domains_pkey",
+          "columns": ["trace_session_id", "domain"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_trace_events": {
+      "name": "browser_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trace_session_id": {
+          "name": "trace_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "browser_trace_events_trace_idx": {
+          "name": "browser_trace_events_trace_idx",
+          "columns": [
+            {
+              "expression": "trace_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_trace_events_trace_fkey": {
+          "name": "browser_trace_events_trace_fkey",
+          "tableFrom": "browser_trace_events",
+          "tableTo": "browser_traces",
+          "columnsFrom": ["trace_session_id"],
+          "columnsTo": ["session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_traces": {
+      "name": "browser_traces",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_message": {
+          "name": "result_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "browser_traces_workspace_started_idx": {
+          "name": "browser_traces_workspace_started_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_traces_membership_fkey": {
+          "name": "browser_traces_membership_fkey",
+          "tableFrom": "browser_traces",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "browser_traces_status_check": {
+          "name": "browser_traces_status_check",
+          "value": "\"browser_traces\".\"status\" IN ('running', 'success', 'failure', 'error', 'cancelled')"
+        },
+        "browser_traces_duration_ms_check": {
+          "name": "browser_traces_duration_ms_check",
+          "value": "\"browser_traces\".\"duration_ms\" IS NULL OR \"browser_traces\".\"duration_ms\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(16, 8)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chats_workspace_updated_idx": {
+          "name": "chats_workspace_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_workspace_id_fkey": {
+          "name": "chats_workspace_id_fkey",
+          "tableFrom": "chats",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chats_input_tokens_check": {
+          "name": "chats_input_tokens_check",
+          "value": "\"chats\".\"input_tokens\" >= 0"
+        },
+        "chats_output_tokens_check": {
+          "name": "chats_output_tokens_check",
+          "value": "\"chats\".\"output_tokens\" >= 0"
+        },
+        "chats_cost_usd_check": {
+          "name": "chats_cost_usd_check",
+          "value": "\"chats\".\"cost_usd\" IS NULL OR \"chats\".\"cost_usd\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scheduled_agent_jobs": {
+      "name": "scheduled_agent_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_channel": {
+          "name": "conversation_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timing": {
+          "name": "timing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missed_run_policy": {
+          "name": "missed_run_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'run_latest'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scheduled_agent_jobs_due_idx": {
+          "name": "scheduled_agent_jobs_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_agent_jobs_owner_idx": {
+          "name": "scheduled_agent_jobs_owner_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_agent_jobs_membership_fkey": {
+          "name": "scheduled_agent_jobs_membership_fkey",
+          "tableFrom": "scheduled_agent_jobs",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scheduled_agent_jobs_conversation_channel_check": {
+          "name": "scheduled_agent_jobs_conversation_channel_check",
+          "value": "\"scheduled_agent_jobs\".\"conversation_channel\" IN ('eve', 'linq')"
+        },
+        "scheduled_agent_jobs_conversation_id_check": {
+          "name": "scheduled_agent_jobs_conversation_id_check",
+          "value": "\"scheduled_agent_jobs\".\"conversation_id\" <> ''"
+        },
+        "scheduled_agent_jobs_missed_run_policy_check": {
+          "name": "scheduled_agent_jobs_missed_run_policy_check",
+          "value": "\"scheduled_agent_jobs\".\"missed_run_policy\" IN ('skip', 'run_latest', 'catch_up')"
+        },
+        "scheduled_agent_jobs_status_check": {
+          "name": "scheduled_agent_jobs_status_check",
+          "value": "\"scheduled_agent_jobs\".\"status\" IN ('active', 'paused', 'completed', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scheduled_agent_runs": {
+      "name": "scheduled_agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "worker_session_id": {
+          "name": "worker_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deferred_completion_turn_id": {
+          "name": "deferred_completion_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_input_requests": {
+          "name": "pending_input_requests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_status": {
+          "name": "report_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_ready'"
+        },
+        "report_sequence": {
+          "name": "report_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_at": {
+          "name": "retry_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_lease_token": {
+          "name": "report_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_lease_expires_at": {
+          "name": "report_lease_expires_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scheduled_agent_runs_occurrence_idx": {
+          "name": "scheduled_agent_runs_occurrence_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_agent_runs_ready_idx": {
+          "name": "scheduled_agent_runs_ready_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_agent_runs_report_idx": {
+          "name": "scheduled_agent_runs_report_idx",
+          "columns": [
+            {
+              "expression": "report_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_agent_runs_job_id_scheduled_agent_jobs_id_fk": {
+          "name": "scheduled_agent_runs_job_id_scheduled_agent_jobs_id_fk",
+          "tableFrom": "scheduled_agent_runs",
+          "tableTo": "scheduled_agent_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scheduled_agent_runs_status_check": {
+          "name": "scheduled_agent_runs_status_check",
+          "value": "\"scheduled_agent_runs\".\"status\" IN ('queued', 'running', 'waiting_for_input', 'completed', 'dead_letter')"
+        },
+        "scheduled_agent_runs_report_status_check": {
+          "name": "scheduled_agent_runs_report_status_check",
+          "value": "\"scheduled_agent_runs\".\"report_status\" IN ('not_ready', 'not_needed', 'pending', 'queued', 'delivered', 'suppressed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_sessions_workspace_idx": {
+          "name": "agent_sessions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_membership_fkey": {
+          "name": "agent_sessions_membership_fkey",
+          "tableFrom": "agent_sessions",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encrypted_secrets": {
+      "name": "encrypted_secrets",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encrypted_secrets_workspace_id_fkey": {
+          "name": "encrypted_secrets_workspace_id_fkey",
+          "tableFrom": "encrypted_secrets",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "encrypted_secrets_pkey": {
+          "name": "encrypted_secrets_pkey",
+          "columns": ["workspace_id", "namespace", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "encrypted_secrets_namespace_check": {
+          "name": "encrypted_secrets_namespace_check",
+          "value": "\"encrypted_secrets\".\"namespace\" = 'vault'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vault_items": {
+      "name": "vault_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vault_items_workspace_updated_idx": {
+          "name": "vault_items_workspace_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vault_items_workspace_id_fkey": {
+          "name": "vault_items_workspace_id_fkey",
+          "tableFrom": "vault_items",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vault_items_kind_check": {
+          "name": "vault_items_kind_check",
+          "value": "\"vault_items\".\"kind\" IN ('login', 'payment', 'address', 'contact', 'phone', 'identity', 'token')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_workspace_id_fkey": {
+          "name": "settings_workspace_id_fkey",
+          "tableFrom": "settings",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_pkey": {
+          "name": "settings_pkey",
+          "columns": ["workspace_id", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "settings_key_check": {
+          "name": "settings_key_check",
+          "value": "\"settings\".\"key\" = 'gateway_model'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_workspace_id_fkey": {
+          "name": "user_profiles_workspace_id_fkey",
+          "tableFrom": "user_profiles",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_profiles_country_code_check": {
+          "name": "user_profiles_country_code_check",
+          "value": "\"user_profiles\".\"country_code\" IS NULL OR char_length(\"user_profiles\".\"country_code\") = 2"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_memberships": {
+      "name": "workspace_memberships",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_memberships_workspace_id_fkey": {
+          "name": "workspace_memberships_workspace_id_fkey",
+          "tableFrom": "workspace_memberships",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_memberships_pkey": {
+          "name": "workspace_memberships_pkey",
+          "columns": ["workspace_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_memberships_role_check": {
+          "name": "workspace_memberships_role_check",
+          "value": "\"workspace_memberships\".\"role\" = 'owner'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1788376857527,
       "tag": "0009_cold_power_man",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1788393204481,
+      "tag": "0010_rapid_cerise",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/schedules.ts
+++ b/db/schema/schedules.ts
@@ -126,6 +126,7 @@ export const scheduledAgentRuns = pgTable(
       .notNull()
       .default("queued"),
     workerSessionId: text("worker_session_id"),
+    deferredCompletionTurnId: text("deferred_completion_turn_id"),
     pendingInputRequests: jsonb("pending_input_requests").$type<
       readonly InputRequest[]
     >(),

--- a/db/services/scheduled-agent-jobs.ts
+++ b/db/services/scheduled-agent-jobs.ts
@@ -1,5 +1,17 @@
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, inArray, isNull, lte, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  lte,
+  ne,
+  or,
+  sql,
+} from "drizzle-orm";
 import { inputRequestSchema, type InputRequest } from "eve/client";
 import type { AccessScope } from "@/lib/access-scope";
 import {
@@ -280,6 +292,7 @@ export async function claimReadyScheduledAgentRuns(options: {
       .update(scheduledAgentRuns)
       .set({
         attempts: sql`${scheduledAgentRuns.attempts} + 1`,
+        deferredCompletionTurnId: null,
         leaseExpiresAt,
         leaseToken,
         retryAt: null,
@@ -384,6 +397,29 @@ export async function waitForScheduledAgentRunInput(
   return run ? parseRun(run) : undefined;
 }
 
+export async function deferScheduledAgentRunCompletion(
+  runId: string,
+  leaseToken: string,
+  turnId: string,
+  now = new Date()
+) {
+  const [run] = await db
+    .update(scheduledAgentRuns)
+    .set({
+      deferredCompletionTurnId: turnId,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(scheduledAgentRuns.id, runId),
+        eq(scheduledAgentRuns.status, "running"),
+        eq(scheduledAgentRuns.leaseToken, leaseToken)
+      )
+    )
+    .returning({ id: scheduledAgentRuns.id });
+  return run !== undefined;
+}
+
 export async function getScheduledAgentRunInput(
   scope: AccessScope,
   conversation: Pick<
@@ -481,6 +517,7 @@ export async function restoreScheduledAgentRunInput(
   await db
     .update(scheduledAgentRuns)
     .set({
+      deferredCompletionTurnId: null,
       lastError: errorMessage.slice(0, 2_000),
       leaseExpiresAt: null,
       status: "waiting_for_input",
@@ -503,6 +540,7 @@ export async function finishScheduledAgentRunInput(
   await db
     .update(scheduledAgentRuns)
     .set({
+      deferredCompletionTurnId: null,
       pendingInputRequests: null,
       lastError: null,
       reportLeaseExpiresAt: null,
@@ -522,13 +560,22 @@ export async function finishScheduledAgentRunInput(
 export async function completeScheduledAgentRun(
   runId: string,
   leaseToken: string,
+  turnId: string,
   outcome: ScheduledRunOutcome,
   completedAt = new Date()
 ) {
+  const completionCondition =
+    outcome.kind === "nothing_to_report"
+      ? isNull(scheduledAgentRuns.deferredCompletionTurnId)
+      : or(
+          isNull(scheduledAgentRuns.deferredCompletionTurnId),
+          ne(scheduledAgentRuns.deferredCompletionTurnId, turnId)
+        );
   const [run] = await db
     .update(scheduledAgentRuns)
     .set({
       completedAt,
+      deferredCompletionTurnId: null,
       pendingInputRequests: null,
       lastError: null,
       leaseExpiresAt: null,
@@ -546,11 +593,25 @@ export async function completeScheduledAgentRun(
     .where(
       and(
         eq(scheduledAgentRuns.id, runId),
-        eq(scheduledAgentRuns.leaseToken, leaseToken)
+        eq(scheduledAgentRuns.status, "running"),
+        eq(scheduledAgentRuns.leaseToken, leaseToken),
+        completionCondition
       )
     )
     .returning();
-  return run ? parseRun(run) : undefined;
+  if (run) return { status: "completed" as const, run: parseRun(run) };
+  const deferred = await db.query.scheduledAgentRuns.findFirst({
+    columns: { id: true },
+    where: and(
+      eq(scheduledAgentRuns.id, runId),
+      eq(scheduledAgentRuns.status, "running"),
+      eq(scheduledAgentRuns.leaseToken, leaseToken),
+      outcome.kind === "nothing_to_report"
+        ? isNotNull(scheduledAgentRuns.deferredCompletionTurnId)
+        : eq(scheduledAgentRuns.deferredCompletionTurnId, turnId)
+    ),
+  });
+  return deferred ? { status: "deferred" as const } : undefined;
 }
 
 export async function releaseScheduledAgentRun(
@@ -570,6 +631,7 @@ export async function releaseScheduledAgentRun(
   const [released] = await db
     .update(scheduledAgentRuns)
     .set({
+      deferredCompletionTurnId: null,
       lastError: errorMessage.slice(0, 2_000),
       leaseExpiresAt: null,
       leaseToken: null,
@@ -629,9 +691,16 @@ export async function listRecoverableScheduledReports(
   limit = 25
 ) {
   return db.transaction(async (transaction) => {
-    const runs = await transaction
-      .select()
+    const reports = await transaction
+      .select({
+        conversationChannel: scheduledAgentJobs.conversationChannel,
+        run: scheduledAgentRuns,
+      })
       .from(scheduledAgentRuns)
+      .innerJoin(
+        scheduledAgentJobs,
+        eq(scheduledAgentRuns.jobId, scheduledAgentJobs.id)
+      )
       .where(
         and(
           inArray(scheduledAgentRuns.status, [
@@ -650,8 +719,10 @@ export async function listRecoverableScheduledReports(
       )
       .orderBy(asc(scheduledAgentRuns.updatedAt))
       .limit(limit)
-      .for("update", { skipLocked: true });
-    const stale = runs.filter((run) => run.reportStatus === "queued");
+      .for("update", { of: scheduledAgentRuns, skipLocked: true });
+    const stale = reports
+      .map(({ run }) => run)
+      .filter((run) => run.reportStatus === "queued");
     if (stale.length > 0) {
       await transaction
         .update(scheduledAgentRuns)
@@ -672,7 +743,10 @@ export async function listRecoverableScheduledReports(
           )
         );
     }
-    return runs.map((run) => run.id);
+    return reports.map(({ conversationChannel, run }) => ({
+      conversationChannel,
+      runId: run.id,
+    }));
   });
 }
 

--- a/db/tests/database-migration.test.ts
+++ b/db/tests/database-migration.test.ts
@@ -36,6 +36,8 @@ describe("database migrations", () => {
       );
     `);
     await applyMigration(database, "0008_black_sandman.sql");
+    await applyMigration(database, "0009_cold_power_man.sql");
+    await applyMigration(database, "0010_rapid_cerise.sql");
 
     const tables = await database.query<{ count: number }>(
       `SELECT count(*)::int AS count

--- a/db/tests/scheduled-agent-jobs.test.ts
+++ b/db/tests/scheduled-agent-jobs.test.ts
@@ -29,6 +29,7 @@ describe("scheduled agent jobs", () => {
       "0007_known_fenris.sql",
       "0008_black_sandman.sql",
       "0009_cold_power_man.sql",
+      "0010_rapid_cerise.sql",
     ]) {
       await applyMigration(client, migration);
     }
@@ -232,7 +233,7 @@ describe("scheduled agent jobs", () => {
       await jobs.listRecoverableScheduledReports(
         new Date("2026-09-01T13:07:00.000Z")
       )
-    ).toEqual([claim.run.id]);
+    ).toEqual([{ conversationChannel: "linq", runId: claim.run.id }]);
     const retriedQuestionReport = await jobs.claimScheduledReport(
       claim.run.id,
       new Date("2026-09-01T13:07:00.000Z")
@@ -316,21 +317,59 @@ describe("scheduled agent jobs", () => {
       claim.run.leaseToken,
       "replacement-worker-session"
     );
+    expect(
+      await jobs.deferScheduledAgentRunCompletion(
+        claim.run.id,
+        claim.run.leaseToken,
+        "turn-1",
+        new Date("2026-09-01T13:01:59.000Z")
+      )
+    ).toBe(true);
+    expect(
+      await jobs.completeScheduledAgentRun(
+        claim.run.id,
+        claim.run.leaseToken,
+        "turn-1",
+        {
+          kind: "result",
+          summary: "Browser research is still running.",
+          urgency: "normal",
+        },
+        new Date("2026-09-01T13:02:00.000Z")
+      )
+    ).toEqual({ status: "deferred" });
+    expect(
+      await jobs.completeScheduledAgentRun(
+        claim.run.id,
+        claim.run.leaseToken,
+        "turn-2",
+        {
+          kind: "nothing_to_report",
+          reason: "Another background task is still running.",
+        },
+        new Date("2026-09-01T13:02:01.000Z")
+      )
+    ).toEqual({ status: "deferred" });
     const completed = await jobs.completeScheduledAgentRun(
       claim.run.id,
       claim.run.leaseToken,
+      "turn-3",
       {
         kind: "result",
         summary: "The price fell to $250.",
         urgency: "normal",
       },
-      new Date("2026-09-01T13:02:00.000Z")
+      new Date("2026-09-01T13:02:02.000Z")
     );
     expect(completed).toMatchObject({
-      reportSequence: 2,
-      reportStatus: "pending",
       status: "completed",
-      workerSessionId: "replacement-worker-session",
+      run: {
+        deferredCompletionTurnId: null,
+        reportSequence: 2,
+        reportStatus: "pending",
+        status: "completed",
+        workerSessionId: "replacement-worker-session",
+      },
     });
     const report = await jobs.claimScheduledReport(claim.run.id, dueAt);
     expect(report).toMatchObject({
@@ -345,7 +384,7 @@ describe("scheduled agent jobs", () => {
         new Date("2026-09-01T13:10:00.000Z")
       ),
     ]);
-    expect(recovered.flat()).toContain(claim.run.id);
+    expect(recovered.flat().map(({ runId }) => runId)).toContain(claim.run.id);
     const competingClaims = await Promise.all([
       jobs.claimScheduledReport(claim.run.id, dueAt),
       jobs.claimScheduledReport(claim.run.id, dueAt),

--- a/tests/agent/hooks/scheduled-run-completion.test.ts
+++ b/tests/agent/hooks/scheduled-run-completion.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HookContext } from "eve/hooks";
 import type {
   completeScheduledAgentRun,
+  deferScheduledAgentRunCompletion,
   markScheduledAgentRunStarted,
   releaseScheduledAgentRun,
   waitForScheduledAgentRunInput,
@@ -9,6 +10,7 @@ import type {
 
 const services = vi.hoisted(() => ({
   complete: vi.fn<typeof completeScheduledAgentRun>(),
+  deferCompletion: vi.fn<typeof deferScheduledAgentRunCompletion>(),
   markStarted: vi.fn<typeof markScheduledAgentRunStarted>(),
   release: vi.fn<typeof releaseScheduledAgentRun>(),
   waitForInput: vi.fn<typeof waitForScheduledAgentRunInput>(),
@@ -16,6 +18,7 @@ const services = vi.hoisted(() => ({
 
 vi.mock("@/db/services/scheduled-agent-jobs", () => ({
   completeScheduledAgentRun: services.complete,
+  deferScheduledAgentRunCompletion: services.deferCompletion,
   markScheduledAgentRunStarted: services.markStarted,
   releaseScheduledAgentRun: services.release,
   waitForScheduledAgentRunInput: services.waitForInput,
@@ -91,8 +94,8 @@ const retriedContext = {
 beforeEach(() => {
   vi.clearAllMocks();
   services.markStarted.mockResolvedValue(true);
+  services.deferCompletion.mockResolvedValue(true);
   services.release.mockResolvedValue("queued");
-  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null)));
 });
 
 describe("scheduled run completion hook", () => {
@@ -139,48 +142,49 @@ describe("scheduled run completion hook", () => {
     );
   });
 
-  it("persists the outcome and immediately wakes report delivery", async () => {
+  it("persists the outcome for durable report delivery", async () => {
     services.complete.mockResolvedValue({
-      attempts: 1,
-      completedAt: new Date("2026-09-01T13:02:00.000Z"),
-      createdAt: new Date("2026-09-01T13:00:00.000Z"),
-      id: runId,
-      pendingInputRequests: null,
-      jobId: "00000000-0000-4000-8000-000000000003",
-      lastError: null,
-      leaseExpiresAt: null,
-      leaseToken: null,
-      outcome: {
-        kind: "result",
-        summary: "The price fell to $250.",
-        urgency: "normal",
-      },
-      reportStatus: "pending",
-      reportSequence: 1,
-      reportLeaseExpiresAt: null,
-      reportLeaseToken: null,
-      retryAt: null,
-      scheduledFor: new Date("2026-09-01T13:00:00.000Z"),
-      startedAt: new Date("2026-09-01T13:00:00.000Z"),
       status: "completed",
-      updatedAt: new Date("2026-09-01T13:02:00.000Z"),
-      workerSessionId: "worker-session",
+      run: {
+        attempts: 1,
+        completedAt: new Date("2026-09-01T13:02:00.000Z"),
+        createdAt: new Date("2026-09-01T13:00:00.000Z"),
+        deferredCompletionTurnId: null,
+        id: runId,
+        pendingInputRequests: null,
+        jobId: "00000000-0000-4000-8000-000000000003",
+        lastError: null,
+        leaseExpiresAt: null,
+        leaseToken: null,
+        outcome: {
+          kind: "result",
+          summary: "The price fell to $250.",
+          urgency: "normal",
+        },
+        reportStatus: "pending",
+        reportSequence: 1,
+        reportLeaseExpiresAt: null,
+        reportLeaseToken: null,
+        retryAt: null,
+        scheduledFor: new Date("2026-09-01T13:00:00.000Z"),
+        startedAt: new Date("2026-09-01T13:00:00.000Z"),
+        status: "completed",
+        updatedAt: new Date("2026-09-01T13:02:00.000Z"),
+        workerSessionId: "worker-session",
+      },
     });
-    const handler = completionHook.events?.["result.completed"];
+    const handler = completionHook.events?.["message.completed"];
     await handler?.(
       {
         data: {
-          result: {
-            kind: "result",
-            summary: "The price fell to $250.",
-            urgency: "normal",
-          },
+          finishReason: "stop",
+          message: "The price fell to $250.",
           sequence: 0,
           stepIndex: 0,
           turnId: "turn-1",
         },
         meta: { at: "2026-09-01T13:02:00.000Z", id: "event-1" },
-        type: "result.completed",
+        type: "message.completed",
       },
       context
     );
@@ -188,6 +192,7 @@ describe("scheduled run completion hook", () => {
     expect(services.complete).toHaveBeenCalledWith(
       runId,
       leaseToken,
+      "turn-1",
       {
         kind: "result",
         summary: "The price fell to $250.",
@@ -195,13 +200,133 @@ describe("scheduled run completion hook", () => {
       },
       new Date("2026-09-01T13:02:00.000Z")
     );
-    expect(fetch).toHaveBeenCalledWith(
-      new URL("https://example.com/internal/scheduled-run/report"),
-      expect.objectContaining({ method: "POST" })
+  });
+
+  it("defers an interim outcome until background work wakes a later turn", async () => {
+    const delegated = completionHook.events?.["subagent.completed"];
+    await delegated?.(
+      {
+        data: {
+          backgroundTask: { status: "working", taskId: "task-1" },
+          callId: "call-1",
+          output: '{"status":"working"}',
+          subagentName: "worker",
+        },
+        meta: { at: "2026-09-01T13:01:00.000Z", id: "event-task" },
+        type: "subagent.completed",
+      },
+      context
+    );
+    services.complete.mockResolvedValue({ status: "deferred" });
+
+    const completed = completionHook.events?.["message.completed"];
+    await completed?.(
+      {
+        data: {
+          finishReason: "stop",
+          message: null,
+          sequence: 0,
+          stepIndex: 1,
+          turnId: "turn-1",
+        },
+        meta: { at: "2026-09-01T13:01:01.000Z", id: "event-interim" },
+        type: "message.completed",
+      },
+      context
+    );
+
+    expect(services.deferCompletion).toHaveBeenCalledExactlyOnceWith(
+      runId,
+      leaseToken,
+      "turn-1",
+      new Date("2026-09-01T13:01:00.000Z")
+    );
+    expect(services.complete).toHaveBeenCalledWith(
+      runId,
+      leaseToken,
+      "turn-1",
+      expect.anything(),
+      new Date("2026-09-01T13:01:01.000Z")
     );
   });
 
-  it("parks the worker and immediately reports a question", async () => {
+  it("ignores messages emitted before a tool call completes", async () => {
+    const completed = completionHook.events?.["message.completed"];
+    await completed?.(
+      {
+        data: {
+          finishReason: "tool-calls",
+          message: "I will check that now.",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        meta: { at: "2026-09-01T13:01:00.000Z", id: "event-tool-text" },
+        type: "message.completed",
+      },
+      context
+    );
+
+    expect(services.complete).not.toHaveBeenCalled();
+  });
+
+  it("retries a non-success model boundary instead of completing it", async () => {
+    const completed = completionHook.events?.["message.completed"];
+    await completed?.(
+      {
+        data: {
+          finishReason: "length",
+          message: "This response was truncated",
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        meta: { at: "2026-09-01T13:01:00.000Z", id: "event-truncated" },
+        type: "message.completed",
+      },
+      context
+    );
+
+    expect(services.complete).not.toHaveBeenCalled();
+    expect(services.release).toHaveBeenCalledExactlyOnceWith(
+      runId,
+      leaseToken,
+      "Scheduled worker stopped with finish reason: length.",
+      new Date("2026-09-01T13:01:00.000Z")
+    );
+  });
+
+  it("bounds a long final handoff before persisting it", async () => {
+    const completed = completionHook.events?.["message.completed"];
+    await completed?.(
+      {
+        data: {
+          finishReason: "stop",
+          message: "a".repeat(4_001),
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn-1",
+        },
+        meta: { at: "2026-09-01T13:01:00.000Z", id: "event-long" },
+        type: "message.completed",
+      },
+      context
+    );
+
+    expect(services.complete).toHaveBeenCalledWith(
+      runId,
+      leaseToken,
+      "turn-1",
+      {
+        kind: "result",
+        summary: "a".repeat(4_000),
+        urgency: "normal",
+      },
+      new Date("2026-09-01T13:01:00.000Z")
+    );
+  });
+
+  it("parks the worker and queues its question for delivery", async () => {
     const request = {
       action: {
         callId: "call-1",
@@ -219,6 +344,7 @@ describe("scheduled run completion hook", () => {
       completedAt: null,
       createdAt: new Date("2026-09-01T13:00:00.000Z"),
       id: runId,
+      deferredCompletionTurnId: null,
       pendingInputRequests: [request],
       jobId: "00000000-0000-4000-8000-000000000003",
       lastError: null,
@@ -256,10 +382,6 @@ describe("scheduled run completion hook", () => {
       leaseToken,
       [request],
       new Date("2026-09-01T13:01:00.000Z")
-    );
-    expect(fetch).toHaveBeenCalledWith(
-      new URL("https://example.com/internal/scheduled-run/report"),
-      expect.objectContaining({ method: "POST" })
     );
   });
 

--- a/tests/agent/schedules/dynamic.test.ts
+++ b/tests/agent/schedules/dynamic.test.ts
@@ -103,15 +103,36 @@ describe("dynamic schedule dispatch", () => {
     });
   });
 
-  it("requests recovery through the report callback", async () => {
+  it("delivers recoverable Linq reports through the schedule channel handle", async () => {
     const report = scheduledReport();
-    services.listReports.mockResolvedValue([report.run.id]);
-    const workerSend = vi.fn<ReturnType<ScheduleToFn>["send"]>();
-    const to = vi.fn<ScheduleToFn>(() => ({ send: workerSend }));
+    services.listReports.mockResolvedValue([
+      { conversationChannel: "linq", runId: report.run.id },
+    ]);
+    services.claimReports.mockResolvedValue(report);
+    const send = vi
+      .fn<ReturnType<ScheduleToFn>["send"]>()
+      .mockResolvedValue(workerSession("main-session"));
+    const to = vi.fn<ScheduleToFn>(() => ({ send }));
 
     await runSchedule(to);
 
-    expect(workerSend).not.toHaveBeenCalled();
+    expect(requests.report).not.toHaveBeenCalled();
+    expect(send.mock.calls[0]?.[1]).toMatchObject({
+      auth: { authenticator: "scheduled-result" },
+      turnPolicy: "queue",
+    });
+  });
+
+  it("keeps Eve debug reports on its active-session callback", async () => {
+    const report = scheduledReport();
+    services.listReports.mockResolvedValue([
+      { conversationChannel: "eve", runId: report.run.id },
+    ]);
+    const to = vi.fn<ScheduleToFn>();
+
+    await runSchedule(to);
+
+    expect(to).not.toHaveBeenCalled();
     expect(requests.report).toHaveBeenCalledExactlyOnceWith(report.run.id);
   });
 
@@ -119,6 +140,14 @@ describe("dynamic schedule dispatch", () => {
     const claim = scheduledClaim();
     services.claimRuns.mockResolvedValue([claim]);
     services.releaseRun.mockResolvedValue("dead_letter");
+    services.claimReports.mockResolvedValue({
+      ...scheduledReport(),
+      job: claim.job,
+      run: {
+        ...scheduledReport().run,
+        id: claim.run.id,
+      },
+    });
     const send = vi
       .fn<ReturnType<ScheduleToFn>["send"]>()
       .mockRejectedValue(new Error("Workflow did not accept the candidate."));
@@ -131,7 +160,8 @@ describe("dynamic schedule dispatch", () => {
       claim.run.leaseToken,
       "Workflow did not accept the candidate."
     );
-    expect(requests.report).toHaveBeenCalledExactlyOnceWith(claim.run.id);
+    expect(requests.report).not.toHaveBeenCalled();
+    expect(services.claimReports).toHaveBeenCalledExactlyOnceWith(claim.run.id);
   });
 });
 
@@ -285,6 +315,7 @@ function scheduledClaim(): Awaited<
       attempts: 1,
       completedAt: null,
       createdAt: new Date("2026-09-02T13:00:00.000Z"),
+      deferredCompletionTurnId: null,
       id: "00000000-0000-4000-8000-000000000002",
       pendingInputRequests: null,
       jobId: "00000000-0000-4000-8000-000000000001",


### PR DESCRIPTION
## What changed

- deliver recovered iMessage reports through Eve's native Linq schedule target instead of a co-deployed custom HTTP route
- let Eve's pending/settled background-task policy control scheduled worker output
- defer completion while background work is pending, then persist and report the settled handoff
- retry non-success model boundaries and keep report delivery idempotent

## Runtime flow

1. The scheduler claims a due run and starts its isolated scheduled-worker session.
2. If it launches background workers, the run records that delegation and ignores launch acknowledgements and pending-task silence.
3. Eve wakes the same session when the background cohort settles; the final handoff completes the durable run.
4. A later scheduler tick claims the report and sends it to the stored iMessage thread through `to(linq, { threadId })`.
5. `send_message` delivery finalizes the report using the existing stable idempotency key.

## Validation

- `pnpm check` (73 files, 332 tests)
- `pnpm build`
- `pnpm build:eve`
- `pnpm db:check`
- local scheduler smoke test: due run claimed, completed, report recovered, and native Linq report session accepted