### PR TITLE
Fix cancelled session ownership recovery

### DIFF
--- a/agent/hooks/session-owner.ts
+++ b/agent/hooks/session-owner.ts
@@ -1,4 +1,4 @@
-import { defineHook } from "eve/hooks";
+import { defineHook, type HookContext } from "eve/hooks";
 import { saveChat } from "@/db/services/chats";
 import { ensureScope } from "@/db/services/scope";
 import { claimSession } from "@/db/services/sessions";
@@ -7,21 +7,26 @@ import { scopeFromPrincipal } from "@/agent/lib/principal-scope";
 export default defineHook({
   events: {
     async "session.started"(_event, ctx) {
-      const initiator = ctx.session.auth.initiator;
-      if (!initiator) return;
-
-      const scope = scopeFromPrincipal(initiator);
-      await ensureScope(scope);
-      await claimSession(scope, ctx.session.id);
+      await claimOwnedSession(ctx);
     },
     async "message.received"(_event, ctx) {
-      const initiator = ctx.session.auth.initiator;
-      if (!initiator) return;
+      const scope = await claimOwnedSession(ctx);
+      if (!scope) return;
 
-      await saveChat(scopeFromPrincipal(initiator), {
+      await saveChat(scope, {
         channel: ctx.channel.kind,
         sessionId: ctx.session.id,
       });
     },
   },
 });
+
+async function claimOwnedSession(ctx: HookContext) {
+  const initiator = ctx.session.auth.initiator;
+  if (!initiator) return undefined;
+
+  const scope = scopeFromPrincipal(initiator);
+  await ensureScope(scope);
+  await claimSession(scope, ctx.session.id);
+  return scope;
+}

--- a/tests/agent/hooks/session-owner.test.ts
+++ b/tests/agent/hooks/session-owner.test.ts
@@ -1,13 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HookContext } from "eve/hooks";
 import type { saveChat } from "@/db/services/chats";
+import type { ensureScope } from "@/db/services/scope";
+import type { claimSession } from "@/db/services/sessions";
 import sessionOwner from "@/agent/hooks/session-owner";
 
 const mocks = vi.hoisted(() => ({
+  claimSession: vi.fn<typeof claimSession>(),
+  ensureScope: vi.fn<typeof ensureScope>(),
   saveChat: vi.fn<typeof saveChat>(),
 }));
 
 vi.mock("@/db/services/chats", () => ({ saveChat: mocks.saveChat }));
+vi.mock("@/db/services/scope", () => ({ ensureScope: mocks.ensureScope }));
+vi.mock("@/db/services/sessions", () => ({
+  claimSession: mocks.claimSession,
+}));
 
 type MessageReceivedHandler = NonNullable<
   NonNullable<typeof sessionOwner.events>["message.received"]
@@ -40,11 +48,13 @@ const context = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.claimSession.mockResolvedValue();
+  mocks.ensureScope.mockResolvedValue();
   mocks.saveChat.mockResolvedValue();
 });
 
 describe("session ownership hook", () => {
-  it("indexes messages received outside the web chat client", async () => {
+  it("repairs ownership before indexing a received message", async () => {
     const handler = sessionOwner.events?.["message.received"];
     expect(handler).toBeDefined();
 
@@ -58,10 +68,18 @@ describe("session ownership hook", () => {
     } satisfies Parameters<MessageReceivedHandler>[0];
     await handler?.(event, context);
 
+    expect(mocks.ensureScope).toHaveBeenCalledWith(scope);
+    expect(mocks.claimSession).toHaveBeenCalledWith(scope, "session-1");
     expect(mocks.saveChat).toHaveBeenCalledWith(scope, {
       channel: "channel:linq",
       sessionId: "session-1",
     });
+    expect(mocks.ensureScope.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.claimSession.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(mocks.claimSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.saveChat.mock.invocationCallOrder[0] ?? 0
+    );
   });
 
   it("records the web channel for HTTP messages", async () => {


### PR DESCRIPTION
## Summary

- repair root-session ownership when a normal authenticated message arrives after an early cancelled session start
- keep the browser agent's existing child-and-root ownership checks unchanged
- cover the recovery ordering before chat history persistence

## Why

Production traces showed the affected conversation began with an empty cancelled first turn. The session then continued, but its missing root ownership row was never recreated: later message handling only waited for ownership before indexing the chat. A normally started browser child therefore failed the root ownership half of its authorization check on every browser call.

Successful browser sessions did not have that early empty cancellation. The same ownership error also appeared on August 28, before the Eve 0.49 upgrade, which rules out the recent framework upgrade as the origin.

The fix keeps ownership anchored to the durable session initiator. Both session start and message receipt now idempotently ensure the workspace and claim the session before chat persistence. Existing session IDs remain protected by the primary-key conflict behavior, so a later caller cannot transfer ownership.

## Validation

- `pnpm test -- tests/agent/hooks/session-owner.test.ts agent/subagents/browser-agent/lib/tests/worker-access.test.ts db/tests/services.test.ts` (3 files, 5 tests)
- `pnpm check` (77 test files, 360 tests; lint, types, formatting, Knip, and boundaries)
- `pnpm build`
- independent read-only review: clean; verification complete

## Review focus

- initiator-scoped ownership recovery in `message.received`
- `ensureScope` → `claimSession` → `saveChat` ordering
