### PR TITLE
Handle profile memory cancellation during steering

### DIFF
--- a/agent/lib/profile-memory.ts
+++ b/agent/lib/profile-memory.ts
@@ -1,4 +1,10 @@
-import type { MemoryScopeContext } from "eve/memory";
+import {
+  defineMemoryProvider,
+  type MemoryOperationContext,
+  type MemoryProvider,
+  type MemoryRecallHandler,
+  type MemoryScopeContext,
+} from "eve/memory";
 import { z } from "zod";
 import type { env } from "@/env";
 import { resolveModeValue } from "@/agent/lib/mode";
@@ -40,4 +46,32 @@ export function resolveProfileMemoryScope(context: MemoryScopeContext) {
     interactive: scope,
     "scheduled-worker": scope,
   });
+}
+
+export function preserveProfileMemoryCancellation(provider: MemoryProvider) {
+  const compactionRecall = provider.recall["compaction.completed"];
+  return defineMemoryProvider({
+    ...provider,
+    recall: {
+      "turn.started": (context) =>
+        recallWithCancellationReason(provider.recall["turn.started"], context),
+      "compaction.completed": (context) =>
+        compactionRecall
+          ? recallWithCancellationReason(compactionRecall, context)
+          : undefined,
+    },
+  });
+}
+
+async function recallWithCancellationReason<
+  Context extends MemoryOperationContext,
+>(handler: MemoryRecallHandler<Context>, context: Context) {
+  try {
+    return await handler(context);
+  } catch (error) {
+    if (context.abortSignal.aborted) {
+      context.abortSignal.throwIfAborted();
+    }
+    throw error;
+  }
 }

--- a/agent/lib/tests/profile-memory.test.ts
+++ b/agent/lib/tests/profile-memory.test.ts
@@ -1,7 +1,13 @@
-import type { MemoryScopeContext, MemoryToolsContext } from "eve/memory";
+import {
+  defineMemoryProvider,
+  type MemoryScopeContext,
+  type MemoryTurnStartedContext,
+  type MemoryToolsContext,
+} from "eve/memory";
 import { describe, expect, it } from "vitest";
 import personalInfoMemory from "@/agent/memory/personal_info";
 import {
+  preserveProfileMemoryCancellation,
   resolveProfileMemoryBackend,
   resolveProfileMemoryScope,
 } from "@/agent/lib/profile-memory";
@@ -115,7 +121,87 @@ describe("profile memory", () => {
     );
     expect(scheduledTools).toBeNull();
   });
+
+  it("preserves the turn cancellation reason when recall loses it", async () => {
+    const blobAbort = new DOMException(
+      "This operation was aborted",
+      "AbortError"
+    );
+    const cancellation = Object.assign(new Error("The turn was cancelled."), {
+      name: "TurnCancelledError",
+    });
+    const controller = new AbortController();
+    controller.abort(cancellation);
+    const provider = preserveProfileMemoryCancellation(
+      defineMemoryProvider({
+        recall: {
+          async "turn.started"() {
+            throw blobAbort;
+          },
+        },
+      })
+    );
+
+    await expect(
+      provider.recall["turn.started"](memoryOperationContext(controller.signal))
+    ).rejects.toBe(cancellation);
+  });
+
+  it("does not hide a recall failure while the turn remains active", async () => {
+    const blobAbort = new DOMException(
+      "This operation was aborted",
+      "AbortError"
+    );
+    const provider = preserveProfileMemoryCancellation(
+      defineMemoryProvider({
+        recall: {
+          async "turn.started"() {
+            throw blobAbort;
+          },
+        },
+      })
+    );
+
+    await expect(
+      provider.recall["turn.started"](
+        memoryOperationContext(new AbortController().signal)
+      )
+    ).rejects.toBe(blobAbort);
+  });
 });
+
+function memoryOperationContext(
+  abortSignal: AbortSignal
+): MemoryTurnStartedContext {
+  return {
+    abortSignal,
+    async getSandbox() {
+      throw new Error("Sandbox access is outside this focused test.");
+    },
+    getSkill() {
+      throw new Error("Skill access is outside this focused test.");
+    },
+    memory: {
+      scope: {
+        key: "personal-info-key",
+        namespace: "openinstinct-profile-memory-v1",
+        value: "personal:workspace",
+      },
+      slot: "profile",
+    },
+    messages: [],
+    operationId: "memory-operation",
+    session: {
+      auth: {
+        current: userPrincipal("authjs", "personal:workspace"),
+        initiator: null,
+      },
+      id: "session",
+      turn: { id: "turn", sequence: 1 },
+    },
+    turn: { id: "turn", input: [], sequence: 1 },
+  };
+}
 
 function memoryToolsContext(
   current: MemoryToolsContext["session"]["auth"]["current"],

--- a/agent/memory/profile.ts
+++ b/agent/memory/profile.ts
@@ -2,18 +2,20 @@ import { defineMemory } from "eve/memory";
 import { fileMemory } from "eve/memory/file";
 import { vercelBlob } from "eve/memory/file/vercel";
 import {
+  preserveProfileMemoryCancellation,
   resolveProfileMemoryBackend,
   resolveProfileMemoryScope,
 } from "../lib/profile-memory";
 import { env } from "@/env";
 
 const backend = resolveProfileMemoryBackend(env);
-const provider =
+const provider = preserveProfileMemoryCancellation(
   backend.kind === "vercel-blob"
     ? fileMemory({
         backend: vercelBlob(backend.options),
       })
-    : fileMemory();
+    : fileMemory()
+);
 
 export default defineMemory({
   description: "Remember stable facts and preferences about the current user.",


### PR DESCRIPTION
## Summary

- wrap the profile `fileMemory()` provider through Eve's public `MemoryProvider` contract
- restore the turn's canonical cancellation reason when a delegated recall fails after its supplied signal is aborted
- preserve ordinary recall failures and the provider's tools, capture, and compaction behavior

## Why

Linq can deliver message text and its link as adjacent messages. Eve's default steering correctly cancels the incomplete first turn, but a Vercel Blob recall can surface that cancellation as a generic `AbortError`. That lost cancellation identity caused Eve to treat the turn as a terminal session failure.

This keeps Eve's native steering behavior and fixes the OpenInstinct-owned profile-memory boundary without changing or patching Eve itself.

## Validation

- `pnpm exec vitest run agent/lib/tests/profile-memory.test.ts`
- `pnpm check` — 74 test files, 344 tests
- `pnpm build`
- `pnpm build:eve`
- `git diff --check`

## Review focus

- cancellation reason replacement only occurs after recall throws and the supplied `AbortSignal` is actually aborted
- active-turn recall failures remain unchanged
