### PR TITLE
test(oxlint): cover anti-slop rules

### DIFF
--- a/tools/oxlint/README.md
+++ b/tools/oxlint/README.md
@@ -13,3 +13,6 @@ The `anti-slop` plugin vendors the generic rules and shared helpers from
 [`dmmulroy/anti-slop`](https://github.com/dmmulroy/anti-slop) at commit
 `0b863049ca2173b74ae6ebf1f8d0f6f911f9a220`. The upstream Effect integration
 is intentionally excluded. Its MIT license is included in the plugin folder.
+The RuleTester cases under `anti-slop/tests` adapt the upstream suite at the
+same commit and add local coverage for upstream gaps. Refresh those cases
+whenever the vendored source is updated.

--- a/tools/oxlint/anti-slop/tests/anti-slop-plugin.test.ts
+++ b/tools/oxlint/anti-slop/tests/anti-slop-plugin.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import plugin from "@/tools/oxlint/anti-slop/index.ts";
+
+import "./no-chained-type-assertions.cases.ts";
+import "./no-conditional-empty-object-spread.cases.ts";
+import "./no-known-value-widening.cases.ts";
+import "./no-module-mocking.cases.ts";
+import "./no-object-parameters.cases.ts";
+import "./no-reflect-apply.cases.ts";
+import "./no-reflect-get.cases.ts";
+import "./no-runtime-typeof.cases.ts";
+import "./no-shape-in-symbol-names.cases.ts";
+import "./no-unknown-parameters.cases.ts";
+import "./no-unknown-returns.cases.ts";
+import "./no-unknown-type-aliases.cases.ts";
+import "./no-unsafe-dictionary-type.cases.ts";
+import "./no-widen-then-assert.cases.ts";
+import "./require-safety-comment-for-type-assertion.cases.ts";
+
+const registeredRuleNames = [
+  "no-chained-type-assertions",
+  "no-conditional-empty-object-spread",
+  "no-known-value-widening",
+  "no-module-mocking",
+  "no-object-parameters",
+  "no-reflect-apply",
+  "no-reflect-get",
+  "no-runtime-typeof",
+  "no-shape-in-symbol-names",
+  "no-unknown-parameters",
+  "no-unknown-returns",
+  "no-unknown-type-aliases",
+  "no-unsafe-dictionary-type",
+  "no-widen-then-assert",
+  "require-safety-comment-for-type-assertion",
+];
+
+test("exports every repository-vendored anti-slop rule", () => {
+  assert.deepEqual(Object.keys(plugin.rules).toSorted(), registeredRuleNames);
+});
+
+test("does not advertise automatic fixes for policy-only diagnostics", () => {
+  for (const rule of Object.values(plugin.rules)) {
+    assert.equal(rule.meta?.fixable, undefined);
+  }
+});

--- a/tools/oxlint/anti-slop/tests/no-chained-type-assertions.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-chained-type-assertions.cases.ts
@@ -1,0 +1,43 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noChainedTypeAssertionsRule } from "@/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts";
+
+const error = { messageId: "chained" };
+
+tester.run("anti-slop/no-chained-type-assertions", noChainedTypeAssertionsRule, {
+  valid: [
+    "const user = input as User;",
+    "const user = <User>input;",
+    "const values = [1, 2] as const;",
+    "const result = transform(input as Source) as Result;",
+    "const nested = { value: input as Source } as Container;",
+    "const values = (([1, 2] as const)) as const;",
+  ],
+  invalid: [
+    {
+      name: "as assertion chain",
+      code: "const user = input as object as User;",
+      errors: [{ ...error, line: 1, column: 13 }],
+    },
+    {
+      name: "parenthesized assertion chain",
+      code: "const user = ((input as object)) as User;",
+      errors: [error],
+    },
+    {
+      name: "angle-bracket assertion chain",
+      code: "const user = <User><object>input;",
+      errors: [error],
+    },
+    {
+      name: "mixed const and non-const chain",
+      code: "const values = ([1, 2] as const) as readonly number[];",
+      errors: [error],
+    },
+    {
+      name: "reports a long chain once",
+      code: "const user = input as unknown as object as User;",
+      errors: 1,
+    },
+  ],
+});

--- a/tools/oxlint/anti-slop/tests/no-conditional-empty-object-spread.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-conditional-empty-object-spread.cases.ts
@@ -1,0 +1,31 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noConditionalEmptyObjectSpreadRule } from "@/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts";
+
+const error = { messageId: "avoid" };
+
+if (noConditionalEmptyObjectSpreadRule.meta?.fixable !== undefined) {
+  throw new Error("The rule must not offer an unsafe semantics-changing fix.");
+}
+
+tester.run(
+  "anti-slop/no-conditional-empty-object-spread",
+  noConditionalEmptyObjectSpreadRule,
+  {
+    valid: [
+      "const result = { value };",
+      "const result = { ...values };",
+      "const result = condition ? { value } : {};",
+    ],
+    invalid: [
+      {
+        code: "const result = { ...(value !== undefined ? { value } : {}) };",
+        errors: [error],
+      },
+      {
+        code: "const result = { ...(condition ? {} : { value }) };",
+        errors: [error],
+      },
+    ],
+  },
+);

