### PR TITLE
Load chat history progressively

### DIFF
--- a/src/app/(authenticated)/chat/[sessionId]/_components/activity/card.tsx
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/activity/card.tsx
@@ -83,9 +83,10 @@ export function ActivityCard({
                 {sessions.map((session) => {
                   const status =
                     statuses.get(session.childSessionId) ?? "starting";
-                  const task = getSubagentTask(
-                    eventsBySession.get(session.childSessionId) ?? []
-                  );
+                  const task =
+                    getSubagentTask(
+                      eventsBySession.get(session.childSessionId) ?? []
+                    ) ?? session.task;
                   return (
                     <Button
                       aria-label={`${agentLabel(session.name)} task, ${status}`}
@@ -103,7 +104,7 @@ export function ActivityCard({
                           {agentLabel(session.name)}
                         </span>
                         <span className="block truncate type-caption text-muted-foreground">
-                          {task ?? "Waiting for assignment"}
+                          {task ?? "Open to load task details"}
                         </span>
                       </span>
                       <StatusIndicator status={status} />

--- a/src/app/(authenticated)/chat/[sessionId]/_components/activity/index.tsx
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/activity/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Client, type MessageStreamEvent } from "eve/client";
+import type { MessageStreamEvent } from "eve/client";
 import { ListTreeIcon } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -14,7 +14,6 @@ import {
 import {
   collectSubagentSessions,
   getSubagentStatus,
-  getSubagentSubscriptionKey,
 } from "@/app/_lib/subagent-sessions";
 import type { ChatUsage } from "@/lib/chat";
 import { cn } from "@/lib/utils";
@@ -23,103 +22,34 @@ import { ActivityCard } from "./card";
 import { TracePreview } from "./preview";
 import { useChatUsage } from "./use-chat-usage";
 
-const client = new Client({ host: "" });
+const emptyEventsBySession = new Map<string, readonly MessageStreamEvent[]>();
 
 export function SubagentPanel({
   events,
+  historyComplete,
   initialUsage,
   onTraceViewChange,
   sessionId,
   traceView,
 }: {
   readonly events: readonly MessageStreamEvent[];
+  readonly historyComplete: boolean;
   readonly initialUsage?: ChatUsage;
   readonly onTraceViewChange: (view: TraceView) => void;
   readonly sessionId?: string;
   readonly traceView: TraceView;
 }) {
-  const [eventsBySession, setEventsBySession] = useState<
-    ReadonlyMap<string, readonly MessageStreamEvent[]>
-  >(new Map());
-  const [streamErrors, setStreamErrors] = useState<ReadonlyMap<string, string>>(
-    new Map()
-  );
   const [selectedId, setSelectedId] = useState<string>();
   const [mobileOpen, setMobileOpen] = useState(false);
   const traceCloseButton = useRef<HTMLButtonElement>(null);
   const restoreFocusId = useRef<string | undefined>(undefined);
   const sessions = useMemo(() => collectSubagentSessions(events), [events]);
-  const usage = useChatUsage({ events, initialUsage, sessionId });
-  const subscriptionKey = getSubagentSubscriptionKey(sessions);
-
-  useEffect(() => {
-    if (!subscriptionKey) return undefined;
-    const controllers = subscriptionKey.split("\n").map((subscription) => {
-      const [encodedSessionId] = subscription.split(":");
-      const childSessionId = decodeURIComponent(encodedSessionId ?? "");
-      const controller = new AbortController();
-      const child = client.sessions.attach(childSessionId);
-
-      void (async () => {
-        try {
-          const snapshot = await child.snapshot({ signal: controller.signal });
-          if (controller.signal.aborted) return;
-
-          setStreamErrors((current) => {
-            if (!current.has(childSessionId)) return current;
-            const next = new Map(current);
-            next.delete(childSessionId);
-            return next;
-          });
-          setEventsBySession((current) => {
-            const next = new Map(current);
-            next.set(childSessionId, snapshot.events);
-            return next;
-          });
-
-          const liveChild = client.sessions.attach(childSessionId, {
-            streamIndex: snapshot.session.streamIndex,
-          });
-          for await (const event of liveChild.stream({
-            signal: controller.signal,
-          })) {
-            setEventsBySession((current) => {
-              const sessionEvents = current.get(childSessionId) ?? [];
-              if (
-                sessionEvents.some(
-                  (candidate) => candidate.meta.id === event.meta.id
-                )
-              ) {
-                return current;
-              }
-              const next = new Map(current);
-              next.set(childSessionId, [...sessionEvents, event]);
-              return next;
-            });
-          }
-        } catch (error) {
-          if (!controller.signal.aborted) {
-            setStreamErrors((current) => {
-              const next = new Map(current);
-              next.set(
-                childSessionId,
-                error instanceof Error
-                  ? error.message
-                  : "The task stream disconnected."
-              );
-              return next;
-            });
-          }
-        }
-      })();
-
-      return controller;
-    });
-
-    return () => {
-      for (const controller of controllers) controller.abort();
-    };
-  }, [subscriptionKey]);
+  const usage = useChatUsage({
+    events,
+    historyComplete,
+    initialUsage,
+    sessionId,
+  });
 
   useEffect(() => {
     if (!window.matchMedia("(min-width: 48rem)").matches) return undefined;
@@ -160,13 +90,10 @@ export function SubagentPanel({
       new Map(
         sessions.map((session) => [
           session.childSessionId,
-          getSubagentStatus(
-            eventsBySession.get(session.childSessionId) ?? [],
-            session
-          ),
+          getSubagentStatus([], session),
         ])
       ),
-    [eventsBySession, sessions]
+    [sessions]
   );
   const workingCount = [...statuses.values()].filter((status) =>
     ["starting", "working"].includes(status)
@@ -182,7 +109,7 @@ export function SubagentPanel({
   const activity = (
     <ActivityCard
       doneCount={doneCount}
-      eventsBySession={eventsBySession}
+      eventsBySession={emptyEventsBySession}
       onSelect={openTask}
       onTraceViewChange={onTraceViewChange}
       sessions={sessions}
@@ -244,12 +171,10 @@ export function SubagentPanel({
         >
           {selected ? (
             <TracePreview
-              events={eventsBySession.get(selected.childSessionId) ?? []}
               closeButtonRef={traceCloseButton}
+              key={selected.childSessionId}
               onClose={closeTask}
               session={selected}
-              status={statuses.get(selected.childSessionId) ?? "starting"}
-              streamError={streamErrors.get(selected.childSessionId)}
             />
           ) : null}
         </div>
@@ -278,11 +203,9 @@ export function SubagentPanel({
           </SheetHeader>
           {selected ? (
             <TracePreview
-              events={eventsBySession.get(selected.childSessionId) ?? []}
+              key={selected.childSessionId}
               onClose={closeTask}
               session={selected}
-              status={statuses.get(selected.childSessionId) ?? "starting"}
-              streamError={streamErrors.get(selected.childSessionId)}
             />
           ) : (
             activity

--- a/src/app/(authenticated)/chat/[sessionId]/_components/activity/preview.tsx
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/activity/preview.tsx
@@ -1,29 +1,26 @@
-import type { MessageStreamEvent } from "eve/client";
 import { SparklesIcon, XIcon } from "lucide-react";
 import type { RefObject } from "react";
-import type {
-  SubagentSession,
-  SubagentStatus,
+import {
+  getSubagentStatus,
+  type SubagentSession,
 } from "@/app/_lib/subagent-sessions";
 import { Button } from "@/components/ui/button";
 import { agentLabel } from "./presentation";
 import { SubagentTrace } from "./trace";
+import { useSessionHistory } from "./use-session-history";
 
 export function TracePreview({
   closeButtonRef,
-  events,
   onClose,
   session,
-  status,
-  streamError,
 }: {
   readonly closeButtonRef?: RefObject<HTMLButtonElement | null>;
-  readonly events: readonly MessageStreamEvent[];
   readonly onClose: () => void;
   readonly session: SubagentSession;
-  readonly status: SubagentStatus;
-  readonly streamError?: string;
 }) {
+  const history = useSessionHistory(session.childSessionId);
+  const status = getSubagentStatus(history.events, session);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <header className="flex h-14 shrink-0 items-center gap-3 border-b px-4">
@@ -49,9 +46,13 @@ export function TracePreview({
       </header>
       <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-6 sm:px-6">
         <SubagentTrace
-          events={events}
+          events={history.events}
+          hasOlder={history.hasOlder}
+          isLoading={history.isLoading}
+          isLoadingOlder={history.isLoadingOlder}
+          loadOlder={history.loadOlder}
           status={status}
-          streamError={streamError}
+          streamError={history.error}
           target={session}
         />
       </div>

--- a/src/app/(authenticated)/chat/[sessionId]/_components/activity/trace.tsx
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/activity/trace.tsx
@@ -5,7 +5,7 @@ import {
   type MessageStreamEvent,
   type SubagentCalledStreamEvent,
 } from "eve/client";
-import { BotIcon } from "lucide-react";
+import { BotIcon, LoaderCircleIcon } from "lucide-react";
 import { useMemo } from "react";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import {
@@ -15,6 +15,7 @@ import {
   AlertTitle,
 } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { getLatestTurnFailure } from "../../_lib/turn-failure";
 import { messageTimestamps } from "../../_lib/message-events";
 import type { SubagentStatus } from "@/app/_lib/subagent-sessions";
@@ -24,11 +25,19 @@ const messageReducer = defaultMessageReducer();
 
 export function SubagentTrace({
   events,
+  hasOlder,
+  isLoading,
+  isLoadingOlder,
+  loadOlder,
   streamError,
   status,
   target,
 }: {
   readonly events: readonly MessageStreamEvent[];
+  readonly hasOlder: boolean;
+  readonly isLoading: boolean;
+  readonly isLoadingOlder: boolean;
+  readonly loadOlder: () => Promise<void>;
   readonly streamError?: string;
   readonly status: SubagentStatus;
   readonly target: SubagentCalledStreamEvent["data"];
@@ -67,6 +76,21 @@ export function SubagentTrace({
         </AlertAction>
       </Alert>
       <div className="space-y-5 py-5">
+        {hasOlder ? (
+          <Button
+            className="mx-auto flex"
+            disabled={isLoadingOlder}
+            onClick={() => void loadOlder()}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            {isLoadingOlder ? (
+              <LoaderCircleIcon className="animate-spin" />
+            ) : null}
+            {isLoadingOlder ? "Loading…" : "Load older messages"}
+          </Button>
+        ) : null}
         {data.messages.map((message, index) => (
           <AgentMessage
             canRespond={false}
@@ -77,7 +101,7 @@ export function SubagentTrace({
             timestamp={timestamps.get(message.id)}
           />
         ))}
-        {isRunning && data.messages.length === 0 ? (
+        {(isLoading || isRunning) && data.messages.length === 0 ? (
           <Shimmer className="type-supporting-body" duration={1}>
             Loading task trace
           </Shimmer>

--- a/src/app/(authenticated)/chat/[sessionId]/_components/activity/use-chat-usage.ts
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/activity/use-chat-usage.ts
@@ -6,10 +6,12 @@ import { api } from "@/trpc/client";
 
 export function useChatUsage({
   events,
+  historyComplete,
   initialUsage,
   sessionId,
 }: {
   readonly events: readonly MessageStreamEvent[];
+  readonly historyComplete: boolean;
   readonly initialUsage?: ChatUsage;
   readonly sessionId?: string;
 }) {
@@ -28,13 +30,19 @@ export function useChatUsage({
   )?.meta.id;
 
   useEffect(() => {
-    if (sessionId === undefined || latestTerminalTurnId === undefined) return;
+    if (
+      !historyComplete ||
+      sessionId === undefined ||
+      latestTerminalTurnId === undefined
+    ) {
+      return;
+    }
 
     const terminalTurn = `${sessionId}:${latestTerminalTurnId}`;
     if (persistedTurn.current === terminalTurn) return;
     persistedTurn.current = terminalTurn;
     saveChat({ sessionId, usage });
-  }, [latestTerminalTurnId, saveChat, sessionId, usage]);
+  }, [historyComplete, latestTerminalTurnId, saveChat, sessionId, usage]);
 
   return usage;
 }

--- a/src/app/(authenticated)/chat/[sessionId]/_components/activity/use-session-history.ts
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/activity/use-session-history.ts
@@ -1,0 +1,128 @@
+"use client";
+
+import {
+  Client,
+  isCurrentTurnBoundaryEvent,
+  type MessageStreamEvent,
+} from "eve/client";
+import { useEffect, useRef, useState } from "react";
+import {
+  readLatestSessionHistory,
+  readOlderSessionHistory,
+  type SessionHistoryPage,
+} from "../../_lib/session-history";
+
+const client = new Client({ host: "" });
+
+export function useSessionHistory(sessionId: string) {
+  const [history, setHistory] = useState<SessionHistoryPage>();
+  const [error, setError] = useState<string>();
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  const historyRef = useRef(history);
+
+  useEffect(() => {
+    historyRef.current = history;
+  }, [history]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void readLatestSessionHistory(sessionId, controller.signal)
+      .then(async (latest) => {
+        if (controller.signal.aborted) return undefined;
+        historyRef.current = latest;
+        setHistory(latest);
+
+        const tail = latest.events.at(-1);
+        if (!tail || isCurrentTurnBoundaryEvent(tail)) return undefined;
+
+        const session = client.sessions.attach(sessionId, {
+          streamIndex: latest.endIndex,
+        });
+        let nextIndex = latest.endIndex;
+        for await (const event of session.stream({
+          signal: controller.signal,
+          startIndex: nextIndex,
+        })) {
+          nextIndex += 1;
+          appendEvent(setHistory, event, nextIndex);
+          if (isCurrentTurnBoundaryEvent(event)) break;
+        }
+        return undefined;
+      })
+      .catch((cause: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : "The task stream disconnected."
+          );
+        }
+        return undefined;
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [sessionId]);
+
+  const loadOlder = async () => {
+    const current = historyRef.current;
+    if (!current || current.startIndex === 0 || isLoadingOlder) return;
+    setIsLoadingOlder(true);
+    try {
+      const older = await readOlderSessionHistory(
+        sessionId,
+        current.startIndex
+      );
+      setHistory((latest) =>
+        latest
+          ? {
+              ...latest,
+              events: [...older.events, ...latest.events],
+              startIndex: older.startIndex,
+            }
+          : latest
+      );
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Unable to load older task messages."
+      );
+    } finally {
+      setIsLoadingOlder(false);
+    }
+  };
+
+  return {
+    error,
+    events: history?.events ?? [],
+    hasOlder: (history?.startIndex ?? 0) > 0,
+    isLoading: history === undefined && error === undefined,
+    isLoadingOlder,
+    loadOlder,
+  };
+}
+
+function appendEvent(
+  setHistory: React.Dispatch<
+    React.SetStateAction<SessionHistoryPage | undefined>
+  >,
+  event: MessageStreamEvent,
+  endIndex: number
+) {
+  setHistory((current) => {
+    if (!current) return current;
+    if (
+      current.events.some((candidate) => candidate.meta.id === event.meta.id)
+    ) {
+      return { ...current, endIndex };
+    }
+    return {
+      ...current,
+      endIndex,
+      events: [...current.events, event],
+    };
+  });
+}

--- a/src/app/(authenticated)/chat/[sessionId]/_components/chat-agent.ts
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/chat-agent.ts
@@ -1,3 +1,29 @@
-import type { EveMessageData, UseEveAgentHelpers } from "eve/react";
+import type {
+  CancelSessionResult,
+  InputResponse,
+  MessageStreamEvent,
+  RespondTurnOptions,
+  SendTurnOptions,
+} from "eve/client";
+import type { EveMessageData, UseEveAgentStatus } from "eve/react";
+import type { UserContent } from "ai";
 
-export type ChatAgent = UseEveAgentHelpers<EveMessageData>;
+export interface ChatAgent {
+  readonly cancel: () => Promise<CancelSessionResult>;
+  readonly data: EveMessageData;
+  readonly error?: Error;
+  readonly events: readonly MessageStreamEvent[];
+  readonly hasOlder: boolean;
+  readonly isLoadingOlder: boolean;
+  readonly loadOlder: () => Promise<void>;
+  readonly respond: <TOutput = unknown>(
+    inputResponses: readonly InputResponse[],
+    options?: RespondTurnOptions<TOutput>
+  ) => Promise<void>;
+  readonly resume: () => Promise<void>;
+  readonly send: <TOutput = unknown>(
+    message: string | UserContent,
+    options?: SendTurnOptions<TOutput>
+  ) => Promise<void>;
+  readonly status: UseEveAgentStatus;
+}

--- a/src/app/(authenticated)/chat/[sessionId]/_components/chat-session.test.tsx
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/chat-session.test.tsx
@@ -1,28 +1,37 @@
-import type { useEveAgent } from "eve/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
-type AgentOptions = Parameters<typeof useEveAgent>[0];
-
 interface Mocks {
   activityEvents: readonly unknown[] | undefined;
-  agent: { events: readonly unknown[]; send: Mock<() => Promise<void>> };
+  agent: {
+    events: readonly unknown[];
+    hasOlder: boolean;
+    isLoadingOlder: boolean;
+    loadOlder: Mock<() => Promise<void>>;
+    send: Mock<() => Promise<void>>;
+  };
   conversationAgent: unknown;
   inputAgent: unknown;
-  options: AgentOptions | undefined;
+  sessionId: string | undefined;
 }
 
 const mocks = vi.hoisted<Mocks>(() => ({
   activityEvents: undefined,
-  agent: { events: [], send: vi.fn<() => Promise<void>>() },
+  agent: {
+    events: [],
+    hasOlder: true,
+    isLoadingOlder: false,
+    loadOlder: vi.fn<() => Promise<void>>(),
+    send: vi.fn<() => Promise<void>>(),
+  },
   conversationAgent: undefined,
   inputAgent: undefined,
-  options: undefined,
+  sessionId: undefined,
 }));
 
-vi.mock("eve/react", () => ({
-  useEveAgent: (options: AgentOptions) => {
-    mocks.options = options;
+vi.mock("./use-session-agent", () => ({
+  useSessionAgent: (sessionId: string) => {
+    mocks.sessionId = sessionId;
     return mocks.agent;
   },
 }));
@@ -53,13 +62,14 @@ import { ChatSession } from "./chat-session";
 describe("chat session", () => {
   beforeEach(() => {
     mocks.activityEvents = undefined;
+    mocks.agent.loadOlder.mockReset().mockResolvedValue(undefined);
     mocks.agent.send.mockReset().mockResolvedValue(undefined);
     mocks.conversationAgent = undefined;
     mocks.inputAgent = undefined;
-    mocks.options = undefined;
+    mocks.sessionId = undefined;
   });
 
-  it("resumes the routed session without resubmitting its first prompt", () => {
+  it("loads the routed session through the paginated agent", () => {
     const markup = renderToStaticMarkup(
       <ChatSession
         initialUsage={{ costUsd: null, inputTokens: 3, outputTokens: 2 }}
@@ -67,10 +77,7 @@ describe("chat session", () => {
       />
     );
 
-    expect(mocks.options).toMatchObject({
-      initialSession: { sessionId: "session/one", streamIndex: 0 },
-      resume: true,
-    });
+    expect(mocks.sessionId).toBe("session/one");
     expect(mocks.agent.send).not.toHaveBeenCalled();
     expect(mocks.conversationAgent).toBe(mocks.agent);
     expect(mocks.inputAgent).toBe(mocks.agent);

--- a/src/app/(authenticated)/chat/[sessionId]/_components/chat-session.tsx
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/chat-session.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEveAgent } from "eve/react";
 import { useState } from "react";
 import type { ChatUsage } from "@/lib/chat";
 import type { TraceView } from "../_lib/trace-view";
 import { SubagentPanel } from "./activity";
 import { ChatConversation } from "./conversation";
 import { ChatInput } from "./input";
+import { useSessionAgent } from "./use-session-agent";
 
 export function ChatSession({
   initialUsage,
@@ -16,10 +16,7 @@ export function ChatSession({
   readonly sessionId: string;
 }) {
   const [traceView, setTraceView] = useState<TraceView>("imessage");
-  const agent = useEveAgent({
-    initialSession: { sessionId, streamIndex: 0 },
-    resume: true,
-  });
+  const agent = useSessionAgent(sessionId);
 
   return (
     <div className="relative flex h-full min-h-0 overflow-hidden bg-background text-foreground">
@@ -27,6 +24,11 @@ export function ChatSession({
         <ChatConversation
           agent={agent}
           initial={false}
+          history={{
+            hasOlder: agent.hasOlder,
+            isLoadingOlder: agent.isLoadingOlder,
+            loadOlder: agent.loadOlder,
+          }}
           sessionId={sessionId}
           traceView={traceView}
         />
@@ -34,6 +36,7 @@ export function ChatSession({
       </div>
       <SubagentPanel
         events={agent.events}
+        historyComplete={!agent.hasOlder}
         initialUsage={initialUsage}
         onTraceViewChange={setTraceView}
         sessionId={sessionId}

--- a/src/app/(authenticated)/chat/[sessionId]/_components/conversation/index.tsx
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/conversation/index.tsx
@@ -1,4 +1,4 @@
-import { AlertCircleIcon, BrainIcon } from "lucide-react";
+import { AlertCircleIcon, BrainIcon, LoaderCircleIcon } from "lucide-react";
 import { Fragment, useMemo } from "react";
 import {
   imessageTimestamps,
@@ -15,11 +15,13 @@ import {
 import { Message, MessageContent } from "@/components/ai-elements/message";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { AgentMessage } from "./message";
 import type { ChatAgent } from "../chat-agent";
 
 export function ChatConversation({
   agent,
+  history,
   initial,
   sessionId,
   traceView,
@@ -28,6 +30,11 @@ export function ChatConversation({
     ChatAgent,
     "data" | "error" | "events" | "respond" | "status"
   >;
+  readonly history?: {
+    readonly hasOlder: boolean;
+    readonly isLoadingOlder: boolean;
+    readonly loadOlder: () => Promise<void>;
+  };
   readonly initial?: false;
   readonly sessionId?: string;
   readonly traceView: TraceView;
@@ -79,6 +86,26 @@ export function ChatConversation({
       }
     >
       <ConversationContent className="mx-auto w-full max-w-3xl gap-6 px-4 pt-6 pb-36 sm:px-6">
+        {history?.hasOlder ? (
+          <Button
+            className="self-center"
+            disabled={history.isLoadingOlder}
+            onClick={() => void history.loadOlder()}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            {history.isLoadingOlder ? (
+              <LoaderCircleIcon className="animate-spin" />
+            ) : null}
+            {history.isLoadingOlder ? "Loading…" : "Load older messages"}
+          </Button>
+        ) : null}
+        {isRestoring && messages.length === 0 ? (
+          <Shimmer className="type-supporting-body self-center" duration={1}>
+            Loading recent messages
+          </Shimmer>
+        ) : null}
         {messages.map((message, index) => {
           if (showPendingThinking && message.id === pendingAssistantMessageId) {
             return null;

--- a/src/app/(authenticated)/chat/[sessionId]/_components/use-session-agent.ts
+++ b/src/app/(authenticated)/chat/[sessionId]/_components/use-session-agent.ts
@@ -1,0 +1,303 @@
+"use client";
+
+import {
+  Client,
+  defaultMessageReducer,
+  isCurrentTurnBoundaryEvent,
+  type InputResponse,
+  type MessageStreamEvent,
+  type RespondTurnOptions,
+  type SendTurnOptions,
+} from "eve/client";
+import type { EveMessageData, UseEveAgentStatus } from "eve/react";
+import type { UserContent } from "ai";
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  readLatestSessionHistory,
+  readOlderSessionHistory,
+  type SessionHistoryPage,
+} from "../_lib/session-history";
+import type { ChatAgent } from "./chat-agent";
+
+const client = new Client({ host: "" });
+const messageReducer = defaultMessageReducer();
+
+export function useSessionAgent(sessionId: string): ChatAgent {
+  const [history, setHistory] = useState<SessionHistoryPage>();
+  const [status, setStatus] = useState<UseEveAgentStatus>("resuming");
+  const [error, setError] = useState<Error>();
+  const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+  const historyRef = useRef(history);
+  const operationRef = useRef<Promise<void> | undefined>(undefined);
+
+  useEffect(() => {
+    historyRef.current = history;
+  }, [history]);
+
+  const followActiveTurn = useCallback(
+    async (startIndex: number, signal?: AbortSignal) => {
+      const session = client.sessions.attach(sessionId, {
+        streamIndex: startIndex,
+      });
+      let nextIndex = startIndex;
+      for await (const event of session.stream({ signal, startIndex })) {
+        nextIndex += 1;
+        appendSessionEvent(historyRef, setHistory, event, nextIndex);
+        setStatus("streaming");
+        if (isCurrentTurnBoundaryEvent(event)) break;
+      }
+    },
+    [sessionId]
+  );
+
+  const catchUp = useCallback(
+    async (signal?: AbortSignal) => {
+      const current = historyRef.current;
+      if (!current) return;
+
+      const session = client.sessions.attach(sessionId, {
+        streamIndex: current.endIndex,
+      });
+      let nextIndex = current.endIndex;
+      let latest = current.events.at(-1);
+      for await (const event of session.stream({
+        follow: false,
+        signal,
+        startIndex: nextIndex,
+      })) {
+        nextIndex += 1;
+        latest = event;
+        appendSessionEvent(historyRef, setHistory, event, nextIndex);
+      }
+
+      if (latest && !isCurrentTurnBoundaryEvent(latest)) {
+        await followActiveTurn(nextIndex, signal);
+      }
+    },
+    [followActiveTurn, sessionId]
+  );
+
+  const runOperation = useCallback((operation: () => Promise<void>) => {
+    const activeOperation = operationRef.current;
+    if (activeOperation) return activeOperation;
+    const promise = operation().finally(() => {
+      if (operationRef.current === promise) operationRef.current = undefined;
+    });
+    operationRef.current = promise;
+    return promise;
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void readLatestSessionHistory(sessionId, controller.signal)
+      .then(async (latest) => {
+        if (controller.signal.aborted) return undefined;
+        historyRef.current = latest;
+        setHistory(latest);
+        const tail = latest.events.at(-1);
+        if (tail && !isCurrentTurnBoundaryEvent(tail)) {
+          setStatus("streaming");
+          await runOperation(async () => {
+            await followActiveTurn(latest.endIndex, controller.signal);
+          });
+        }
+        setStatus("ready");
+        return undefined;
+      })
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return undefined;
+        setError(toError(cause));
+        setStatus("error");
+        return undefined;
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [followActiveTurn, runOperation, sessionId]);
+
+  const resume = useCallback(
+    () =>
+      runOperation(async () => {
+        setStatus("resuming");
+        setError(undefined);
+        try {
+          await catchUp();
+          setStatus("ready");
+        } catch (cause) {
+          setError(toError(cause));
+          setStatus("error");
+        }
+      }),
+    [catchUp, runOperation]
+  );
+
+  const send = useCallback(
+    async <TOutput>(
+      message: string | UserContent,
+      options?: SendTurnOptions<TOutput>
+    ) => {
+      const activeOperation = operationRef.current;
+      if (activeOperation && options?.turnPolicy === "steer") {
+        const current = historyRef.current;
+        if (!current) throw new Error("The conversation is still loading.");
+        const session = client.sessions.attach(sessionId, {
+          streamIndex: current.endIndex,
+        });
+        await session.send(message, options);
+        await activeOperation;
+        await resume();
+        return;
+      }
+
+      await runOperation(async () => {
+        const current = historyRef.current;
+        if (!current) throw new Error("The conversation is still loading.");
+        setError(undefined);
+        setStatus("submitted");
+        const session = client.sessions.attach(sessionId, {
+          streamIndex: current.endIndex,
+        });
+        let nextIndex = current.endIndex;
+        try {
+          const response = await session.send(message, options);
+          for await (const event of response) {
+            nextIndex += 1;
+            appendSessionEvent(historyRef, setHistory, event, nextIndex);
+            setStatus("streaming");
+          }
+          setStatus("ready");
+        } catch (cause) {
+          setError(toError(cause));
+          setStatus("error");
+          throw cause;
+        }
+      });
+    },
+    [resume, runOperation, sessionId]
+  );
+
+  const respond = useCallback(
+    async <TOutput>(
+      inputResponses: readonly InputResponse[],
+      options?: RespondTurnOptions<TOutput>
+    ) => {
+      await runOperation(async () => {
+        const current = historyRef.current;
+        if (!current) throw new Error("The conversation is still loading.");
+        setError(undefined);
+        setStatus("submitted");
+        const session = client.sessions.attach(sessionId, {
+          streamIndex: current.endIndex,
+        });
+        let nextIndex = current.endIndex;
+        try {
+          const response = await session.respond(inputResponses, options);
+          for await (const event of response) {
+            nextIndex += 1;
+            appendSessionEvent(historyRef, setHistory, event, nextIndex);
+            setStatus("streaming");
+          }
+          setStatus("ready");
+        } catch (cause) {
+          setError(toError(cause));
+          setStatus("error");
+          throw cause;
+        }
+      });
+    },
+    [runOperation, sessionId]
+  );
+
+  const loadOlder = async () => {
+    const current = historyRef.current;
+    if (!current || current.startIndex === 0 || isLoadingOlder) return;
+    setIsLoadingOlder(true);
+    try {
+      const older = await readOlderSessionHistory(
+        sessionId,
+        current.startIndex
+      );
+      setHistory((latest) =>
+        latest
+          ? {
+              ...latest,
+              events: [...older.events, ...latest.events],
+              startIndex: older.startIndex,
+            }
+          : latest
+      );
+    } catch (cause) {
+      setError(toError(cause));
+    } finally {
+      setIsLoadingOlder(false);
+    }
+  };
+
+  const events = history?.events ?? emptyEvents;
+  const data = useMemo<EveMessageData>(
+    () =>
+      events.reduce(
+        (current, event) => messageReducer.reduce(current, event),
+        messageReducer.initial()
+      ),
+    [events]
+  );
+
+  return {
+    cancel: async () => await client.sessions.attach(sessionId).cancel(),
+    data,
+    error,
+    events,
+    hasOlder: (history?.startIndex ?? 0) > 0,
+    isLoadingOlder,
+    loadOlder,
+    respond,
+    resume,
+    send,
+    status,
+  };
+}
+
+const emptyEvents: readonly MessageStreamEvent[] = [];
+
+function appendSessionEvent(
+  historyRef: RefObject<SessionHistoryPage | undefined>,
+  setHistory: Dispatch<SetStateAction<SessionHistoryPage | undefined>>,
+  event: MessageStreamEvent,
+  endIndex: number
+) {
+  setHistory((current) => {
+    if (!current) return current;
+    let next: SessionHistoryPage;
+    if (
+      current.events.some((candidate) => candidate.meta.id === event.meta.id)
+    ) {
+      next = { ...current, endIndex };
+    } else {
+      next = {
+        ...current,
+        endIndex,
+        events: [...current.events, event],
+      };
+    }
+    historyRef.current = next;
+    return next;
+  });
+}
+
+function toError(cause: unknown) {
+  return cause instanceof Error
+    ? cause
+    : new Error("The session request failed.");
+}

--- a/src/app/(authenticated)/chat/[sessionId]/_lib/session-history.test.ts
+++ b/src/app/(authenticated)/chat/[sessionId]/_lib/session-history.test.ts
@@ -1,0 +1,61 @@
+import type { MessageStreamEvent } from "eve/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readLatestSessionHistory } from "./session-history";
+
+describe("session history", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests a bounded tail and keeps only the latest four message turns", async () => {
+    const events = Array.from({ length: 6 }, (_, index) =>
+      receivedMessage(index)
+    );
+    const fetchMock = vi.fn<() => Promise<Response>>(() =>
+      Promise.resolve(
+        new Response(events.map((event) => JSON.stringify(event)).join("\n"), {
+          headers: { "x-eve-stream-tail-index": "5" },
+        })
+      )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const history = await readLatestSessionHistory("session/one");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/eve/v1/session/session%2Fone/stream?startIndex=-128&includeTailIndex=1",
+      expect.objectContaining({ cache: "no-store" })
+    );
+    expect(history).toEqual({
+      endIndex: 6,
+      events: events.slice(2),
+      startIndex: 2,
+    });
+  });
+
+  it("rejects a stream response without a durable tail cursor", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<() => Promise<Response>>(() => Promise.resolve(new Response("\n")))
+    );
+
+    await expect(readLatestSessionHistory("missing-tail")).rejects.toThrow(
+      "valid tail index"
+    );
+  });
+});
+
+function receivedMessage(index: number): MessageStreamEvent {
+  return {
+    data: {
+      message: `Message ${String(index)}`,
+      sequence: index,
+      turnId: `turn_${String(index)}`,
+    },
+    meta: {
+      at: new Date(index * 1000).toISOString(),
+      id: `event_${String(index)}`,
+    },
+    type: "message.received",
+  };
+}

--- a/src/app/(authenticated)/chat/[sessionId]/_lib/session-history.ts
+++ b/src/app/(authenticated)/chat/[sessionId]/_lib/session-history.ts
@@ -1,0 +1,163 @@
+import { Client, type MessageStreamEvent } from "eve/client";
+import { z } from "zod";
+
+const eventsPerRead = 128;
+const messagesPerPage = 4;
+const tailIndexHeader = "x-eve-stream-tail-index";
+const client = new Client({ host: "" });
+const messageStreamEventSchema = z.custom<MessageStreamEvent>(
+  (value) =>
+    z
+      .object({
+        data: z.unknown(),
+        meta: z.object({ at: z.string(), id: z.string() }).loose(),
+        type: z.string(),
+      })
+      .loose()
+      .safeParse(value).success
+);
+
+export interface SessionHistoryPage {
+  readonly endIndex: number;
+  readonly events: readonly MessageStreamEvent[];
+  readonly startIndex: number;
+}
+
+export async function readLatestSessionHistory(
+  sessionId: string,
+  signal?: AbortSignal
+): Promise<SessionHistoryPage> {
+  const response = await fetch(
+    sessionStreamUrl(sessionId, {
+      includeTailIndex: true,
+      startIndex: -eventsPerRead,
+    }),
+    { cache: "no-store", signal }
+  );
+  if (!response.ok) throw await streamResponseError(response);
+
+  const tailIndex = readTailIndex(response);
+  const latestEvents = await readNdjsonEvents(response);
+  const endIndex = tailIndex + 1;
+  const startIndex = Math.max(0, endIndex - latestEvents.length);
+
+  return await extendToMessageBoundary(
+    { endIndex, events: latestEvents, startIndex },
+    sessionId,
+    signal
+  );
+}
+
+export async function readOlderSessionHistory(
+  sessionId: string,
+  before: number,
+  signal?: AbortSignal
+): Promise<SessionHistoryPage> {
+  return await extendToMessageBoundary(
+    { endIndex: before, events: [], startIndex: before },
+    sessionId,
+    signal
+  );
+}
+
+async function extendToMessageBoundary(
+  initial: SessionHistoryPage,
+  sessionId: string,
+  signal?: AbortSignal
+) {
+  let page = initial;
+
+  while (
+    page.startIndex > 0 &&
+    receivedMessageCount(page.events) < messagesPerPage
+  ) {
+    /* oxlint-disable-next-line eslint/no-await-in-loop -- Each backward read starts at the cursor returned by the preceding read. */
+    const older = await readEventChunk(sessionId, page.startIndex, signal);
+    page = {
+      endIndex: page.endIndex,
+      events: [...older.events, ...page.events],
+      startIndex: older.startIndex,
+    };
+  }
+
+  const messageIndexes = page.events.flatMap((event, index) =>
+    event.type === "message.received" ? [index] : []
+  );
+  const firstMessage = messageIndexes.at(-messagesPerPage);
+  if (firstMessage === undefined || firstMessage === 0) return page;
+
+  return {
+    ...page,
+    events: page.events.slice(firstMessage),
+    startIndex: page.startIndex + firstMessage,
+  };
+}
+
+async function readEventChunk(
+  sessionId: string,
+  before: number,
+  signal?: AbortSignal
+): Promise<SessionHistoryPage> {
+  const startIndex = Math.max(0, before - eventsPerRead);
+  const eventLimit = before - startIndex;
+  const session = client.sessions.attach(sessionId, {
+    streamIndex: startIndex,
+  });
+  const events: MessageStreamEvent[] = [];
+
+  for await (const event of session.stream({
+    follow: false,
+    signal,
+    startIndex,
+  })) {
+    events.push(event);
+    if (events.length === eventLimit) break;
+  }
+
+  return { endIndex: before, events, startIndex };
+}
+
+function receivedMessageCount(events: readonly MessageStreamEvent[]) {
+  return events.reduce(
+    (count, event) => count + Number(event.type === "message.received"),
+    0
+  );
+}
+
+function sessionStreamUrl(
+  sessionId: string,
+  options: { readonly includeTailIndex: boolean; readonly startIndex: number }
+) {
+  const search = new URLSearchParams({
+    startIndex: options.startIndex.toString(),
+  });
+  if (options.includeTailIndex) search.set("includeTailIndex", "1");
+  return `/eve/v1/session/${encodeURIComponent(sessionId)}/stream?${search}`;
+}
+
+function readTailIndex(response: Response) {
+  const value = response.headers.get(tailIndexHeader);
+  const index = value === null ? Number.NaN : Number(value);
+  if (!Number.isSafeInteger(index) || index < -1) {
+    throw new Error("The session stream did not report a valid tail index.");
+  }
+  return index;
+}
+
+async function readNdjsonEvents(response: Response) {
+  const body = await response.text();
+  const events: MessageStreamEvent[] = [];
+  for (const line of body.split("\n")) {
+    if (!line.trim()) continue;
+    events.push(messageStreamEventSchema.parse(JSON.parse(line)));
+  }
+  return events;
+}
+
+async function streamResponseError(response: Response) {
+  const body = await response.text();
+  return new Error(
+    body.trim() ||
+      `Unable to read the session stream (${String(response.status)}).`
+  );
+}

--- a/src/app/(authenticated)/chat/[sessionId]/page.tsx
+++ b/src/app/(authenticated)/chat/[sessionId]/page.tsx
@@ -8,5 +8,11 @@ export default async function ChatSessionPage({
   const { sessionId } = await params;
   const scope = await requireRequestScope();
   const chat = await readChat(scope, sessionId);
-  return <ChatSession initialUsage={chat?.usage} sessionId={sessionId} />;
+  return (
+    <ChatSession
+      initialUsage={chat?.usage}
+      key={sessionId}
+      sessionId={sessionId}
+    />
+  );
 }

--- a/src/app/_lib/subagent-sessions.test.ts
+++ b/src/app/_lib/subagent-sessions.test.ts
@@ -72,6 +72,34 @@ describe("collectSubagentSessions", () => {
     ).toEqual(["child_2", "child_1"]);
   });
 
+  it("uses the parent action description without reading the child stream", () => {
+    const [session] = collectSubagentSessions([
+      {
+        type: "actions.requested",
+        data: {
+          actions: [
+            {
+              callId: "call_1",
+              description: "Research nearby appointments",
+              input: { task: "Find a slot" },
+              kind: "subagent-call",
+              name: "Research appointments",
+              nodeId: "worker",
+              subagentName: "researcher",
+            },
+          ],
+          sequence: 0,
+          stepIndex: 0,
+          turnId: "turn_1",
+        },
+        meta,
+      },
+      called,
+    ]);
+
+    expect(session?.task).toBe("Research nearby appointments");
+  });
+
   it("moves a continued child back to the front", () => {
     const secondChild = {
       ...called,

--- a/src/app/_lib/subagent-sessions.ts
+++ b/src/app/_lib/subagent-sessions.ts
@@ -6,6 +6,7 @@ import type {
 
 export type SubagentSession = SubagentCalledStreamEvent["data"] & {
   readonly completion?: SubagentCompletedStreamEvent["data"];
+  readonly task?: string;
 };
 
 export type SubagentStatus =
@@ -20,11 +21,23 @@ export function collectSubagentSessions(
   events: readonly MessageStreamEvent[]
 ): readonly SubagentSession[] {
   const completions = new Map<string, SubagentCompletedStreamEvent["data"]>();
+  const tasks = new Map<string, string>();
   const sessions = new Map<string, SubagentSession>();
 
   for (const event of events) {
     if (event.type === "subagent.completed") {
       completions.set(event.data.callId, event.data);
+      continue;
+    }
+    if (event.type === "actions.requested") {
+      for (const action of event.data.actions) {
+        if (
+          action.kind === "subagent-call" ||
+          action.kind === "remote-agent-call"
+        ) {
+          tasks.set(action.callId, action.description);
+        }
+      }
     }
   }
 
@@ -34,6 +47,7 @@ export function collectSubagentSessions(
     const session = {
       ...event.data,
       completion: completions.get(event.data.callId),
+      task: tasks.get(event.data.callId),
     };
     sessions.delete(session.childSessionId);
     sessions.set(session.childSessionId, session);


### PR DESCRIPTION
## Summary
- load only the latest four message turns when opening an existing chat
- add cursor-based “Load older messages” controls for the main conversation and worker traces
- defer every worker stream until that worker is opened, while deriving task labels from parent events
- avoid persisting partial-history usage totals

## Verification
- `pnpm exec vitest run --exclude ".claude/**"` (360 tests)
- `pnpm exec oxlint src agent db evals scripts --deny-warnings`
- `pnpm exec oxfmt --check src agent db evals scripts`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- local dev shell browser check: page rendered with no framework error overlay; authenticated chat verification was blocked by the standalone browser sign-in boundary

## Check caveat
`pnpm check` is blocked before project checks complete by the existing user-owned `.claude/worktrees/browser-trace-telemetry/.oxlintrc.jsonc` nested type-aware config. The equivalent scoped checks above pass, and `.claude/` was left untouched.