### PR TITLE
Fix chat history session indexing

### DIFF
--- a/agent/hooks/session-owner.ts
+++ b/agent/hooks/session-owner.ts
@@ -1,5 +1,4 @@
 import { defineHook } from "eve/hooks";
-import type { ChatChannel } from "@/lib/chat";
 import { saveChat } from "@/db/services/chats";
 import { ensureScope } from "@/db/services/scope";
 import { claimSession } from "@/db/services/sessions";
@@ -20,15 +19,9 @@ export default defineHook({
       if (!initiator) return;
 
       await saveChat(scopeFromPrincipal(initiator), {
-        channel: chatChannel(ctx.channel.kind),
+        channel: ctx.channel.kind,
         sessionId: ctx.session.id,
       });
     },
   },
 });
-
-function chatChannel(kind: string | undefined): ChatChannel | undefined {
-  if (kind === "channel:linq") return "linq";
-  if (kind === "http") return "eve";
-  return undefined;
-}

--- a/agent/hooks/session-owner.ts
+++ b/agent/hooks/session-owner.ts
@@ -1,4 +1,5 @@
 import { defineHook } from "eve/hooks";
+import type { ChatChannel } from "@/lib/chat";
 import { saveChat } from "@/db/services/chats";
 import { ensureScope } from "@/db/services/scope";
 import { claimSession } from "@/db/services/sessions";
@@ -19,8 +20,15 @@ export default defineHook({
       if (!initiator) return;
 
       await saveChat(scopeFromPrincipal(initiator), {
+        channel: chatChannel(ctx.channel.kind),
         sessionId: ctx.session.id,
       });
     },
   },
 });
+
+function chatChannel(kind: string | undefined): ChatChannel | undefined {
+  if (kind === "channel:linq") return "linq";
+  if (kind === "http") return "eve";
+  return undefined;
+}

--- a/db/migrations/0011_faulty_unicorn.sql
+++ b/db/migrations/0011_faulty_unicorn.sql
@@ -1,2 +1,1 @@
-ALTER TABLE "chats" ADD COLUMN "channel" text;--> statement-breakpoint
-ALTER TABLE "chats" ADD CONSTRAINT "chats_channel_check" CHECK ("chats"."channel" IS NULL OR "chats"."channel" IN ('eve', 'linq'));
+ALTER TABLE "chats" ADD COLUMN "channel" text;

--- a/db/migrations/0011_faulty_unicorn.sql
+++ b/db/migrations/0011_faulty_unicorn.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "chats" ADD COLUMN "channel" text;--> statement-breakpoint
+ALTER TABLE "chats" ADD CONSTRAINT "chats_channel_check" CHECK ("chats"."channel" IS NULL OR "chats"."channel" IN ('eve', 'linq'));

--- a/db/migrations/meta/0011_snapshot.json
+++ b/db/migrations/meta/0011_snapshot.json
@@ -1028,10 +1028,6 @@
         "chats_cost_usd_check": {
           "name": "chats_cost_usd_check",
           "value": "\"chats\".\"cost_usd\" IS NULL OR \"chats\".\"cost_usd\" >= 0"
-        },
-        "chats_channel_check": {
-          "name": "chats_channel_check",
-          "value": "\"chats\".\"channel\" IS NULL OR \"chats\".\"channel\" IN ('eve', 'linq')"
         }
       },
       "isRLSEnabled": false