--- a/tools/oxlint/anti-slop/tests/no-known-value-widening.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-known-value-widening.cases.ts
@@ -1,0 +1,165 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noKnownValueWideningRule } from "@/tools/oxlint/anti-slop/rules/no-known-value-widening.ts";
+
+
+const error = { messageId: "widening" };
+
+const prelude = "type Command = () => void; const startCommand = () => {};";
+
+tester.run("anti-slop/no-known-value-widening", noKnownValueWideningRule, {
+	valid: [
+		`${prelude} const commands: Record<string, Command> = {};`,
+		`${prelude} type Index<T> = Record<string, T>; const commands: Index<Command> = {};`,
+		`${prelude} class Registry { commands: Record<string, Command> = {}; }`,
+		`${prelude} class Registry { accessor commands: Record<string, Command> = {}; }`,
+		`${prelude} let commands: Record<string, Command>; commands = {};`,
+		`${prelude} function create(): Record<string, Command> { return {}; }`,
+		`${prelude} const create = (): Record<string, Command> => ({});`,
+		`${prelude} const commands = {} as Record<string, Command>;`,
+		`${prelude} const commands = <Record<string, Command>>{};`,
+		`${prelude} const commands = { start: startCommand };`,
+		`${prelude} const commands = { start: startCommand } as const;`,
+		`${prelude} const commands = { start: startCommand } satisfies Record<string, Command>;`,
+		`${prelude} type Commands = Record<string, Command>; const commands = { start: startCommand } as const satisfies Commands;`,
+		`${prelude} interface Commands { readonly start: Command } const commands: Commands = { start: startCommand };`,
+		`${prelude} type Commands = { readonly start: Command }; const commands: Commands = { start: startCommand };`,
+		`${prelude} type PermissionLevels = { readonly [Level in Permission]: number }; const levels: PermissionLevels = { admin: 1 };`,
+		`${prelude} function create() { return { start: startCommand }; }`,
+		`${prelude} interface Commands { readonly start: Command } function create(): Commands { return { start: startCommand }; }`,
+		`${prelude} declare function make(): Record<string, Command>; const commands: Record<string, Command> = make();`,
+		`${prelude} import { Commands } from './types'; const commands: Commands = { start: startCommand };`,
+		`${prelude} type Diet = 'vegan' | 'omnivore'; const labels: Record<Diet, string> = { vegan: 'V', omnivore: 'O' };`,
+		`${prelude} type Diet = 'vegan' | 'omnivore'; type Labels = Record<Diet, string>; const labels: Labels = { vegan: 'V', omnivore: 'O' };`,
+		`${prelude} type Diet = 'vegan' | 'omnivore'; const labels: Readonly<Record<Diet, string>> = { vegan: 'V', omnivore: 'O' };`,
+		`${prelude} const labels: Record<'a' | 'b', number> = { a: 1, b: 2 };`,
+		`${prelude} type Index<Key extends PropertyKey, Value> = Record<Key, Value>; const commands: Index<'start', Command> = { start: startCommand };`,
+		"function isString(value: unknown): value is string { return true; } declare const input: unknown; isString(input);",
+		"function isString(value: string | unknown): value is string { return true; } declare const input: string | unknown; isString(input);",
+		"function isString(value: unknown): value is string { return true; } declare function readInput(): unknown; isString(readInput());",
+	],
+	invalid: [
+		{ code: "const value: unknown = {};", errors: [error] },
+		{ code: "const value: object = {};", errors: [error] },
+		{ code: "let value: unknown; value = {};", errors: [error] },
+		{ code: "function create(): unknown { return {}; }", errors: [error] },
+		{
+			code: `${prelude} const commands: Record<string, Command> = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const commands: { [key: string]: Command } = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const commands: { [K in string]: Command } = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const commands: { start: Command } = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const commands = { start: startCommand } as Record<string, Command>;`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const commands = ({ start: startCommand } as Record<string, Command>) as object;`,
+			errors: 1,
+		},
+		{
+			code: `${prelude} class Registry { commands: Record<string, Command> = { start: startCommand }; }`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} let commands: Record<string, Command>; commands = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} function create(): Record<string, Command> { return { start: startCommand }; }`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} function create(): { start: Command } { return { start: startCommand }; }`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const source = { start: startCommand }; const commands: Record<string, Command> = source;`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Open = Record<string, Command>; const source = { start: startCommand }; const commands: Open = source;`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Open = { [key: string]: Command }; const source = { start: startCommand }; const commands: Open = source;`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Open = { [key in string]: Command }; const source = { start: startCommand }; const commands: Open = source;`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Open = Readonly<Record<string, Command>>; const source = { start: startCommand }; const commands: Open = source;`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} function outer() { type Open = Record<string, Command>; const commands: Open = { start: startCommand }; }`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Index<T> = Record<string, T>; const commands: Index<Command> = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Identity<T> = T; const commands: Identity<Record<string, Command>> = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Index<T> = Record<string, T>; type CommandsByName = Index<Command>; const commands: CommandsByName = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Index<T = Command> = Record<string, T>; const commands: Index = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} type Key = string; const commands: Record<Key, Command> = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const commands: Record<PropertyKey, Command> = { start: startCommand };`,
+			errors: [error],
+		},
+		{
+			code: `${prelude} const commands: Record<string | 'start', Command> = { start: startCommand };`,
+			errors: [error],
+		},
+		{ code: "const value: unknown = 1;", errors: [error] },
+		{ code: "const value: object = [];", errors: [error] },
+		{
+			code: "function isString(value: unknown): value is string { return true; } isString('known');",
+			errors: [error],
+		},
+		{
+			code: "function isString(value: unknown): value is string { return true; } const known = 'known'; isString(known);",
+			errors: [error],
+		},
+		{
+			code: "function isString(value: string | unknown): value is string { return true; } isString('known');",
+			errors: [error],
+		},
+		{
+			code: "function isString(value: unknown): value is string { return true; } function check(known: string): boolean { return isString(known); }",
+			errors: [error],
+		},
+		{
+			code: "const isString = (value: unknown): value is string => true; const known: string = getValue(); isString(known);",
+			errors: [error],
+		},
+		{
+			code: "type User = { readonly id: string }; function isUser(value: unknown): value is User { return true; } function parse(): User { return { id: 'known' }; } const user = parse(); isUser(user);",
+			errors: [error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/tests/no-module-mocking.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-module-mocking.cases.ts
@@ -1,0 +1,27 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noModuleMockingRule } from "@/tools/oxlint/anti-slop/rules/no-module-mocking.ts";
+
+const error = { messageId: "moduleMock" };
+
+tester.run("anti-slop/no-module-mocking", noModuleMockingRule, {
+  valid: [
+    "const store = new InMemoryUserStore();",
+    "vi.spyOn(store, 'save');",
+    "const vi = { mock() {} }; vi.mock();",
+    "function test(jest: { mock(): void }) { jest.mock(); }",
+    "import { vi as localVi } from './helpers'; localVi.mock('./module');",
+  ],
+  invalid: [
+    { code: "vi.mock('./user-store');", errors: [error] },
+    { code: "jest.mock('./user-store');", errors: [error] },
+    { code: "vi['doMock']('./user-store');", errors: [error] },
+    { code: "jest.unstable_mockModule('./user-store');", errors: [error] },
+    { code: "import { vi } from 'vitest'; vi.mock('./user-store');", errors: [error] },
+    { code: "import { vi as testApi } from 'vitest'; testApi.mock('./user-store');", errors: [error] },
+    {
+      code: "import { jest } from '@jest/globals'; jest.mock('./user-store');",
+      errors: [error],
+    },
+  ],
+});

--- a/tools/oxlint/anti-slop/tests/no-object-parameters.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-object-parameters.cases.ts
@@ -1,0 +1,62 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noObjectParametersRule } from "@/tools/oxlint/anti-slop/rules/no-object-parameters.ts";
+
+const error = { messageId: "objectParameter" };
+
+tester.run("anti-slop/no-object-parameters", noObjectParametersRule, {
+	valid: [
+		"type Alias = object;",
+		"function f(value: Alias) {}",
+		"interface Owner { readonly id: string } function f(value: Owner) {}",
+		"function f<Value>(value: Value) {}",
+		"function f<Value extends object>(value: Value) {}",
+		"function f<Value extends Owner, Owner extends { readonly id: string }>(value: Value) {}",
+		"type Owner = { readonly id: string }; function f<Value extends Owner>(value: Value) {}",
+		"type Alias = object; function consume<Alias>(value: Alias) {}",
+		"type Alias = object; type Consumer<Alias> = (value: Alias) => void;",
+		"type Alias = object; interface Consumer<Alias> { consume(value: Alias): void }",
+		"type Key = object; type Mapped<Input> = { [Key in keyof Input]: (value: Key) => void };",
+		"type Item = object; type Unpacked<Input> = Input extends Promise<infer Item> ? (value: Item) => void : never;",
+		"type Payload = object; function outer() { type Payload = { readonly id: string }; function consume(value: Payload) {} }",
+		"type Identity<T> = T; function consume<Identity>(value: Identity) {}",
+		"function one() { type Payload = object; } function two() { function consume(value: Payload) {} }",
+	],
+	invalid: [
+		{ code: "function f(value: object) {}", errors: [error] },
+		{ code: "type Alias = object; function f(value: Alias) {}", errors: [error] },
+		{ code: "type Alias = (object); function f(value: Alias) {}", errors: [error] },
+		{
+			code: "type Item = object; type Fallback<Input> = Input extends infer Item ? string : (value: Item) => void;",
+			errors: [error],
+		},
+		{
+			code: "function consume(value: object = {}): void {}",
+			errors: [{ ...error, data: { parameter: "value" } }],
+		},
+		{
+			code: "function consume({ value }: object = {}): void {}",
+			errors: [{ ...error, data: { parameter: "{ value }" } }],
+		},
+		{
+			code: "type Bag = object; function consume({ value }: Bag): void {}",
+			errors: [{ ...error, data: { parameter: "{ value }" } }],
+		},
+		{
+			code: "function outer() { type Payload = object; function consume(value: Payload) {} }",
+			errors: [error],
+		},
+		{
+			code: "function outer() { function consume(value: Payload) {} type Payload = object; }",
+			errors: [error],
+		},
+		{
+			code: "type Identity<T> = T; function consume(value: Identity<object>) {}",
+			errors: [error],
+		},
+		{
+			code: "type Identity<T> = T; type Wrapped<T> = Identity<T>; function consume(value: Wrapped<object>) {}",
+			errors: [error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/tests/no-reflect-apply.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-reflect-apply.cases.ts
@@ -1,0 +1,18 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noReflectApplyRule } from "@/tools/oxlint/anti-slop/rules/no-reflect-apply.ts";
+
+const error = { messageId: "reflectApply" };
+
+tester.run("anti-slop/no-reflect-apply", noReflectApplyRule, {
+  valid: [
+    "const value = operation.apply(owner, args);",
+    "Reflect.get(owner, key);",
+    "const Reflect = { apply() { return 1; } }; Reflect.apply();",
+    "function invoke(Reflect: { apply(): number }) { return Reflect.apply(); }",
+  ],
+  invalid: [
+    { code: "const value = Reflect.apply(operation, owner, args);", errors: [error] },
+    { code: "const value = Reflect['apply'](operation, owner, args);", errors: [error] },
+  ],
+});

--- a/tools/oxlint/anti-slop/tests/no-reflect-get.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-reflect-get.cases.ts
@@ -1,0 +1,19 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noReflectGetRule } from "@/tools/oxlint/anti-slop/rules/no-reflect-get.ts";
+
+const error = { messageId: "reflectGet" };
+
+tester.run("anti-slop/no-reflect-get", noReflectGetRule, {
+  valid: [
+    "const value = owner.property;",
+    "const value = owner[key];",
+    "Reflect.set(owner, key, value);",
+    "const Reflect = { get() { return 1; } }; Reflect.get();",
+    "function read(Reflect: { get(): number }) { return Reflect.get(); }",
+  ],
+  invalid: [
+    { name: "static access", code: "const value = Reflect.get(owner, key);", errors: [error] },
+    { name: "computed access", code: "const value = Reflect['get'](owner, key);", errors: [error] },
+  ],
+});

--- a/tools/oxlint/anti-slop/tests/no-runtime-typeof.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-runtime-typeof.cases.ts
@@ -1,0 +1,46 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noRuntimeTypeofRule } from "@/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts";
+
+const error = { messageId: "runtimeTypeof" };
+const allowInTypeGuards = [{ allowInTypeGuards: true }];
+
+tester.run("anti-slop/no-runtime-typeof", noRuntimeTypeofRule, {
+	valid: [
+		'const isServer = typeof document === "undefined";',
+		'const hasStorage = typeof localStorage !== "undefined";',
+		'if (typeof globalThis.crypto === "undefined") throw new Error("no crypto");',
+		'const missing = "undefined" === typeof process;',
+		"const value = input;",
+		{
+			code: 'function isString(value: unknown): value is string { return typeof value === "string"; }',
+			options: allowInTypeGuards,
+		},
+		{
+			code: 'const isString = (value: unknown): value is string => typeof value === "string";',
+			options: allowInTypeGuards,
+		},
+		{
+			code: 'function assertString(value: unknown): asserts value is string { if (typeof value !== "string") throw new Error(); }',
+			options: allowInTypeGuards,
+		},
+	],
+	invalid: [
+		{ code: 'if (typeof input === "string") use(input);', errors: [error] },
+		{ code: "if (typeof input === undefined) use(input);", errors: [error] },
+		{
+			code: 'function isString(value: unknown): value is string { return typeof value === "string"; }',
+			errors: [error],
+		},
+		{
+			code: 'function parse(value: unknown): string { if (typeof value !== "string") throw new Error(); return value; }',
+			options: allowInTypeGuards,
+			errors: [error],
+		},
+		{
+			code: 'function isString(value: unknown): value is string { const check = () => typeof value === "string"; return check(); }',
+			options: allowInTypeGuards,
+			errors: [error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/tests/no-shape-in-symbol-names.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-shape-in-symbol-names.cases.ts
@@ -1,0 +1,37 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noForbiddenTermInSymbolNamesRule } from "@/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts";
+
+const error = { messageId: "forbiddenSymbolName" };
+
+tester.run("anti-slop/no-shape-in-symbol-names", noForbiddenTermInSymbolNamesRule, {
+	valid: [
+		"declare const schema: ExternalSchema; const field = schema.shape.id;",
+		"declare const outer: External; const value = outer.inner.shape;",
+		"declare const schema: ExternalSchema; schema.shape.id.parse('x');",
+		"const owner = { id: 1 }; const value = owner.id;",
+		"class Owner { #value = 1; read() { return this.#value; } }",
+		{ code: "const view = <Panel />;", filename: "component.tsx" },
+	],
+	invalid: [
+		{ code: "const shape = 1;", errors: [error] },
+		{ code: "function shapeOf() {}", errors: [error] },
+		{ code: "type PayloadShape = { id: string };", errors: [error] },
+		{ code: "type Payload = { shape: string };", errors: [error] },
+		{
+			code: "declare const owner: External; const shape = 'field'; const value = owner[shape];",
+			errors: 2,
+		},
+		{
+			name: "private identifier",
+			code: "class Owner { #shape = 1; }",
+			errors: [error],
+		},
+		{
+			name: "JSX identifier",
+			code: "const view = <PayloadShape />;",
+			filename: "component.tsx",
+			errors: [error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/tests/no-unknown-parameters.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-unknown-parameters.cases.ts
@@ -1,0 +1,35 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noUnknownParametersRule } from "@/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts";
+
+const error = { messageId: "unknownParameter" };
+
+tester.run("anti-slop/no-unknown-parameters", noUnknownParametersRule, {
+	valid: [
+		"function enrich(cause: unknown): void {}",
+		"function enrich(cause: Error | unknown): void {}",
+		"function isString(value: unknown): value is string { return true; }",
+		"const isString = (value: unknown): value is string => true;",
+		"function assertString(value: unknown): asserts value is string {}",
+		"type Guard = (value: unknown) => value is string;",
+		"declare function isString(value: unknown): value is string;",
+		"type Guards = { isString(value: unknown): value is string };",
+		"function parse(value: string | number): void {}",
+	],
+	invalid: [
+		{ code: "function parse(value: unknown): void {}", errors: [error] },
+		{ code: "function parse(value: string | unknown): void {}", errors: [error] },
+		{
+			code: "function parse(value: string | (number | unknown)): void {}",
+			errors: [error],
+		},
+		{
+			code: "function isString(value: unknown, context: unknown): value is string { return true; }",
+			errors: [{ ...error, data: { parameter: "context" } }],
+		},
+		{
+			code: "export function parse({ value }: unknown = {}): void {}",
+			errors: [{ ...error, data: { parameter: "{ value }" } }],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/tests/no-unknown-returns.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-unknown-returns.cases.ts
@@ -1,0 +1,46 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noUnknownReturnsRule } from "@/tools/oxlint/anti-slop/rules/no-unknown-returns.ts";
+
+const error = { messageId: "unknownReturn" };
+
+tester.run("anti-slop/no-unknown-returns", noUnknownReturnsRule, {
+  valid: [
+    "type ImportedValue = unknown;",
+    "function parse(): ImportedValue { return input; }",
+    "function parse(): User { return user; }",
+    "function infer() { return input; }",
+    "function generic<Value>(): Value { return value; }",
+    "type Value = unknown; function generic<Value>(): Value { return value; }",
+    "type Key = unknown; type Mapped<Input> = { [Key in keyof Input]: () => Key };",
+    "type Item = unknown; type Unpacked<Input> = Input extends Promise<infer Item> ? () => Item : never;",
+    "function cause(): { cause: unknown } { return { cause: input }; }",
+    "type Result = { value: unknown }; function load(): Result { return result; }",
+    "function load(): Promise<User> { return promise; }",
+    "type Identity<T> = T; function load(): Identity<User> { return user; }",
+    "type Value = unknown; function outer() { type Value = User; function load(): Value { return user; } }",
+  ],
+  invalid: [
+    { code: "function load(): unknown { return input; }", errors: [error] },
+    { code: "const load = (): unknown => input;", errors: [error] },
+    { code: "type Loader = () => unknown;", errors: [error] },
+    { code: "interface Loader { load(): unknown }", errors: [error] },
+    { code: "declare function load(): unknown;", errors: [error] },
+    { code: "function load(): string | unknown { return input; }", errors: [error] },
+    { code: "function load(): Promise<unknown> { return promise; }", errors: [error] },
+    { code: "type UnknownValue = unknown; function load(): UnknownValue { return input; }", errors: [error] },
+    { code: "type Item = unknown; type Fallback<Input> = Input extends infer Item ? string : () => Item;", errors: [error] },
+    {
+      code: "function outer() { type Result = unknown; function load(): Result { return input; } }",
+      errors: [error],
+    },
+    {
+      code: "type Identity<T> = T; function load(): Identity<unknown> { return input; }",
+      errors: [error],
+    },
+    {
+      code: "type Identity<T> = T; type Wrapped<T> = Promise<Identity<T>>; function load(): Wrapped<unknown> { return promise; }",
+      errors: [error],
+    },
+  ],
+});

--- a/tools/oxlint/anti-slop/tests/no-unknown-type-aliases.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-unknown-type-aliases.cases.ts
@@ -1,0 +1,36 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noUnknownTypeAliasesRule } from "@/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts";
+
+const error = { messageId: "unknownAlias" };
+
+tester.run("anti-slop/no-unknown-type-aliases", noUnknownTypeAliasesRule, {
+	valid: [
+		"type User = { readonly id: string };",
+		"type Alias = string; type UserId = Alias;",
+		"type Payload = string | number;",
+		"type Box<T> = { readonly value: T }; type Payload = Box<unknown>;",
+	],
+	invalid: [
+		{ code: "type Alias = unknown;", errors: [error] },
+		{ code: "type Current = unknown;", errors: [error] },
+		{ code: "type UnknownValue = unknown; type Alias = UnknownValue;", errors: [error, error] },
+		{ code: "type Payload = string | unknown;", errors: [error] },
+		{
+			code: "type Payload = string | unknown; type NestedPayload = number | Payload;",
+			errors: [error, error],
+		},
+		{
+			code: "type Identity<T> = T; type Payload = Identity<unknown>;",
+			errors: [error],
+		},
+		{
+			code: "type Identity<T> = T; type Wrapped<T> = Identity<T>; type Payload = Wrapped<unknown>;",
+			errors: [error],
+		},
+		{
+			code: "function outer() { type Payload = unknown; }",
+			errors: [error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/tests/no-unsafe-dictionary-type.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-unsafe-dictionary-type.cases.ts
@@ -1,0 +1,114 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noUnsafeDictionaryTypeRule } from "@/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts";
+
+
+const error = { messageId: "unsafeDictionary" };
+
+tester.run("anti-slop/no-unsafe-dictionary-type", noUnsafeDictionaryTypeRule, {
+	valid: [
+		"type Commands = Record<string, Command>;",
+		"type Metadata = Record<PropertyKey, JsonValue>;",
+		"type PermissionLevels = Record<Permission, number>;",
+		"type Indexed = { [key: string]: Command };",
+		"type CompatibleIndexes = { [index: number]: Command; [key: string]: Command | OtherCommand };",
+		"type Exhaustive = { [K in Permission]: number };",
+		"type Allowed = Record<string, { payload: unknown }>;",
+		"type AlsoAllowed = Record<string, Result<Data, unknown>>;",
+		"type Index<T> = Record<string, T>; type EntityIndex<T extends Entity> = Record<string, T>;",
+		"type Safe = Index<Command>; type Index<T> = Record<string, T>;",
+		"type A = Map<string, unknown>; type B = ReadonlyMap<string, unknown>; type C = WeakMap<object, unknown>;",
+		"import { Record } from './local'; type A = Record<string, unknown>;",
+		"type Record<K, V> = { key: K; value: V }; type A = Record<string, unknown>;",
+		"type Readonly<T> = { value: T }; type A = Record<string, Readonly<unknown>>;",
+		"type NonNullable<T> = { value: T }; type A = Record<string, NonNullable<unknown>>;",
+		"type Value<T> = T; type Index<T = Command, U = Value<T>> = Record<string, U>; type A = Index;",
+		"interface Owner { readonly id: string } type A = Record<string, unknown & Owner>;",
+		"interface Owner { readonly id: string } interface Child extends Owner {} type A = Record<string, Child>;",
+		"interface Owner { readonly id: string } interface Child extends Owner { readonly __brand?: never } type A = Record<string, Child>;",
+		"interface Escape {} interface Escape { readonly id: string } type A = Record<string, Escape>;",
+		"interface Escape { readonly id: string } interface Escape {} type A = Record<string, Escape>;",
+		"interface Owner { readonly id: string } type A = Record<string, object & Owner>;",
+		"type Wrap<T> = { readonly wrapped: T }; type Inner<T, U> = { readonly value: T } & Wrap<U>; type Outer<T, U> = Record<string, Inner<T, U>>; declare function f<T, U>(): Outer<T, U>;",
+		"type WithSchema<T extends Record<string, unknown>> = (schema: T) => void;",
+		"function run<T extends Record<string, unknown>>(input: T): T { return input; }",
+		"declare class Store<T extends Record<string, unknown>> { read(): T }",
+		"type Deep<T extends Readonly<Record<string, unknown>>> = T;",
+	],
+	invalid: [
+		{ code: "type A = Record<string, unknown>;", errors: [error] },
+		{ code: "type A = { [key: string]: any };", errors: [error] },
+		{ code: "type A = { [index: number]: Command; [key: string]: unknown | Command };", errors: 1 },
+		{ code: "type A = { [K in PropertyKey]: object };", errors: [error] },
+		{ code: "type A = { [K in PropertyKey]: NonNullable<unknown> };", errors: [error] },
+		{ code: "type A = { [key: string]: NonNullable<unknown> };", errors: [error] },
+		{ code: "type A = Record<string, {}>;", errors: [error] },
+		{ code: "interface Escape {} type A = Record<string, Escape>;", errors: [error] },
+		{
+			code: "interface Escape { readonly __brand?: never } type A = Record<string, Escape>;",
+			errors: [error],
+		},
+		{
+			code: "type Escape = { readonly __brand?: never }; type A = Record<string, Escape>;",
+			errors: [error],
+		},
+		{ code: "type A = Record<string, { readonly __brand?: never }>;", errors: [error] },
+		{ code: "type A = Record<string, string | unknown>;", errors: [error] },
+		{ code: "interface Escape {} type A = Record<string, string | Escape>;", errors: [error] },
+		{ code: "type A = Record<string, unknown & {}>;", errors: [error] },
+		{
+			code: "interface Owner { readonly id: string } type A = Record<string, any & Owner>;",
+			errors: [error],
+		},
+		{ code: "type Escape = unknown; type A = Record<string, Escape>;", errors: [error] },
+		{ code: "type Dict = Record<string, unknown>;", errors: [error] },
+		{ code: "type A = Readonly<Partial<Required<(Record<string, unknown>)>>>;", errors: [error] },
+		{ code: "type A = { readonly [key: string]: unknown };", errors: [error] },
+		{ code: "type A = { readonly [K in string]: unknown };", errors: [error] },
+		{ code: "type Source = Record<string, unknown>; type A = Pick<Source, string>;", errors: 2 },
+		{ code: "type Source = Record<string, unknown>; type A = Omit<Source, never>;", errors: 2 },
+		{ code: "type Index<T> = Record<string, T>; type A = Index<unknown>;", errors: 1 },
+		{ code: "interface A { [key: string]: unknown }", errors: [error] },
+		{ code: "type A = Readonly<Record<string, unknown>>;", errors: 1 },
+		{ code: "type A = Record<string, Readonly<unknown>>;", errors: [error] },
+		{ code: "type A = Record<string, Partial<unknown>>;", errors: [error] },
+		{ code: "type A = Record<string, Required<unknown>>;", errors: [error] },
+		{ code: "type Escape = Readonly<unknown>; type A = Record<string, Escape>;", errors: 1 },
+		{
+			code: "type Wrapped<T> = Readonly<T>; type A = Record<string, Wrapped<unknown>>;",
+			errors: 1,
+		},
+		{ code: "type A = Record<string, NonNullable<unknown>>;", errors: [error] },
+		{ code: "type Escape = NonNullable<unknown>; type A = Record<string, Escape>;", errors: 1 },
+		{
+			code: "type Unsafe = Record<string, unknown>; const x: Unsafe = {}; const y: Unsafe = {};",
+			errors: 1,
+		},
+		{
+			code: "type Unsafe = Record<string, unknown>; type AlsoUnsafe = Unsafe; const x: Unsafe = {};",
+			errors: 2,
+		},
+		{ code: "type Index<T = unknown> = Record<string, T>; type A = Index;", errors: 1 },
+		{
+			code: "type Index<T, U = T> = Record<string, U>; type A = Index<string, unknown>;",
+			errors: 1,
+		},
+		{ code: "type Index<T, U = T> = Record<string, U>; type A = Index<unknown>;", errors: 1 },
+		{
+			code: "type Value<T> = T; type Index<T, U = Value<T>> = Record<string, U>; type A = Index<unknown>;",
+			errors: 1,
+		},
+		{
+			code: "type Marker<T> = { readonly __brand?: never }; type Index<T, U = Marker<T>> = Record<string, U>; type A = Index<Item>;",
+			errors: 1,
+		},
+		{
+			code: "function outer() { type Identity<T> = T; type A = Record<string, Identity<unknown>>; }",
+			errors: 1,
+		},
+		{
+			code: "function local() { type Record<K, V> = { key: K; value: V }; type A = Record<string, unknown>; } function global() { type A = Record<string, unknown>; }",
+			errors: 1,
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/tests/no-widen-then-assert.cases.ts
+++ b/tools/oxlint/anti-slop/tests/no-widen-then-assert.cases.ts
@@ -1,0 +1,83 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { noWidenThenAssertRule } from "@/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts";
+
+const error = { messageId: "widenThenAssert" };
+
+tester.run("anti-slop/no-widen-then-assert", noWidenThenAssertRule, {
+	valid: [
+		"const source = { id: 'first' }; const widened: unknown = source;",
+		"declare const input: unknown; const parsed = input as { readonly id: string };",
+		"declare const input: any; const widened: unknown = input; const parsed = widened as User;",
+		"const widened: object = { id: 'first' }; const parsed = widened as User;",
+		"const source = { id: 'first' }; let widened: unknown = source; const parsed = widened as { id: string };",
+		"const source = { id: 'first' }; const widened: unknown = source; widened = input; const parsed = widened as { id: string };",
+		"const widened: unknown = { id: 'first' }; function parse() { return widened as { id: string }; }",
+		"const parsed = widened as { id: string }; const widened: unknown = { id: 'first' };",
+		"const widened: object = { id: 'first' }; const parsed = widened as string;",
+		"const widened: Record<string, unknown> = { id: 'first' }; const parsed = widened as UserIndex;",
+		"const widened: Record<string, unknown> = { id: 'first' }; const parsed = widened as unknown;",
+		"const widened: Record<'id', unknown> = { id: 'first' }; const parsed = widened as Record<'id', string>;",
+	],
+	invalid: [
+		{
+			code: "const source = { id: 'second' }; const widened: unknown = source; const parsed = widened as { readonly id: string };",
+			errors: [error],
+		},
+		{
+			name: "any declaration",
+			code: "const source = [1, 2]; const widened: any = source; const parsed = widened as number[];",
+			errors: [error],
+		},
+		{
+			name: "object declaration",
+			code: "const source = { id: 'second' }; const widened: object = source; const parsed = widened as { readonly id: string };",
+			errors: [error],
+		},
+		{
+			name: "broad Record declaration",
+			code: "const source = { id: 'second' }; const widened: Record<string, unknown> = source; const parsed = widened as Record<'id', string>;",
+			errors: [error],
+		},
+		{
+			name: "readonly broad Record declaration",
+			code: "const source = { id: 'second' }; const widened: Readonly<Record<PropertyKey, any>> = source; const parsed = widened as Readonly<Record<'id', string>>;",
+			errors: [error],
+		},
+		{
+			name: "broad index signature declaration",
+			code: "const source = { id: 'second' }; const widened: { [key: string]: unknown } = source; const parsed = widened as { id: string };",
+			errors: [error],
+		},
+		{
+			name: "initializer assertion widens the binding",
+			code: "const source = { id: 'second' }; const widened = source as unknown; const parsed = widened as { id: string };",
+			errors: [error],
+		},
+		{
+			name: "angle-bracket narrowing assertion",
+			code: "const source = { id: 'second' }; const widened: unknown = source; const parsed = <{ id: string }>widened;",
+			errors: [error],
+		},
+		{
+			name: "same annotated type restored from object",
+			code: "type User = { id: string }; declare function load(): User; const source: User = load(); const widened: object = source; const parsed = widened as User;",
+			errors: [error],
+		},
+		{
+			name: "same asserted type restored from object",
+			code: "type User = { id: string }; declare const input: unknown; const source = input as User; const widened: object = source; const parsed = widened as User;",
+			errors: [error],
+		},
+		{
+			name: "known evidence follows immutable aliases",
+			code: "const source = { id: 'second' }; const alias = source; const widened: unknown = alias; const parsed = widened as { id: string };",
+			errors: [error],
+		},
+		{
+			name: "same-function boundary",
+			code: "function parse() { const source = { id: 'second' }; const widened: unknown = source; return widened as { id: string }; }",
+			errors: [error],
+		},
+	],
+});

--- a/tools/oxlint/anti-slop/tests/require-safety-comment-for-type-assertion.cases.ts
+++ b/tools/oxlint/anti-slop/tests/require-safety-comment-for-type-assertion.cases.ts
@@ -1,0 +1,71 @@
+import { typescriptRuleTester as tester } from "./rule-tester.ts";
+
+import { requireSafetyCommentForTypeAssertionRule } from "@/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts";
+
+const error = { messageId: "missingSafetyComment" };
+
+tester.run(
+  "anti-slop/require-safety-comment-for-type-assertion (custom markers)",
+  requireSafetyCommentForTypeAssertionRule,
+  {
+    valid: [
+      {
+        code: "// INVARIANT: The caller parsed this value.\nconst value = input as User;",
+        options: [{ markers: ["INVARIANT"] }],
+      },
+      {
+        code: "// SAFETY: The caller parsed this value.\nconst value = input as User;",
+        options: [{ markers: ["INVARIANT", "SAFETY"] }],
+      },
+      {
+        code: "// SAFE+: The caller parsed this value.\nconst value = input as User;",
+        options: [{ markers: ["SAFE+"] }],
+      },
+    ],
+    invalid: [
+      {
+        code: "// SAFETY: This marker is not configured.\nconst value = input as User;",
+        options: [{ markers: ["INVARIANT"] }],
+        errors: [error],
+      },
+      {
+        code: "// INVARIANT:   \nconst value = input as User;",
+        options: [{ markers: ["INVARIANT"] }],
+        errors: [error],
+      },
+    ],
+  },
+);
+
+tester.run(
+  "anti-slop/require-safety-comment-for-type-assertion",
+  requireSafetyCommentForTypeAssertionRule,
+  {
+    valid: [
+      "const values = [1, 2] as const;",
+      "const value = <const>{ id: 'one' };",
+      "// SAFETY: The parser established the UserId invariant.\nconst id = value as UserId;",
+      "function parse(): UserId {\n// SAFETY: Validation above established the UserId invariant.\nreturn value as UserId;\n}",
+      "const id = /* SAFETY: Validation established the invariant. */ value as UserId;",
+      "// SAFETY: The parser established the exported UserId invariant.\nexport const id = value as UserId;",
+      "/* SAFETY:\n * The parser established the exported UserId invariant.\n */\nexport const id = value as UserId;",
+    ],
+    invalid: [
+      { code: "const id = value as UserId;", errors: [error] },
+      { code: "const id = <UserId>value;", errors: [error] },
+      { code: "const id = value as UserId; // SAFETY: Too late.", errors: [error] },
+      {
+        code: "// This cast seems fine.\nconst id = value as UserId;",
+        errors: [error],
+      },
+      { code: "// SAFETY:\nconst id = value as UserId;", errors: [error] },
+      { code: "// SAFETY:   \nconst id = value as UserId;", errors: [error] },
+      { code: "const id = /* SAFETY: */ value as UserId;", errors: [error] },
+      { code: "export const id = value as UserId;", errors: [error] },
+      {
+        code: "// This is not a safety justification.\nexport const id = value as UserId;",
+        errors: [error],
+      },
+    ],
+  },
+);

--- a/tools/oxlint/anti-slop/tests/rule-tester.ts
+++ b/tools/oxlint/anti-slop/tests/rule-tester.ts
@@ -1,0 +1,10 @@
+import { RuleTester } from "oxlint/plugins-dev";
+import { describe, test } from "vitest";
+
+RuleTester.describe = describe;
+RuleTester.it = test;
+RuleTester.itOnly = test.only;
+
+export const typescriptRuleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: "ts" } },
+});


### PR DESCRIPTION
## Summary

- add Oxlint RuleTester coverage for all 15 repository-vendored anti-slop rules
- exercise important options, syntax and scope boundaries, diagnostics, and the intentional non-fixable contract
- document the pinned upstream test provenance and refresh expectation

## Validation

- pnpm exec vitest run tools/oxlint/anti-slop/tests/anti-slop-plugin.test.ts (322 passed)
- pnpm check (682 passed; lint, types, formatting, Knip, and boundaries clean)
- DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54329/open_instinct BETTER_AUTH_URL=http://localhost:3000 pnpm build