### PR TITLE
Stabilize supervisor subprocess tests

### DIFF
--- a/tests/agent-evals.test.ts
+++ b/tests/agent-evals.test.ts
@@ -3,8 +3,14 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  SUPERVISOR_TEST_TIMEOUT_MS,
+  waitForSupervisorClose,
+  waitForSupervisorLogEntry,
+} from "./helpers/supervisor-process";
 
 const temporaryDirectories: string[] = [];
+const supervisorTestOptions = { timeout: SUPERVISOR_TEST_TIMEOUT_MS };
 
 afterEach(async () => {
   await Promise.all(
@@ -14,7 +20,7 @@ afterEach(async () => {
   );
 });
 
-describe("agent eval supervisor", () => {
+describe("agent eval supervisor", supervisorTestOptions, () => {
   it("runs migrations and the filtered suite against an isolated database", async () => {
     const result = await runSupervisor({
       AI_GATEWAY_API_KEY: "test-gateway-key",
@@ -174,30 +180,18 @@ fi
   supervisor.stderr.on("data", (chunk: string) => {
     stderr += chunk;
   });
+  const exitCode = waitForSupervisorClose(supervisor);
   if (environment.EVAL_BLOCK_ACTION) {
-    await waitForLogEntry(logPath, ` ${environment.EVAL_BLOCK_ACTION} `);
+    await waitForSupervisorLogEntry(
+      logPath,
+      ` ${environment.EVAL_BLOCK_ACTION} `
+    );
     supervisor.kill("SIGINT");
   }
-  const code = await new Promise<number | null>((resolve, reject) => {
-    supervisor.once("error", reject);
-    supervisor.once("exit", resolve);
-  });
 
   return {
-    code,
+    code: await exitCode,
     commands: await readFile(logPath, "utf8").catch(() => ""),
     stderr,
   };
-}
-
-async function waitForLogEntry(path: string, expected: string) {
-  /* oxlint-disable eslint/no-await-in-loop -- This bounded poll observes the supervisor log before sending a signal. */
-  for (let attempt = 0; attempt < 250; attempt += 1) {
-    const contents = await readFile(path, "utf8").catch(() => "");
-    if (contents.includes(expected)) return;
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  /* oxlint-enable eslint/no-await-in-loop */
-
-  throw new Error(`Timed out waiting for ${expected}`);
 }

--- a/tests/helpers/supervisor-process.ts
+++ b/tests/helpers/supervisor-process.ts
@@ -1,0 +1,48 @@
+import type { ChildProcess } from "node:child_process";
+import { readFile } from "node:fs/promises";
+
+const LOG_POLL_INTERVAL_MS = 20;
+const LOG_WAIT_TIMEOUT_MS = 5_000;
+
+export const SUPERVISOR_TEST_TIMEOUT_MS = LOG_WAIT_TIMEOUT_MS + 5_000;
+
+export function waitForSupervisorClose(supervisor: ChildProcess) {
+  return new Promise<number | null>((resolve, reject) => {
+    supervisor.once("error", reject);
+    supervisor.once("close", resolve);
+  });
+}
+
+export async function waitForSupervisorLogEntry(
+  path: string,
+  expected: string
+) {
+  const deadline = Date.now() + LOG_WAIT_TIMEOUT_MS;
+  let contents = "";
+  let readError: unknown;
+
+  /* oxlint-disable eslint/no-await-in-loop -- This bounded poll must observe each read before scheduling the next retry. */
+  while (Date.now() < deadline) {
+    try {
+      contents = await readFile(path, "utf8");
+      readError = undefined;
+    } catch (error) {
+      contents = "";
+      readError = error;
+    }
+
+    if (contents.includes(expected)) return;
+    await new Promise((resolve) => setTimeout(resolve, LOG_POLL_INTERVAL_MS));
+  }
+  /* oxlint-enable eslint/no-await-in-loop */
+
+  const lastObservation =
+    readError === undefined
+      ? `Last log contents: ${JSON.stringify(contents)}`
+      : `Last log read failed: ${
+          readError instanceof Error ? readError.message : "Unknown read error"
+        }`;
+  throw new Error(
+    `Timed out after ${String(LOG_WAIT_TIMEOUT_MS)}ms waiting for ${JSON.stringify(expected)} in ${path}. ${lastObservation}`
+  );
+}

--- a/tests/local-development.test.ts
+++ b/tests/local-development.test.ts
@@ -4,8 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
+import {
+  SUPERVISOR_TEST_TIMEOUT_MS,
+  waitForSupervisorClose,
+  waitForSupervisorLogEntry,
+} from "./helpers/supervisor-process";
 
 const temporaryDirectories: string[] = [];
+const supervisorTestOptions = { timeout: SUPERVISOR_TEST_TIMEOUT_MS };
 
 afterEach(async () => {
   await Promise.all(
@@ -15,7 +21,7 @@ afterEach(async () => {
   );
 });
 
-describe("local development", () => {
+describe("local development", supervisorTestOptions, () => {
   it("owns the PostgreSQL lifecycle around the application process", async () => {
     const [compose, developmentScript, packageManifestSource] =
       await Promise.all([
@@ -192,16 +198,13 @@ printf 'pnpm %s\\n' "$*" >> "$DEV_SUPERVISOR_LOG"
     }
   );
 
-  await waitForLogEntry(
+  const exitCode = waitForSupervisorClose(supervisor);
+  await waitForSupervisorLogEntry(
     logPath,
     environment.DEV_BLOCK_ACTION === "port"
       ? " port postgres 5432"
       : " up --detach --wait"
   );
-  const exitCode = new Promise<number | null>((resolve, reject) => {
-    supervisor.once("error", reject);
-    supervisor.once("exit", resolve);
-  });
   supervisor.kill("SIGINT");
 
   return {
@@ -248,10 +251,7 @@ printf 'pnpm %s %s\n' "$*" "$DATABASE_URL" >> "$DEV_SUPERVISOR_LOG"
       stdio: "ignore",
     }
   );
-  const exitCode = new Promise<number | null>((resolve, reject) => {
-    supervisor.once("error", reject);
-    supervisor.once("exit", resolve);
-  });
+  const exitCode = waitForSupervisorClose(supervisor);
 
   return {
     code: await exitCode,
@@ -289,28 +289,11 @@ printf '%s\n' "$*" >> "$DEV_SUPERVISOR_LOG"
   supervisor.stderr.on("data", (chunk: string) => {
     stderr += chunk;
   });
-  const exitCode = new Promise<number | null>((resolve, reject) => {
-    supervisor.once("error", reject);
-    supervisor.once("exit", resolve);
-  });
+  const exitCode = waitForSupervisorClose(supervisor);
 
   return {
     code: await exitCode,
     commands: await readFile(logPath, "utf8").catch(() => ""),
     stderr,
   };
-}
-
-async function waitForLogEntry(path: string, expected: string) {
-  /* oxlint-disable eslint/no-await-in-loop -- This bounded poll must observe each read before scheduling the next retry. */
-  for (let attempt = 0; attempt < 250; attempt += 1) {
-    const contents = await readFile(path, "utf8").catch(() => "");
-    if (contents.includes(expected)) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  /* oxlint-enable eslint/no-await-in-loop */
-
-  throw new Error(`Timed out waiting for ${expected}`);
 }


### PR DESCRIPTION
## Summary

- extract shared subprocess close and command-log polling behavior into `tests/helpers/supervisor-process.ts`
- give log polling a five-second diagnostic deadline within a ten-second Vitest timeout
- register close observation immediately after spawning while preserving signals, teardown assertions, command logs, and isolated fixtures

## Validation

- 10 consecutive focused runs: 150/150 tests passed
- final focused run: 15/15 tests passed
- missing-log diagnostic smoke check completed before the outer test timeout
- `pnpm check`
- `pnpm build` with documented local placeholder environment values
- independent review: clean