--- a/db/migrations/meta/0011_snapshot.json
+++ b/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1947 @@
+{
+  "id": "c4d701c1-3269-4972-b750-3f136b83f5b9",
+  "prevId": "6a5f5899-87c7-4f9b-8c6b-d33aef5f9198",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_issuer_accountId_uidx": {
+          "name": "account_issuer_accountId_uidx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "phoneNumber": {
+          "name": "phoneNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phoneNumberVerified": {
+          "name": "phoneNumberVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_phoneNumber_unique": {
+          "name": "user_phoneNumber_unique",
+          "nullsNotDistinct": false,
+          "columns": ["phoneNumber"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_image_artifacts": {
+      "name": "browser_image_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_session_id": {
+          "name": "worker_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_pathname": {
+          "name": "storage_pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "browser_image_artifacts_workspace_idempotency_uidx": {
+          "name": "browser_image_artifacts_workspace_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "browser_image_artifacts_workspace_created_idx": {
+          "name": "browser_image_artifacts_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_image_artifacts_membership_fkey": {
+          "name": "browser_image_artifacts_membership_fkey",
+          "tableFrom": "browser_image_artifacts",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "browser_image_artifacts_status_check": {
+          "name": "browser_image_artifacts_status_check",
+          "value": "\"browser_image_artifacts\".\"status\" IN ('pending', 'ready')"
+        },
+        "browser_image_artifacts_source_kind_check": {
+          "name": "browser_image_artifacts_source_kind_check",
+          "value": "\"browser_image_artifacts\".\"source_kind\" IN ('element', 'full_page', 'image_resource', 'viewport')"
+        },
+        "browser_image_artifacts_ready_fields_check": {
+          "name": "browser_image_artifacts_ready_fields_check",
+          "value": "\"browser_image_artifacts\".\"status\" = 'pending' OR (\"browser_image_artifacts\".\"filename\" IS NOT NULL AND \"browser_image_artifacts\".\"media_type\" IS NOT NULL AND \"browser_image_artifacts\".\"byte_size\" > 0 AND \"browser_image_artifacts\".\"content_hash\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.browser_sessions": {
+      "name": "browser_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "worker_session_id": {
+          "name": "worker_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "browser_sessions_workspace_idx": {
+          "name": "browser_sessions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "browser_sessions_worker_idx": {
+          "name": "browser_sessions_worker_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "worker_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_sessions_membership_fkey": {
+          "name": "browser_sessions_membership_fkey",
+          "tableFrom": "browser_sessions",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_trace_domains": {
+      "name": "browser_trace_domains",
+      "schema": "",
+      "columns": {
+        "trace_session_id": {
+          "name": "trace_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "browser_trace_domains_domain_idx": {
+          "name": "browser_trace_domains_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_trace_domains_trace_fkey": {
+          "name": "browser_trace_domains_trace_fkey",
+          "tableFrom": "browser_trace_domains",
+          "tableTo": "browser_traces",
+          "columnsFrom": ["trace_session_id"],
+          "columnsTo": ["session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "browser_trace_domains_pkey": {
+          "name": "browser_trace_domains_pkey",
+          "columns": ["trace_session_id", "domain"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_trace_events": {
+      "name": "browser_trace_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trace_session_id": {
+          "name": "trace_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "browser_trace_events_trace_idx": {
+          "name": "browser_trace_events_trace_idx",
+          "columns": [
+            {
+              "expression": "trace_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_trace_events_trace_fkey": {
+          "name": "browser_trace_events_trace_fkey",
+          "tableFrom": "browser_trace_events",
+          "tableTo": "browser_traces",
+          "columnsFrom": ["trace_session_id"],
+          "columnsTo": ["session_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_traces": {
+      "name": "browser_traces",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_message": {
+          "name": "result_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "browser_traces_workspace_started_idx": {
+          "name": "browser_traces_workspace_started_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browser_traces_membership_fkey": {
+          "name": "browser_traces_membership_fkey",
+          "tableFrom": "browser_traces",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "browser_traces_status_check": {
+          "name": "browser_traces_status_check",
+          "value": "\"browser_traces\".\"status\" IN ('running', 'success', 'failure', 'error', 'cancelled')"
+        },
+        "browser_traces_duration_ms_check": {
+          "name": "browser_traces_duration_ms_check",
+          "value": "\"browser_traces\".\"duration_ms\" IS NULL OR \"browser_traces\".\"duration_ms\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(16, 8)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chats_workspace_updated_idx": {
+          "name": "chats_workspace_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_workspace_id_fkey": {
+          "name": "chats_workspace_id_fkey",
+          "tableFrom": "chats",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chats_input_tokens_check": {
+          "name": "chats_input_tokens_check",
+          "value": "\"chats\".\"input_tokens\" >= 0"
+        },
+        "chats_output_tokens_check": {
+          "name": "chats_output_tokens_check",
+          "value": "\"chats\".\"output_tokens\" >= 0"
+        },
+        "chats_cost_usd_check": {
+          "name": "chats_cost_usd_check",
+          "value": "\"chats\".\"cost_usd\" IS NULL OR \"chats\".\"cost_usd\" >= 0"
+        },
+        "chats_channel_check": {
+          "name": "chats_channel_check",
+          "value": "\"chats\".\"channel\" IS NULL OR \"chats\".\"channel\" IN ('eve', 'linq')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scheduled_agent_jobs": {
+      "name": "scheduled_agent_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_channel": {
+          "name": "conversation_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timing": {
+          "name": "timing",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "missed_run_policy": {
+          "name": "missed_run_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'run_latest'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scheduled_agent_jobs_due_idx": {
+          "name": "scheduled_agent_jobs_due_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_agent_jobs_owner_idx": {
+          "name": "scheduled_agent_jobs_owner_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_agent_jobs_membership_fkey": {
+          "name": "scheduled_agent_jobs_membership_fkey",
+          "tableFrom": "scheduled_agent_jobs",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scheduled_agent_jobs_conversation_channel_check": {
+          "name": "scheduled_agent_jobs_conversation_channel_check",
+          "value": "\"scheduled_agent_jobs\".\"conversation_channel\" IN ('eve', 'linq')"
+        },
+        "scheduled_agent_jobs_conversation_id_check": {
+          "name": "scheduled_agent_jobs_conversation_id_check",
+          "value": "\"scheduled_agent_jobs\".\"conversation_id\" <> ''"
+        },
+        "scheduled_agent_jobs_missed_run_policy_check": {
+          "name": "scheduled_agent_jobs_missed_run_policy_check",
+          "value": "\"scheduled_agent_jobs\".\"missed_run_policy\" IN ('skip', 'run_latest', 'catch_up')"
+        },
+        "scheduled_agent_jobs_status_check": {
+          "name": "scheduled_agent_jobs_status_check",
+          "value": "\"scheduled_agent_jobs\".\"status\" IN ('active', 'paused', 'completed', 'deleted')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scheduled_agent_runs": {
+      "name": "scheduled_agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "worker_session_id": {
+          "name": "worker_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deferred_completion_turn_id": {
+          "name": "deferred_completion_turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_input_requests": {
+          "name": "pending_input_requests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_status": {
+          "name": "report_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_ready'"
+        },
+        "report_sequence": {
+          "name": "report_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_at": {
+          "name": "retry_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_lease_token": {
+          "name": "report_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_lease_expires_at": {
+          "name": "report_lease_expires_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scheduled_agent_runs_occurrence_idx": {
+          "name": "scheduled_agent_runs_occurrence_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_agent_runs_ready_idx": {
+          "name": "scheduled_agent_runs_ready_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_agent_runs_report_idx": {
+          "name": "scheduled_agent_runs_report_idx",
+          "columns": [
+            {
+              "expression": "report_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_agent_runs_job_id_scheduled_agent_jobs_id_fk": {
+          "name": "scheduled_agent_runs_job_id_scheduled_agent_jobs_id_fk",
+          "tableFrom": "scheduled_agent_runs",
+          "tableTo": "scheduled_agent_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scheduled_agent_runs_status_check": {
+          "name": "scheduled_agent_runs_status_check",
+          "value": "\"scheduled_agent_runs\".\"status\" IN ('queued', 'running', 'waiting_for_input', 'completed', 'dead_letter')"
+        },
+        "scheduled_agent_runs_report_status_check": {
+          "name": "scheduled_agent_runs_report_status_check",
+          "value": "\"scheduled_agent_runs\".\"report_status\" IN ('not_ready', 'not_needed', 'pending', 'queued', 'delivered', 'suppressed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_sessions_workspace_idx": {
+          "name": "agent_sessions_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_membership_fkey": {
+          "name": "agent_sessions_membership_fkey",
+          "tableFrom": "agent_sessions",
+          "tableTo": "workspace_memberships",
+          "columnsFrom": ["workspace_id", "created_by_user_id"],
+          "columnsTo": ["workspace_id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.encrypted_secrets": {
+      "name": "encrypted_secrets",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "encrypted_secrets_workspace_id_fkey": {
+          "name": "encrypted_secrets_workspace_id_fkey",
+          "tableFrom": "encrypted_secrets",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "encrypted_secrets_pkey": {
+          "name": "encrypted_secrets_pkey",
+          "columns": ["workspace_id", "namespace", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "encrypted_secrets_namespace_check": {
+          "name": "encrypted_secrets_namespace_check",
+          "value": "\"encrypted_secrets\".\"namespace\" = 'vault'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vault_items": {
+      "name": "vault_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vault_items_workspace_updated_idx": {
+          "name": "vault_items_workspace_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vault_items_workspace_id_fkey": {
+          "name": "vault_items_workspace_id_fkey",
+          "tableFrom": "vault_items",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vault_items_kind_check": {
+          "name": "vault_items_kind_check",
+          "value": "\"vault_items\".\"kind\" IN ('login', 'payment', 'address', 'contact', 'phone', 'identity', 'token')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_workspace_id_fkey": {
+          "name": "settings_workspace_id_fkey",
+          "tableFrom": "settings",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "settings_pkey": {
+          "name": "settings_pkey",
+          "columns": ["workspace_id", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "settings_key_check": {
+          "name": "settings_key_check",
+          "value": "\"settings\".\"key\" = 'gateway_model'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_1": {
+          "name": "address_line_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line_2": {
+          "name": "address_line_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_workspace_id_fkey": {
+          "name": "user_profiles_workspace_id_fkey",
+          "tableFrom": "user_profiles",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_profiles_country_code_check": {
+          "name": "user_profiles_country_code_check",
+          "value": "\"user_profiles\".\"country_code\" IS NULL OR char_length(\"user_profiles\".\"country_code\") = 2"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspace_memberships": {
+      "name": "workspace_memberships",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_memberships_workspace_id_fkey": {
+          "name": "workspace_memberships_workspace_id_fkey",
+          "tableFrom": "workspace_memberships",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_memberships_pkey": {
+          "name": "workspace_memberships_pkey",
+          "columns": ["workspace_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workspace_memberships_role_check": {
+          "name": "workspace_memberships_role_check",
+          "value": "\"workspace_memberships\".\"role\" = 'owner'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1788393204481,
       "tag": "0010_rapid_cerise",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1788449992663,
+      "tag": "0011_faulty_unicorn",
+      "breakpoints": true
     }
   ]
 }

--- a/db/schema/chats.ts
+++ b/db/schema/chats.ts
@@ -9,7 +9,6 @@ import {
   text,
   timestamp,
 } from "drizzle-orm/pg-core";
-import { chatChannels } from "@/lib/chat";
 import { workspaces } from "./workspaces";
 
 export const chats = pgTable(
@@ -17,7 +16,7 @@ export const chats = pgTable(
   {
     sessionId: text("session_id").primaryKey(),
     workspaceId: text("workspace_id").notNull(),
-    channel: text("channel", { enum: chatChannels }),
+    channel: text("channel"),
     title: text("title").notNull(),
     createdAt: timestamp("created_at", {
       mode: "date",
@@ -52,10 +51,6 @@ export const chats = pgTable(
     check(
       "chats_cost_usd_check",
       sql`${table.costUsd} IS NULL OR ${table.costUsd} >= 0`
-    ),
-    check(
-      "chats_channel_check",
-      sql`${table.channel} IS NULL OR ${table.channel} IN ('eve', 'linq')`
     ),
     index("chats_workspace_updated_idx").on(
       table.workspaceId,

--- a/db/schema/chats.ts
+++ b/db/schema/chats.ts
@@ -9,6 +9,7 @@ import {
   text,
   timestamp,
 } from "drizzle-orm/pg-core";
+import { chatChannels } from "@/lib/chat";
 import { workspaces } from "./workspaces";
 
 export const chats = pgTable(
@@ -16,6 +17,7 @@ export const chats = pgTable(
   {
     sessionId: text("session_id").primaryKey(),
     workspaceId: text("workspace_id").notNull(),
+    channel: text("channel", { enum: chatChannels }),
     title: text("title").notNull(),
     createdAt: timestamp("created_at", {
       mode: "date",
@@ -50,6 +52,10 @@ export const chats = pgTable(
     check(
       "chats_cost_usd_check",
       sql`${table.costUsd} IS NULL OR ${table.costUsd} >= 0`
+    ),
+    check(
+      "chats_channel_check",
+      sql`${table.channel} IS NULL OR ${table.channel} IN ('eve', 'linq')`
     ),
     index("chats_workspace_updated_idx").on(
       table.workspaceId,

--- a/db/services/chats.ts
+++ b/db/services/chats.ts
@@ -1,19 +1,13 @@
 import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import type { AccessScope } from "@/lib/access-scope";
-import {
-  chatChannels,
-  chatListSchema,
-  type ChatChannel,
-  type ChatSummary,
-  type SaveChat,
-} from "@/lib/chat";
+import { chatListSchema, type ChatSummary, type SaveChat } from "@/lib/chat";
 import { chats, db } from "@/db";
 import { ensureScope } from "./scope";
 import { waitForSessionOwnership } from "./sessions";
 
 const chatRowSchema = z.object({
-  channel: z.enum(chatChannels).nullable(),
+  channel: z.string().min(1).nullable(),
   costUsd: z.number().nonnegative().nullable(),
   createdAt: z.coerce.date(),
   inputTokens: z.number().int().nonnegative(),
@@ -64,7 +58,7 @@ export async function readChat(scope: AccessScope, sessionId: string) {
 
 export async function saveChat(
   scope: AccessScope,
-  chat: SaveChat & { readonly channel?: ChatChannel }
+  chat: SaveChat & { readonly channel?: string }
 ) {
   // A session outside this workspace is indistinguishable from an unknown one.
   if (!(await waitForSessionOwnership(scope, chat.sessionId))) return;

--- a/db/services/chats.ts
+++ b/db/services/chats.ts
@@ -1,12 +1,19 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import type { AccessScope } from "@/lib/access-scope";
-import { chatListSchema, type ChatSummary, type SaveChat } from "@/lib/chat";
-import { agentSessions, chats, db } from "@/db";
+import {
+  chatChannels,
+  chatListSchema,
+  type ChatChannel,
+  type ChatSummary,
+  type SaveChat,
+} from "@/lib/chat";
+import { chats, db } from "@/db";
 import { ensureScope } from "./scope";
 import { waitForSessionOwnership } from "./sessions";
 
 const chatRowSchema = z.object({
+  channel: z.enum(chatChannels).nullable(),
   costUsd: z.number().nonnegative().nullable(),
   createdAt: z.coerce.date(),
   inputTokens: z.number().int().nonnegative(),
@@ -28,23 +35,15 @@ function toChatSummary(row: z.infer<typeof chatRowSchema>): ChatSummary {
 }
 
 export async function listChats(scope: AccessScope) {
-  const updatedAt = sql<Date>`coalesce(${chats.updatedAt}, ${agentSessions.createdAt})`;
-  const rows = chatRowSchema.array().parse(
-    await db
-      .select({
-        costUsd: chats.costUsd,
-        createdAt: sql<Date>`coalesce(${chats.createdAt}, ${agentSessions.createdAt})`,
-        inputTokens: sql<number>`coalesce(${chats.inputTokens}, 0)`,
-        outputTokens: sql<number>`coalesce(${chats.outputTokens}, 0)`,
-        sessionId: agentSessions.sessionId,
-        title: sql<string>`coalesce(${chats.title}, 'New chat')`,
-        updatedAt,
-      })
-      .from(agentSessions)
-      .leftJoin(chats, eq(chats.sessionId, agentSessions.sessionId))
-      .where(eq(agentSessions.workspaceId, scope.workspaceId))
-      .orderBy(desc(updatedAt))
-  );
+  const rows = chatRowSchema
+    .array()
+    .parse(
+      await db
+        .select()
+        .from(chats)
+        .where(eq(chats.workspaceId, scope.workspaceId))
+        .orderBy(desc(chats.updatedAt))
+    );
   return chatListSchema.parse(rows.map(toChatSummary));
 }
 
@@ -63,7 +62,10 @@ export async function readChat(scope: AccessScope, sessionId: string) {
   return row ? toChatSummary(row) : undefined;
 }
 
-export async function saveChat(scope: AccessScope, chat: SaveChat) {
+export async function saveChat(
+  scope: AccessScope,
+  chat: SaveChat & { readonly channel?: ChatChannel }
+) {
   // A session outside this workspace is indistinguishable from an unknown one.
   if (!(await waitForSessionOwnership(scope, chat.sessionId))) return;
   await ensureScope(scope);
@@ -79,6 +81,7 @@ export async function saveChat(scope: AccessScope, chat: SaveChat) {
     );
   if (existing.length === 0) {
     await db.insert(chats).values({
+      channel: chat.channel ?? null,
       costUsd: chat.usage?.costUsd ?? null,
       createdAt: now,
       inputTokens: chat.usage?.inputTokens ?? 0,
@@ -91,6 +94,7 @@ export async function saveChat(scope: AccessScope, chat: SaveChat) {
     return;
   }
   const updates: Partial<typeof chats.$inferInsert> = { updatedAt: now };
+  if (chat.channel !== undefined) updates.channel = chat.channel;
   if (chat.title !== undefined) updates.title = chat.title;
   if (chat.usage !== undefined) {
     updates.costUsd = chat.usage.costUsd;

--- a/db/tests/database-migration.test.ts
+++ b/db/tests/database-migration.test.ts
@@ -38,6 +38,7 @@ describe("database migrations", () => {
     await applyMigration(database, "0008_black_sandman.sql");
     await applyMigration(database, "0009_cold_power_man.sql");
     await applyMigration(database, "0010_rapid_cerise.sql");
+    await applyMigration(database, "0011_faulty_unicorn.sql");
 
     const tables = await database.query<{ count: number }>(
       `SELECT count(*)::int AS count

--- a/db/tests/services.test.ts
+++ b/db/tests/services.test.ts
@@ -150,7 +150,7 @@ describe("database services", () => {
     expect(await sessions.isSessionOwned(bob, "session-alice")).toBe(false);
 
     await chats.saveChat(alice, {
-      channel: "eve",
+      channel: "http",
       sessionId: "session-alice",
       title: "Initial title",
       usage: { costUsd: 0.25, inputTokens: 10, outputTokens: 4 },
@@ -160,13 +160,13 @@ describe("database services", () => {
       title: "Updated title",
     });
     await chats.saveChat(alice, {
-      channel: "linq",
+      channel: "channel:linq",
       sessionId: "session-imessage",
     });
 
     const aliceChat = await chats.readChat(alice, "session-alice");
     expect(aliceChat?.title).toBe("Updated title");
-    expect(aliceChat?.channel).toBe("eve");
+    expect(aliceChat?.channel).toBe("http");
     expect(aliceChat?.usage).toEqual({
       costUsd: 0.25,
       inputTokens: 10,
@@ -180,7 +180,7 @@ describe("database services", () => {
     ).toEqual(aliceChat);
     expect(
       indexedChats.find((chat) => chat.sessionId === "session-imessage")
-    ).toMatchObject({ channel: "linq", title: "New chat" });
+    ).toMatchObject({ channel: "channel:linq", title: "New chat" });
     expect(await chats.listChats(bob)).toEqual([]);
 
     await chats.saveChat(bob, {

--- a/db/tests/services.test.ts
+++ b/db/tests/services.test.ts
@@ -28,6 +28,7 @@ describe("database services", () => {
     await applyBrowserTraceEventMigration(client);
     await applySchemaAdoptionMigration(client);
     await applyNativeTypesMigration(client);
+    await applyChatChannelMigration(client);
 
     const pgliteDatabase = drizzle(client, { schema });
     // SAFETY: PGlite implements the query-builder surface exercised by these services despite using a different Drizzle driver.
@@ -142,38 +143,14 @@ describe("database services", () => {
     expect(await sessions.isSessionOwned(bob, "session-alice")).toBe(false);
 
     await sessions.claimSession(alice, "session-imessage");
-    const unindexedChats = (await chats.listChats(alice)).toSorted(
-      (left, right) => left.sessionId.localeCompare(right.sessionId)
-    );
-    expect(
-      unindexedChats.map(({ sessionId, title, usage }) => ({
-        sessionId,
-        title,
-        usage,
-      }))
-    ).toEqual([
-      {
-        sessionId: "session-alice",
-        title: "New chat",
-        usage: { costUsd: null, inputTokens: 0, outputTokens: 0 },
-      },
-      {
-        sessionId: "session-imessage",
-        title: "New chat",
-        usage: { costUsd: null, inputTokens: 0, outputTokens: 0 },
-      },
-    ]);
-    expect(
-      unindexedChats.every(
-        (chat) => chat.createdAt.length > 0 && chat.updatedAt.length > 0
-      )
-    ).toBe(true);
+    expect(await chats.listChats(alice)).toEqual([]);
 
     await sessions.claimSession(bob, "session-alice");
     expect(await sessions.isSessionOwned(alice, "session-alice")).toBe(true);
     expect(await sessions.isSessionOwned(bob, "session-alice")).toBe(false);
 
     await chats.saveChat(alice, {
+      channel: "eve",
       sessionId: "session-alice",
       title: "Initial title",
       usage: { costUsd: 0.25, inputTokens: 10, outputTokens: 4 },
@@ -182,9 +159,14 @@ describe("database services", () => {
       sessionId: "session-alice",
       title: "Updated title",
     });
+    await chats.saveChat(alice, {
+      channel: "linq",
+      sessionId: "session-imessage",
+    });
 
     const aliceChat = await chats.readChat(alice, "session-alice");
     expect(aliceChat?.title).toBe("Updated title");
+    expect(aliceChat?.channel).toBe("eve");
     expect(aliceChat?.usage).toEqual({
       costUsd: 0.25,
       inputTokens: 10,
@@ -196,9 +178,9 @@ describe("database services", () => {
     expect(
       indexedChats.find((chat) => chat.sessionId === "session-alice")
     ).toEqual(aliceChat);
-    expect(indexedChats.map((chat) => chat.sessionId)).toContain(
-      "session-imessage"
-    );
+    expect(
+      indexedChats.find((chat) => chat.sessionId === "session-imessage")
+    ).toMatchObject({ channel: "linq", title: "New chat" });
     expect(await chats.listChats(bob)).toEqual([]);
 
     await chats.saveChat(bob, {
@@ -424,6 +406,18 @@ async function applySchemaAdoptionMigration(database: PGlite) {
 async function applyNativeTypesMigration(database: PGlite) {
   const migration = await readFile(
     new URL("../migrations/0008_black_sandman.sql", import.meta.url),
+    "utf8"
+  );
+  /* oxlint-disable eslint/no-await-in-loop -- SQL migration statements must execute in file order. */
+  for (const statement of migration.split("--> statement-breakpoint")) {
+    if (statement.trim()) await database.exec(statement);
+  }
+  /* oxlint-enable eslint/no-await-in-loop */
+}
+
+async function applyChatChannelMigration(database: PGlite) {
+  const migration = await readFile(
+    new URL("../migrations/0011_faulty_unicorn.sql", import.meta.url),
     "utf8"
   );
   /* oxlint-disable eslint/no-await-in-loop -- SQL migration statements must execute in file order. */

--- a/src/app/(authenticated)/chat/history/page.tsx
+++ b/src/app/(authenticated)/chat/history/page.tsx
@@ -17,7 +17,7 @@ export default async function AllChatsPage() {
   const chats = await listChats(scope);
   const totalUsage = combineChatUsage(chats.map((chat) => chat.usage));
   const imessageSessionId = chats.find(
-    (chat) => chat.channel === "linq"
+    (chat) => chat.channel === "channel:linq"
   )?.sessionId;
 
   return (

--- a/src/app/(authenticated)/chat/history/page.tsx
+++ b/src/app/(authenticated)/chat/history/page.tsx
@@ -8,7 +8,6 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { listChats } from "@/db/services/chats";
-import type { ChatSummary } from "@/lib/chat";
 import { requireRequestScope } from "@/lib/request-scope";
 
 export const dynamic = "force-dynamic";
@@ -17,7 +16,9 @@ export default async function AllChatsPage() {
   const scope = await requireRequestScope();
   const chats = await listChats(scope);
   const totalUsage = combineChatUsage(chats.map((chat) => chat.usage));
-  const imessageSessionId = mainImessageSessionId(chats);
+  const imessageSessionId = chats.find(
+    (chat) => chat.channel === "linq"
+  )?.sessionId;
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-8 px-4 py-6 sm:px-6 sm:py-8">
@@ -79,17 +80,6 @@ export default async function AllChatsPage() {
       </section>
     </div>
   );
-}
-
-function mainImessageSessionId(chats: readonly ChatSummary[]) {
-  const indexed = chats.find((chat) => chat.channel === "linq");
-  if (indexed) return indexed.sessionId;
-
-  // iMessage chats created before channel provenance was persisted used the
-  // server-side fallback title. Web chats replace it with the first prompt.
-  return chats.find(
-    (chat) => chat.channel === null && chat.title === "New chat"
-  )?.sessionId;
 }
 
 function formatChatDate(value: string) {

--- a/src/app/(authenticated)/chat/history/page.tsx
+++ b/src/app/(authenticated)/chat/history/page.tsx
@@ -5,8 +5,10 @@ import {
   formatChatUsage,
 } from "@/app/(authenticated)/chat/_lib/chat-usage";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { listChats } from "@/db/services/chats";
+import type { ChatSummary } from "@/lib/chat";
 import { requireRequestScope } from "@/lib/request-scope";
 
 export const dynamic = "force-dynamic";
@@ -15,6 +17,7 @@ export default async function AllChatsPage() {
   const scope = await requireRequestScope();
   const chats = await listChats(scope);
   const totalUsage = combineChatUsage(chats.map((chat) => chat.usage));
+  const imessageSessionId = mainImessageSessionId(chats);
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-8 px-4 py-6 sm:px-6 sm:py-8">
@@ -48,8 +51,19 @@ export default async function AllChatsPage() {
               }
               variant="surface"
             >
-              <MessageSquareIcon className="size-4 shrink-0 text-muted-foreground" />
-              <span className="min-w-0 flex-1 truncate">{chat.title}</span>
+              <MessageSquareIcon
+                className={
+                  chat.sessionId === imessageSessionId
+                    ? "size-4 shrink-0 text-information"
+                    : "size-4 shrink-0 text-muted-foreground"
+                }
+              />
+              <span className="min-w-0 flex-1 truncate">
+                {chat.sessionId === imessageSessionId ? "iMessage" : chat.title}
+              </span>
+              {chat.sessionId === imessageSessionId ? (
+                <Badge variant="information">Main thread</Badge>
+              ) : null}
               <span className="shrink-0 type-label text-muted-foreground">
                 {formatChatUsage(chat.usage)}
               </span>
@@ -65,6 +79,17 @@ export default async function AllChatsPage() {
       </section>
     </div>
   );
+}
+
+function mainImessageSessionId(chats: readonly ChatSummary[]) {
+  const indexed = chats.find((chat) => chat.channel === "linq");
+  if (indexed) return indexed.sessionId;
+
+  // iMessage chats created before channel provenance was persisted used the
+  // server-side fallback title. Web chats replace it with the first prompt.
+  return chats.find(
+    (chat) => chat.channel === null && chat.title === "New chat"
+  )?.sessionId;
 }
 
 function formatChatDate(value: string) {

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-export const chatChannels = ["eve", "linq"] as const;
-
 const chatUsageSchema = z.object({
   costUsd: z.number().nonnegative().nullable(),
   inputTokens: z.number().int().nonnegative(),
@@ -9,7 +7,7 @@ const chatUsageSchema = z.object({
 });
 
 const chatSummarySchema = z.object({
-  channel: z.enum(chatChannels).nullable(),
+  channel: z.string().min(1).nullable(),
   createdAt: z.string(),
   sessionId: z.string().min(1),
   title: z.string().min(1),
@@ -26,6 +24,5 @@ export const saveChatSchema = z.object({
 });
 
 export type ChatUsage = z.infer<typeof chatUsageSchema>;
-export type ChatChannel = (typeof chatChannels)[number];
 export type ChatSummary = z.infer<typeof chatSummarySchema>;
 export type SaveChat = z.infer<typeof saveChatSchema>;

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+export const chatChannels = ["eve", "linq"] as const;
+
 const chatUsageSchema = z.object({
   costUsd: z.number().nonnegative().nullable(),
   inputTokens: z.number().int().nonnegative(),
@@ -7,6 +9,7 @@ const chatUsageSchema = z.object({
 });
 
 const chatSummarySchema = z.object({
+  channel: z.enum(chatChannels).nullable(),
   createdAt: z.string(),
   sessionId: z.string().min(1),
   title: z.string().min(1),
@@ -23,5 +26,6 @@ export const saveChatSchema = z.object({
 });
 
 export type ChatUsage = z.infer<typeof chatUsageSchema>;
+export type ChatChannel = (typeof chatChannels)[number];
 export type ChatSummary = z.infer<typeof chatSummarySchema>;
 export type SaveChat = z.infer<typeof saveChatSchema>;

--- a/tests/agent/hooks/session-owner.test.ts
+++ b/tests/agent/hooks/session-owner.test.ts
@@ -16,7 +16,7 @@ type MessageReceivedHandler = NonNullable<
 const scope = { userId: "user-1", workspaceId: "workspace-1" };
 const context = {
   agent: { name: "test-agent" },
-  channel: {},
+  channel: { kind: "channel:linq" },
   async getSandbox() {
     throw new Error("Sandbox access is outside this focused test.");
   },
@@ -59,6 +59,28 @@ describe("session ownership hook", () => {
     await handler?.(event, context);
 
     expect(mocks.saveChat).toHaveBeenCalledWith(scope, {
+      channel: "linq",
+      sessionId: "session-1",
+    });
+  });
+
+  it("records the web channel for HTTP messages", async () => {
+    const handler = sessionOwner.events?.["message.received"];
+    const event = {
+      data: { message: "hello", sequence: 0, turnId: "turn-1" },
+      meta: {
+        at: "2026-08-31T00:00:00.000Z",
+        id: "event-1",
+      },
+      type: "message.received",
+    } satisfies Parameters<MessageReceivedHandler>[0];
+    await handler?.(event, {
+      ...context,
+      channel: { kind: "http" },
+    });
+
+    expect(mocks.saveChat).toHaveBeenCalledWith(scope, {
+      channel: "eve",
       sessionId: "session-1",
     });
   });

--- a/tests/agent/hooks/session-owner.test.ts
+++ b/tests/agent/hooks/session-owner.test.ts
@@ -59,7 +59,7 @@ describe("session ownership hook", () => {
     await handler?.(event, context);
 
     expect(mocks.saveChat).toHaveBeenCalledWith(scope, {
-      channel: "linq",
+      channel: "channel:linq",
       sessionId: "session-1",
     });
   });
@@ -80,7 +80,7 @@ describe("session ownership hook", () => {
     });
 
     expect(mocks.saveChat).toHaveBeenCalledWith(scope, {
-      channel: "eve",
+      channel: "http",
       sessionId: "session-1",
     });
   });


### PR DESCRIPTION
## Summary

- hide unindexed worker sessions from chat history
- persist the originating Eve channel kind as opaque text, so future channels need no schema change
- label the latest explicitly indexed `channel:linq` conversation as the iMessage main thread
- add the nullable chat channel migration and coverage

Existing rows are left nullable and are not guessed or backfilled; the next inbound message records the channel for the active thread.

## Verification

- `pnpm exec vitest run --exclude ".claude/**"` (356 tests)
- `pnpm build`
- `DATABASE_URL_UNPOOLED=postgresql://user:pass@localhost:5432/eve_kernel pnpm db:check`
- local browser verification: iMessage badge rendered and unindexed worker session stayed hidden