### PR TITLE
Document Vercel CLI deploy gotchas and ignore installer-dropped agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ next-env.d.ts
 dist
 .DS_Store
 *.tsbuildinfo
+
+# Vercel marketplace installers (e.g. `vercel integration add neon`) drop
+# third-party agent skills and a lock file into the checkout; they are not
+# part of the OpenInstinct agent definition.
+/agent/skills/
+/skills-lock.json

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ Treat the private Blob store as production key material: deleting it loses the
 automatically generated encryption key, and rotating that key requires
 re-encrypting existing vault values.
 
+### Deploying with the Vercel CLI
+
+The deploy button sets the project's Framework Preset to Next.js for you. A
+project created with the Vercel CLI (`vercel project add` / `vercel link`)
+defaults to **Other**, which builds green but silently drops the Next.js
+output: every app route returns `404 x-vercel-error: NOT_FOUND` while
+`/eve/v1/health` still answers. Set the preset to Next.js before the first
+Git deploy, either in the project settings or with:
+
+```bash
+vercel api /v9/projects/<project-id> --method PATCH --field framework=nextjs
+```
+
+Provisioning Neon through the CLI (`vercel integration add neon ...`) also
+writes third-party agent skills under `agent/skills/` and a root
+`skills-lock.json`. Eve loads every skill in `agent/skills/`, so the assistant
+quietly gains Neon database-administration skills. Both paths are gitignored;
+delete `agent/skills/` and `skills-lock.json` after provisioning unless you
+want the agent to keep them.
+
 ### Blob storage
 
 The one-click deploy creates and connects a private Blob store automatically.

--- a/tests/source-layout.test.ts
+++ b/tests/source-layout.test.ts
@@ -53,4 +53,18 @@ describe("source layout", () => {
     expect(existsSync("db/services/installation-secrets.ts")).toBe(true);
     expect(existsSync("evals/browser/worker-events.ts")).toBe(true);
   });
+
+  it("keeps third-party installer files out of the agent definition", () => {
+    expect(directories("agent")).toEqual([
+      "channels",
+      "hooks",
+      "instructions",
+      "lib",
+      "memory",
+      "schedules",
+      "subagents",
+      "tools",
+    ]);
+    expect(existsSync("skills-lock.json")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- **Framework preset (closes #48):** a Vercel project created with the CLI (`vercel project add` / `vercel link`) defaults its Framework Preset to **Other**, which builds green but silently drops the Next.js output - every app route 404s while `/eve/v1/health` still answers. The README now documents setting `framework=nextjs` before the first Git deploy.
- **Installer-dropped skills (closes #47):** `vercel integration add neon` writes third-party agent skills under `agent/skills/` and a root `skills-lock.json`, and eve loads every skill in `agent/skills/`. Both paths are now gitignored, and the README tells CLI users to delete them after provisioning.
- **Regression guard:** `tests/source-layout.test.ts` now fails `pnpm check` if unexpected directories (or a `skills-lock.json`) ever land in the agent tree, so a committed installer drop is caught in CI.

## Validation

- `pnpm exec vitest run tests/source-layout.test.ts tests/local-development.test.ts` - 10 tests pass, including the new guard
- Guard verified in both directions: fails with `agent/skills/neon/` + `skills-lock.json` present, passes on a clean tree
- `oxfmt --check` clean on all touched files